### PR TITLE
Add interactive chart of accounts page

### DIFF
--- a/app/src/app/(dashboard)/accounts/page.tsx
+++ b/app/src/app/(dashboard)/accounts/page.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { formatCurrency } from "@/lib/format";
+import { useDashboard } from "@/lib/dashboard-context";
+import type { AccountNode } from "@/lib/types/gnucash";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+const ACCOUNT_TYPE_LABELS: Record<string, string> = {
+  ASSET: "Asset",
+  BANK: "Bank",
+  CASH: "Cash",
+  CREDIT: "Credit Card",
+  LIABILITY: "Liability",
+  STOCK: "Stock",
+  MUTUAL: "Mutual Fund",
+  INCOME: "Income",
+  EXPENSE: "Expense",
+  EQUITY: "Equity",
+  RECEIVABLE: "Receivable",
+  PAYABLE: "Payable",
+  TRADING: "Trading",
+};
+
+const TYPE_COLORS: Record<string, string> = {
+  ASSET: "bg-emerald-50 text-emerald-700",
+  BANK: "bg-emerald-50 text-emerald-700",
+  CASH: "bg-emerald-50 text-emerald-700",
+  STOCK: "bg-blue-50 text-blue-700",
+  MUTUAL: "bg-blue-50 text-blue-700",
+  INCOME: "bg-teal-50 text-teal-700",
+  EXPENSE: "bg-amber-50 text-amber-700",
+  LIABILITY: "bg-red-50 text-red-700",
+  CREDIT: "bg-red-50 text-red-700",
+  PAYABLE: "bg-red-50 text-red-700",
+  EQUITY: "bg-purple-50 text-purple-700",
+  RECEIVABLE: "bg-cyan-50 text-cyan-700",
+  TRADING: "bg-gray-50 text-gray-700",
+};
+
+export default function AccountsPage() {
+  const { data } = useDashboard();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggle = useCallback((guid: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(guid)) next.delete(guid);
+      else next.add(guid);
+      return next;
+    });
+  }, []);
+
+  const expandAll = useCallback(() => {
+    if (!data) return;
+    const allGuids = new Set<string>();
+    function collect(nodes: AccountNode[]) {
+      for (const n of nodes) {
+        if (n.children.length > 0) {
+          allGuids.add(n.guid);
+          collect(n.children);
+        }
+      }
+    }
+    collect(data.accounts);
+    setExpanded(allGuids);
+  }, [data]);
+
+  const collapseAll = useCallback(() => {
+    setExpanded(new Set());
+  }, []);
+
+  if (!data) return null;
+
+  const currency = data.currency;
+  const allExpanded = expanded.size > 0;
+
+  return (
+    <div className="flex flex-col gap-4 sm:gap-6">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="text-lg font-semibold text-[#1A1D1F] sm:text-xl">Chart of Accounts</h2>
+        <button
+          onClick={allExpanded ? collapseAll : expandAll}
+          className="rounded-lg border border-[#EFEFEF] px-3 py-1.5 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7]"
+        >
+          {allExpanded ? "Collapse all" : "Expand all"}
+        </button>
+      </div>
+
+      <Card className="shadow-sm border-[#EFEFEF]">
+        <CardContent className="pt-0 pb-0">
+          <div className="overflow-x-auto">
+            <table className="w-full">
+              <thead>
+                <tr className="border-b border-[#EFEFEF]">
+                  <th className="py-3 text-left text-xs font-medium text-[#9A9FA5]">Account</th>
+                  <th className="py-3 text-left text-xs font-medium text-[#9A9FA5] hidden sm:table-cell w-24">Type</th>
+                  <th className="py-3 text-right text-xs font-medium text-[#9A9FA5] w-32">Balance</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.accounts
+                  .filter((a) => !a.hidden)
+                  .sort((a, b) => a.name.localeCompare(b.name))
+                  .map((account) => (
+                    <AccountRow
+                      key={account.guid}
+                      account={account}
+                      depth={0}
+                      expanded={expanded}
+                      onToggle={toggle}
+                      currency={currency}
+                    />
+                  ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function AccountRow({
+  account,
+  depth,
+  expanded,
+  onToggle,
+  currency,
+}: {
+  account: AccountNode;
+  depth: number;
+  expanded: Set<string>;
+  onToggle: (guid: string) => void;
+  currency: string;
+}) {
+  const hasChildren = account.children.length > 0;
+  const isExpanded = expanded.has(account.guid);
+  const visibleChildren = account.children.filter((c) => !c.hidden);
+  const isTopLevel = depth === 0;
+  const typeColor = TYPE_COLORS[account.type] ?? "bg-gray-50 text-gray-700";
+
+  return (
+    <>
+      <tr
+        className={`border-b border-[#EFEFEF] transition-colors ${hasChildren ? "cursor-pointer hover:bg-[#F9FAFB]" : ""} ${isTopLevel ? "bg-[#FAFBFC]" : ""}`}
+        onClick={hasChildren ? () => onToggle(account.guid) : undefined}
+      >
+        {/* Account name with indentation */}
+        <td className="py-2.5 pr-4">
+          <div className="flex items-center" style={{ paddingLeft: `${depth * 20 + 4}px` }}>
+            {/* Expand/collapse icon */}
+            <span className="mr-2 flex h-4 w-4 shrink-0 items-center justify-center">
+              {hasChildren ? (
+                isExpanded ? (
+                  <ChevronDown className="h-3.5 w-3.5 text-[#9A9FA5]" />
+                ) : (
+                  <ChevronRight className="h-3.5 w-3.5 text-[#9A9FA5]" />
+                )
+              ) : (
+                <span className="h-1 w-1 rounded-full bg-[#D1D5DB]" />
+              )}
+            </span>
+            <span className={`text-xs ${isTopLevel ? "font-semibold text-[#1A1D1F]" : depth === 1 ? "font-medium text-[#1A1D1F]" : "text-[#6F767E]"}`} data-d>
+              {account.name}
+            </span>
+          </div>
+        </td>
+
+        {/* Account type badge */}
+        <td className="hidden py-2.5 pr-4 sm:table-cell">
+          <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${typeColor}`}>
+            {ACCOUNT_TYPE_LABELS[account.type] ?? account.type}
+          </span>
+        </td>
+
+        {/* Balance — flip sign for income/equity/credit/liability so they display intuitively */}
+        <td className="whitespace-nowrap py-2.5 pr-3 text-right text-xs font-medium" data-v>
+          {account.type !== "ROOT" && (() => {
+            const creditTypes = new Set(["INCOME", "EQUITY", "LIABILITY", "CREDIT", "PAYABLE"]);
+            const displayBalance = creditTypes.has(account.type) ? -account.balance : account.balance;
+            return (
+              <span className={displayBalance < 0 ? "text-[#E87C6B]" : "text-[#1A1D1F]"}>
+                {displayBalance < 0 ? "−" : ""}{formatCurrency(Math.abs(displayBalance), currency)}
+              </span>
+            );
+          })()}
+        </td>
+      </tr>
+
+      {/* Render children when expanded */}
+      {isExpanded &&
+        visibleChildren
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((child) => (
+          <AccountRow
+            key={child.guid}
+            account={child}
+            depth={depth + 1}
+            expanded={expanded}
+            onToggle={onToggle}
+            currency={currency}
+          />
+        ))}
+    </>
+  );
+}

--- a/app/src/components/dashboard/sidebar.tsx
+++ b/app/src/components/dashboard/sidebar.tsx
@@ -6,6 +6,7 @@ import { usePathname } from "next/navigation";
 import {
   Home,
   BookOpen,
+  List,
   Receipt,
   CreditCard,
   TrendingUp,
@@ -16,6 +17,7 @@ import { useDashboard } from "@/lib/dashboard-context";
 
 const mainNav = [
   { icon: Home, label: "Dashboard", href: "/" },
+  { icon: List, label: "Accounts", href: "/accounts" },
   { icon: BookOpen, label: "Transactions", href: "/transactions" },
   { icon: Receipt, label: "Income", href: "/income" },
   { icon: CreditCard, label: "Spending", href: "/spending" },

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -10,7 +10,7 @@ import {
 import type { DashboardData } from "@/lib/types/gnucash";
 
 const STORAGE_KEY = "gnucash-dashboard-data";
-const STORAGE_VERSION = "v12"; // bump this when DashboardData shape changes
+const STORAGE_VERSION = "v13"; // bump this when DashboardData shape changes
 const VERSION_KEY = "gnucash-dashboard-version";
 
 interface DashboardContextType {

--- a/app/src/lib/gnucash/parser.ts
+++ b/app/src/lib/gnucash/parser.ts
@@ -198,19 +198,77 @@ function buildAccountTree(
   db: Database.Database
 ): AccountNode[] {
   const commodityMap = new Map(commodities.map((c) => [c.guid, c]));
+  const accountMap = new Map(accounts.map((a) => [a.guid, a]));
 
-  // Get balances for all accounts
-  const balances = db
+  // Determine base currency
+  const book = db
+    .prepare(`SELECT root_account_guid FROM books LIMIT 1`)
+    .get() as { root_account_guid: string } | undefined;
+  const rootAcct = book ? accounts.find((a) => a.guid === book.root_account_guid) : null;
+  const baseCurrencyGuid = rootAcct?.commodity_guid ?? "";
+
+  // Build FX rate map: foreign_currency_guid -> rate_to_base
+  const allFxPrices = db
     .prepare(
-      `SELECT account_guid, SUM(CAST(value_num AS REAL) / value_denom) AS balance
-       FROM splits
-       GROUP BY account_guid`
+      `SELECT p.commodity_guid, p.currency_guid,
+              CAST(p.value_num AS REAL) / p.value_denom AS price
+       FROM prices p
+       JOIN commodities c1 ON p.commodity_guid = c1.guid
+       JOIN commodities c2 ON p.currency_guid = c2.guid
+       WHERE c1.namespace = 'CURRENCY' AND c2.namespace = 'CURRENCY'
+       ORDER BY p.date DESC`
+    )
+    .all() as { commodity_guid: string; currency_guid: string; price: number }[];
+
+  const fxToBase = new Map<string, number>();
+  fxToBase.set(baseCurrencyGuid, 1.0);
+  for (const fx of allFxPrices) {
+    if (fx.currency_guid === baseCurrencyGuid && !fxToBase.has(fx.commodity_guid)) {
+      fxToBase.set(fx.commodity_guid, fx.price);
+    } else if (fx.commodity_guid === baseCurrencyGuid && !fxToBase.has(fx.currency_guid)) {
+      fxToBase.set(fx.currency_guid, 1 / fx.price);
+    }
+  }
+
+  // Get per-account balances using quantity (native commodity)
+  const balanceRows = db
+    .prepare(
+      `SELECT s.account_guid, SUM(CAST(s.quantity_num AS REAL) / s.quantity_denom) AS balance
+       FROM splits s
+       GROUP BY s.account_guid`
     )
     .all() as { account_guid: string; balance: number }[];
-  const balanceMap = new Map(balances.map((b) => [b.account_guid, b.balance]));
+  const rawBalanceMap = new Map(balanceRows.map((b) => [b.account_guid, b.balance]));
 
-  // Build lookup
-  const accountMap = new Map(accounts.map((a) => [a.guid, a]));
+  // Get latest prices for investment commodities (STOCK/MUTUAL)
+  const latestPrices = db
+    .prepare(
+      `SELECT commodity_guid, CAST(value_num AS REAL) / value_denom AS price
+       FROM prices p1
+       WHERE date = (SELECT MAX(date) FROM prices p2 WHERE p2.commodity_guid = p1.commodity_guid)`
+    )
+    .all() as { commodity_guid: string; price: number }[];
+  const priceMap = new Map(latestPrices.map((p) => [p.commodity_guid, p.price]));
+
+  // Convert a raw quantity balance to base currency
+  function toBaseCurrency(account: GnuCashAccount, rawBalance: number): number {
+    const commodity = commodityMap.get(account.commodity_guid);
+    if (!commodity) return rawBalance;
+
+    // Investment accounts: shares × latest price
+    if (account.account_type === "STOCK" || account.account_type === "MUTUAL") {
+      return rawBalance * (priceMap.get(account.commodity_guid) ?? 0);
+    }
+
+    // Foreign currency accounts: balance × FX rate
+    if (commodity.namespace === "CURRENCY" && account.commodity_guid !== baseCurrencyGuid) {
+      return rawBalance * (fxToBase.get(account.commodity_guid) ?? 1);
+    }
+
+    return rawBalance;
+  }
+
+  // Build children lookup
   const childrenMap = new Map<string, GnuCashAccount[]>();
   for (const a of accounts) {
     const key = a.parent_guid ?? "ROOT";
@@ -236,6 +294,14 @@ function buildAccountTree(
       .filter((c) => c.account_type !== "ROOT")
       .map(buildNode);
 
+    // Own balance in base currency (leaf accounts only)
+    const rawBalance = rawBalanceMap.get(account.guid) ?? 0;
+    const ownBalance = toBaseCurrency(account, rawBalance);
+
+    // Roll up: own balance + sum of children's balances
+    const childrenTotal = children.reduce((sum, c) => sum + c.balance, 0);
+    const totalBalance = ownBalance + childrenTotal;
+
     return {
       guid: account.guid,
       name: account.name,
@@ -245,7 +311,7 @@ function buildAccountTree(
       parentGuid: account.parent_guid,
       hidden: account.hidden === 1,
       placeholder: account.placeholder === 1,
-      balance: balanceMap.get(account.guid) ?? 0,
+      balance: totalBalance,
       children,
     };
   }


### PR DESCRIPTION
- New /accounts page with expandable account tree showing all accounts sorted alphabetically with rolled-up balances in base currency
- Fix buildAccountTree to use quantity + FX conversion (not value) for correct multi-currency and investment account balances
- Investment accounts show market value (shares x latest price)
- Credit-type account balances displayed with intuitive sign (income, liabilities show positive)
- Color-coded account type badges, expand/collapse all toggle
- Add Accounts to sidebar navigation
- Bump sessionStorage version to v13