### PR TITLE
Add budget drill-down navigation, imbalance detection, and fix budget…

### DIFF
--- a/app/src/app/(dashboard)/budget/page.tsx
+++ b/app/src/app/(dashboard)/budget/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useMemo } from "react";
+import { useState, useMemo, useCallback } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useDashboard } from "@/lib/dashboard-context";
 import { formatCurrency } from "@/lib/format";
@@ -149,22 +149,106 @@ function YearMonthSelector({
   );
 }
 
+function Breadcrumb({
+  path,
+  allCategories,
+  onNavigate,
+}: {
+  path: string[];
+  allCategories: BudgetCategoryRow[];
+  onNavigate: (depth: number) => void;
+}) {
+  if (path.length === 0) return null;
+
+  const categoryMap = new Map(allCategories.map((c) => [c.accountGuid, c]));
+
+  return (
+    <nav className="flex items-center gap-1 text-sm">
+      <button
+        onClick={() => onNavigate(-1)}
+        className="font-medium text-[#6C9B8B] hover:underline"
+      >
+        All Categories
+      </button>
+      {path.map((guid, i) => {
+        const cat = categoryMap.get(guid);
+        const isLast = i === path.length - 1;
+        return (
+          <span key={guid} className="flex items-center gap-1">
+            <svg className="h-3 w-3 text-[#9A9FA5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+            {isLast ? (
+              <span className="font-medium text-[#1A1D1F]">{cat?.accountName ?? guid}</span>
+            ) : (
+              <button
+                onClick={() => onNavigate(i)}
+                className="font-medium text-[#6C9B8B] hover:underline"
+              >
+                {cat?.accountName ?? guid}
+              </button>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+function ImbalanceBanner({
+  parentCategory,
+  currency,
+  isIncome,
+}: {
+  parentCategory: BudgetCategoryRow;
+  currency: string;
+  isIncome: boolean;
+}) {
+  const { imbalance, budgeted, childBudgetTotal } = parentCategory;
+  if (imbalance === 0) return null;
+
+  const isUnderAllocated = imbalance > 0;
+  const color = isUnderAllocated ? "#E8B86B" : "#E87C6B";
+  const label = isUnderAllocated ? "Unallocated" : "Over-allocated";
+
+  return (
+    <div
+      className="flex items-center gap-2 rounded-lg border px-4 py-2.5 text-sm"
+      style={{ borderColor: color + "40", backgroundColor: color + "08" }}
+    >
+      <svg className="h-4 w-4 shrink-0" style={{ color }} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z" />
+      </svg>
+      <span style={{ color }}>
+        <span className="font-medium">{label}:</span>{" "}
+        {parentCategory.accountName} is budgeted at{" "}
+        <span className="font-semibold" data-v>{formatCurrency(budgeted, currency)}</span>{" "}
+        but sub-budgets total{" "}
+        <span className="font-semibold" data-v>{formatCurrency(childBudgetTotal, currency)}</span>{" "}
+        ({formatCurrency(Math.abs(imbalance), currency)} {isUnderAllocated ? "unallocated" : "over-allocated"})
+      </span>
+    </div>
+  );
+}
+
 function SummaryCard({
   totalBudgeted,
   totalActual,
   currency,
   isIncome = false,
+  parentName,
+  childCount,
 }: {
   totalBudgeted: number;
   totalActual: number;
   currency: string;
   isIncome?: boolean;
+  parentName?: string;
+  childCount?: number;
 }) {
   const remaining = totalBudgeted - totalActual;
   const pct = totalBudgeted > 0 ? (totalActual / totalBudgeted) * 100 : 0;
   const isOver = totalActual > totalBudgeted;
-  // For income: over target is good (green), under target is bad (red)
-  // For expenses: over budget is bad (red), under budget is good (green)
   const overColor = isIncome ? "#6C9B8B" : "#E87C6B";
   const underColor = isIncome ? "#E87C6B" : "#6C9B8B";
   const ringColor = isOver ? overColor : underColor;
@@ -174,12 +258,15 @@ function SummaryCard({
     <Card>
       <CardHeader>
         <CardTitle className="text-sm font-medium text-[#6F767E]">
-          {isIncome ? "Income Summary" : "Budget Summary"}
+          {parentName ? (
+            <span>{parentName} <span className="text-[#9A9FA5]">— {childCount} sub-budget{childCount !== 1 ? "s" : ""}</span></span>
+          ) : (
+            isIncome ? "Income Summary" : "Budget Summary"
+          )}
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className="flex flex-col gap-4">
-          {/* Ring chart */}
           <div className="flex items-center gap-6">
             <div className="relative h-28 w-28 shrink-0">
               <svg viewBox="0 0 100 100" className="h-full w-full -rotate-90">
@@ -237,23 +324,35 @@ function ProgressBars({
   currency,
   isIncome = false,
   ytdVarianceMap,
+  onDrillDown,
+  drillPath,
+  allCategories,
+  onBreadcrumbNavigate,
 }: {
   categories: BudgetCategoryRow[];
   currency: string;
   isIncome?: boolean;
   ytdVarianceMap?: Map<string, number>;
+  onDrillDown: (accountGuid: string) => void;
+  drillPath: string[];
+  allCategories: BudgetCategoryRow[];
+  onBreadcrumbNavigate: (depth: number) => void;
 }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className="text-sm font-medium text-[#6F767E]">Category Progress</CardTitle>
+        <div className="flex flex-col gap-1.5">
+          <CardTitle className="text-sm font-medium text-[#6F767E]">Category Progress</CardTitle>
+          {drillPath.length > 0 && (
+            <Breadcrumb path={drillPath} allCategories={allCategories} onNavigate={onBreadcrumbNavigate} />
+          )}
+        </div>
       </CardHeader>
       <CardContent>
         <div className="flex flex-col gap-3">
           {categories.map((cat) => {
             const pct = cat.budgeted > 0 ? (cat.actual / cat.budgeted) * 100 : (cat.actual > 0 ? 100 : 0);
             const isOver = cat.actual > cat.budgeted;
-            // Income: exceeding target is good, falling short is bad
             const barColor = isIncome
               ? (pct >= 100 ? "#6C9B8B" : pct >= 80 ? "#E8B86B" : "#E87C6B")
               : (pct > 100 ? "#E87C6B" : pct > 80 ? "#E8B86B" : "#6C9B8B");
@@ -271,10 +370,34 @@ function ProgressBars({
               ? (ytdIsOver ? "#6C9B8B" : "#E87C6B")
               : (ytdIsOver ? "#E87C6B" : "#6C9B8B");
 
+            const hasImbalance = cat.hasChildren && cat.imbalance !== 0;
+
             return (
-              <div key={cat.accountGuid} className="flex flex-col gap-1">
+              <div
+                key={cat.accountGuid}
+                className={`flex flex-col gap-1 ${cat.hasChildren ? "cursor-pointer rounded-lg px-2 py-1.5 -mx-2 transition-colors hover:bg-[#F4F5F7]" : ""}`}
+                onClick={cat.hasChildren ? () => onDrillDown(cat.accountGuid) : undefined}
+              >
                 <div className="flex items-center justify-between text-xs">
-                  <span className="font-medium text-[#1A1D1F]" data-l>{cat.fullPath || cat.accountName}</span>
+                  <span className="flex items-center gap-1.5 font-medium text-[#1A1D1F]" data-l>
+                    {cat.accountName}
+                    {cat.hasChildren && (
+                      <svg className="h-3 w-3 text-[#9A9FA5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                      </svg>
+                    )}
+                    {hasImbalance && (
+                      <span
+                        className="inline-flex items-center rounded px-1 py-0.5 text-[10px] font-medium"
+                        style={{
+                          backgroundColor: cat.imbalance > 0 ? "#E8B86B20" : "#E87C6B20",
+                          color: cat.imbalance > 0 ? "#E8B86B" : "#E87C6B",
+                        }}
+                      >
+                        {cat.imbalance > 0 ? "unallocated" : "over-allocated"}
+                      </span>
+                    )}
+                  </span>
                   <span className="text-[#9A9FA5]" data-v>
                     {formatCurrency(cat.actual, currency)} / {formatCurrency(cat.budgeted, currency)}
                   </span>
@@ -318,10 +441,12 @@ function VarianceTable({
   categories,
   currency,
   isIncome = false,
+  onDrillDown,
 }: {
   categories: BudgetCategoryRow[];
   currency: string;
   isIncome?: boolean;
+  onDrillDown: (accountGuid: string) => void;
 }) {
   const [sortKey, setSortKey] = useState<"name" | "budgeted" | "actual" | "variance">("actual");
   const [sortAsc, setSortAsc] = useState(false);
@@ -391,13 +516,37 @@ function VarianceTable({
           <tbody>
             {sorted.map((cat) => {
               const exceeded = cat.variance < 0;
-              // For expenses: exceeded = red. For income: exceeded = green (beat target)
               const varColor = isIncome
                 ? (exceeded ? "#6C9B8B" : "#E87C6B")
                 : (exceeded ? "#E87C6B" : "#6C9B8B");
+              const hasImbalance = cat.hasChildren && cat.imbalance !== 0;
               return (
-                <tr key={cat.accountGuid} className="border-b border-[#EFEFEF]/50 last:border-0">
-                  <td className="py-2.5 pr-4 font-medium text-[#1A1D1F]" data-l>{cat.fullPath || cat.accountName}</td>
+                <tr
+                  key={cat.accountGuid}
+                  className={`border-b border-[#EFEFEF]/50 last:border-0 ${cat.hasChildren ? "cursor-pointer transition-colors hover:bg-[#F4F5F7]" : ""}`}
+                  onClick={cat.hasChildren ? () => onDrillDown(cat.accountGuid) : undefined}
+                >
+                  <td className="py-2.5 pr-4 font-medium text-[#1A1D1F]" data-l>
+                    <span className="flex items-center gap-1.5">
+                      {cat.accountName}
+                      {cat.hasChildren && (
+                        <svg className="h-3 w-3 text-[#9A9FA5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                        </svg>
+                      )}
+                      {hasImbalance && (
+                        <span
+                          className="inline-flex items-center rounded px-1 py-0.5 text-[10px] font-medium"
+                          style={{
+                            backgroundColor: cat.imbalance > 0 ? "#E8B86B20" : "#E87C6B20",
+                            color: cat.imbalance > 0 ? "#E8B86B" : "#E87C6B",
+                          }}
+                        >
+                          {cat.imbalance > 0 ? "unallocated" : "over-allocated"}
+                        </span>
+                      )}
+                    </span>
+                  </td>
                   <td className="py-2.5 pr-4 text-right text-[#6F767E]" data-v>{formatCurrency(cat.budgeted, currency)}</td>
                   <td className="py-2.5 pr-4 text-right text-[#1A1D1F]" data-v>{formatCurrency(cat.actual, currency)}</td>
                   <td className="py-2.5 pr-4 text-right font-medium" style={{ color: varColor }} data-v>
@@ -472,6 +621,7 @@ function computeFilteredCategories(
   selectedMonth: number,
   selectedYear: number,
   yearStr: string,
+  numPeriods: number,
 ): BudgetCategoryRow[] {
   if (!sourceCategories) return [];
   if (viewMode === "monthly") {
@@ -480,19 +630,34 @@ function computeFilteredCategories(
       const budgeted = periodData?.budgeted ?? 0;
       const actual = periodData?.actual[yearStr] ?? 0;
       const variance = budgeted - actual;
+
+      // Recompute childBudgetTotal for this period
+      let childBudgetTotal = cat.childBudgetTotal;
+      let imbalance = cat.imbalance;
+      if (cat.hasChildren && sourceCategories) {
+        const children = sourceCategories.filter((c) => c.parentAccountGuid === cat.accountGuid);
+        childBudgetTotal = children.reduce((sum, c) => {
+          const cp = c.periods.find((p) => p.period === selectedMonth);
+          return sum + (cp?.budgeted ?? 0);
+        }, 0);
+        imbalance = cat.hasExplicitBudget ? budgeted - childBudgetTotal : 0;
+      }
+
       return {
         ...cat,
         budgeted,
         actual,
         variance,
         variancePct: budgeted > 0 ? (variance / budgeted) * 100 : 0,
+        childBudgetTotal,
+        imbalance,
       };
     }).filter((cat) => cat.budgeted > 0 || cat.actual > 0);
   }
 
   const now = new Date();
   const isCurrentYear = selectedYear === now.getFullYear();
-  const maxPeriod = viewMode === "year" ? 11 : (isCurrentYear ? now.getMonth() : 11);
+  const maxPeriod = viewMode === "year" ? (numPeriods - 1) : (isCurrentYear ? now.getMonth() : 11);
   return sourceCategories.map((cat) => {
     let budgeted = 0;
     let actual = 0;
@@ -503,12 +668,30 @@ function computeFilteredCategories(
       }
     }
     const variance = budgeted - actual;
+
+    // Recompute childBudgetTotal for this period range
+    let childBudgetTotal = cat.childBudgetTotal;
+    let imbalance = cat.imbalance;
+    if (cat.hasChildren && sourceCategories) {
+      const children = sourceCategories.filter((c) => c.parentAccountGuid === cat.accountGuid);
+      childBudgetTotal = children.reduce((sum, c) => {
+        let cb = 0;
+        for (const p of c.periods) {
+          if (p.period <= maxPeriod) cb += p.budgeted;
+        }
+        return sum + cb;
+      }, 0);
+      imbalance = cat.hasExplicitBudget ? budgeted - childBudgetTotal : 0;
+    }
+
     return {
       ...cat,
       budgeted,
       actual,
       variance,
       variancePct: budgeted > 0 ? (variance / budgeted) * 100 : 0,
+      childBudgetTotal,
+      imbalance,
     };
   }).filter((cat) => cat.budgeted > 0 || cat.actual > 0);
 }
@@ -521,20 +704,71 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
   const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
   const [selectedBudget, setSelectedBudget] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<BudgetTab>("expense");
+  const [drillPath, setDrillPath] = useState<string[]>([]);
 
   const budgetData = data.budgetData;
   const yearStr = selectedYear.toString();
   const isIncome = activeTab === "income";
 
-  const expenseCategories = useMemo(
-    () => budgetData ? computeFilteredCategories(budgetData.expenseCategories, viewMode, selectedMonth, selectedYear, yearStr) : [],
-    [budgetData, viewMode, selectedMonth, selectedYear, yearStr],
+  const activeBudgetGuid = selectedBudget ?? budgetData?.budgets[0]?.guid ?? "";
+
+  // Get categories for the selected budget
+  const activeBudgetData = budgetData?.categoriesByBudget[activeBudgetGuid];
+
+  const allExpenseCategories = useMemo(
+    () => activeBudgetData
+      ? computeFilteredCategories(activeBudgetData.expenseCategories, viewMode, selectedMonth, selectedYear, yearStr, budgetData?.budgets[0]?.numPeriods ?? 12)
+      : [],
+    [activeBudgetData, viewMode, selectedMonth, selectedYear, yearStr, budgetData],
   );
 
-  const incomeCategories = useMemo(
-    () => budgetData ? computeFilteredCategories(budgetData.incomeCategories, viewMode, selectedMonth, selectedYear, yearStr) : [],
-    [budgetData, viewMode, selectedMonth, selectedYear, yearStr],
+  const allIncomeCategories = useMemo(
+    () => activeBudgetData
+      ? computeFilteredCategories(activeBudgetData.incomeCategories, viewMode, selectedMonth, selectedYear, yearStr, budgetData?.budgets[0]?.numPeriods ?? 12)
+      : [],
+    [activeBudgetData, viewMode, selectedMonth, selectedYear, yearStr, budgetData],
   );
+
+  // Reset drill path when switching budget or tab
+  const handleBudgetSelect = useCallback((guid: string) => {
+    setSelectedBudget(guid);
+    setDrillPath([]);
+  }, []);
+
+  const handleTabChange = useCallback((tab: BudgetTab) => {
+    setActiveTab(tab);
+    setDrillPath([]);
+  }, []);
+
+  // All categories for the active tab (used for breadcrumb lookups)
+  const allCategories = isIncome ? allIncomeCategories : allExpenseCategories;
+
+  // Filter categories based on drill path
+  const visibleCategories = useMemo(() => {
+    if (drillPath.length === 0) {
+      // Top level: show categories with no budgeted parent
+      return allCategories.filter((c) => c.parentAccountGuid === null);
+    }
+    const currentParent = drillPath[drillPath.length - 1];
+    return allCategories.filter((c) => c.parentAccountGuid === currentParent);
+  }, [allCategories, drillPath]);
+
+  // Get the parent category when drilled in (for imbalance banner and summary)
+  const parentCategory = drillPath.length > 0
+    ? allCategories.find((c) => c.accountGuid === drillPath[drillPath.length - 1])
+    : undefined;
+
+  const handleDrillDown = useCallback((accountGuid: string) => {
+    setDrillPath((prev) => [...prev, accountGuid]);
+  }, []);
+
+  const handleBreadcrumbNavigate = useCallback((depth: number) => {
+    if (depth < 0) {
+      setDrillPath([]);
+    } else {
+      setDrillPath((prev) => prev.slice(0, depth + 1));
+    }
+  }, []);
 
   if (!budgetData || budgetData.budgets.length === 0) {
     return (
@@ -545,10 +779,10 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
     );
   }
 
-  // Compute YTD variance per category (used in monthly view to show running total)
+  // Compute YTD variance per category (used in monthly view)
   const ytdVarianceMap = useMemo(() => {
-    if (!budgetData || viewMode !== "monthly") return new Map<string, number>();
-    const source = isIncome ? budgetData.incomeCategories : budgetData.expenseCategories;
+    if (!activeBudgetData || viewMode !== "monthly") return new Map<string, number>();
+    const source = isIncome ? activeBudgetData.incomeCategories : activeBudgetData.expenseCategories;
     const map = new Map<string, number>();
     for (const cat of source) {
       let ytdBudgeted = 0;
@@ -562,14 +796,14 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
       map.set(cat.accountGuid, ytdBudgeted - ytdActual);
     }
     return map;
-  }, [budgetData, viewMode, selectedMonth, yearStr, isIncome]);
+  }, [activeBudgetData, viewMode, selectedMonth, yearStr, isIncome]);
 
-  const activeBudgetGuid = selectedBudget ?? budgetData.budgets[0].guid;
   const c = data.currency;
-  const categories = isIncome ? incomeCategories : expenseCategories;
-  const hasIncome = budgetData.incomeCategories.length > 0;
-  const totalBudgeted = categories.reduce((s, c) => s + c.budgeted, 0);
-  const totalActual = categories.reduce((s, c) => s + c.actual, 0);
+  const hasIncome = (activeBudgetData?.incomeCategories.length ?? 0) > 0;
+
+  // Use parent's budget/actual when drilled in, otherwise sum visible categories
+  const totalBudgeted = parentCategory ? parentCategory.budgeted : visibleCategories.reduce((s, c) => s + c.budgeted, 0);
+  const totalActual = parentCategory ? parentCategory.actual : visibleCategories.reduce((s, c) => s + c.actual, 0);
 
   return (
     <div className="flex flex-col gap-4 sm:gap-6">
@@ -581,7 +815,7 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
           <BudgetSelector
             budgets={budgetData.budgets}
             selected={activeBudgetGuid}
-            onSelect={setSelectedBudget}
+            onSelect={handleBudgetSelect}
           />
         </div>
       </div>
@@ -590,7 +824,7 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
       {hasIncome && (
         <div className="flex gap-1 rounded-lg border border-[#EFEFEF] bg-white self-start">
           <button
-            onClick={() => setActiveTab("expense")}
+            onClick={() => handleTabChange("expense")}
             className={`px-4 py-1.5 text-sm font-medium transition-colors rounded-lg ${
               activeTab === "expense"
                 ? "bg-[#6C9B8B]/10 text-[#6C9B8B]"
@@ -600,7 +834,7 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
             Expenses
           </button>
           <button
-            onClick={() => setActiveTab("income")}
+            onClick={() => handleTabChange("income")}
             className={`px-4 py-1.5 text-sm font-medium transition-colors rounded-lg ${
               activeTab === "income"
                 ? "bg-[#6C9B8B]/10 text-[#6C9B8B]"
@@ -623,6 +857,11 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
         showMonths={viewMode === "monthly"}
       />
 
+      {/* Imbalance banner when drilled in */}
+      {parentCategory && parentCategory.imbalance !== 0 && (
+        <ImbalanceBanner parentCategory={parentCategory} currency={c} isIncome={isIncome} />
+      )}
+
       {/* Row 1: Summary + Progress bars */}
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2 md:gap-5">
         <SummaryCard
@@ -630,20 +869,27 @@ function BudgetContent({ data }: { data: NonNullable<ReturnType<typeof useDashbo
           totalActual={totalActual}
           currency={c}
           isIncome={isIncome}
+          parentName={parentCategory?.accountName}
+          childCount={visibleCategories.length}
         />
         <ProgressBars
-          categories={categories}
+          categories={visibleCategories}
           currency={c}
           isIncome={isIncome}
           ytdVarianceMap={viewMode === "monthly" ? ytdVarianceMap : undefined}
+          onDrillDown={handleDrillDown}
+          drillPath={drillPath}
+          allCategories={allCategories}
+          onBreadcrumbNavigate={handleBreadcrumbNavigate}
         />
       </div>
 
       {/* Row 2: Variance table */}
       <VarianceTable
-        categories={categories}
+        categories={visibleCategories}
         currency={c}
         isIncome={isIncome}
+        onDrillDown={handleDrillDown}
       />
     </div>
   );

--- a/app/src/lib/demo-data.ts
+++ b/app/src/lib/demo-data.ts
@@ -523,14 +523,60 @@ function generateBudgetData(
   const yearStr = currentYear.toString();
   const prevYearStr = (currentYear - 1).toString();
 
-  // Build expense budget categories (budget set on parent categories)
-  const expenseCategories: BudgetCategoryRow[] = expenseAccounts.map((cat) => {
-    const accountGuid = guidFn();
-    // Budget = slightly above average of children's ranges
+  // Build expense budget categories with sub-budgets
+  const expenseCategories: BudgetCategoryRow[] = [];
+  for (const cat of expenseAccounts) {
+    const parentGuid = guidFn();
     const childRanges = cat.children.map((c) => expenseRanges[c] ?? [10, 50]);
-    const monthlyBudget = Math.round(childRanges.reduce((s, [min, max]) => s + (min + max) / 2, 0) * 1.05);
+    // Parent budget = slightly above sum of children (creates a small imbalance to demo the feature)
+    const childMonthlyBudgets = childRanges.map(([min, max]) => Math.round((min + max) / 2));
+    const parentMonthlyBudget = Math.round(childMonthlyBudgets.reduce((s, b) => s + b, 0) * 1.05);
 
-    const periods = Array.from({ length: 12 }, (_, p) => {
+    // Build child rows first
+    const childRows: BudgetCategoryRow[] = cat.children.map((childName, ci) => {
+      const childGuid = guidFn();
+      const childMonthly = childMonthlyBudgets[ci];
+
+      const periods = Array.from({ length: 12 }, (_, p) => {
+        const monthStr = `${currentYear}-${String(p + 1).padStart(2, "0")}`;
+        const prevMonthStr = `${currentYear - 1}-${String(p + 1).padStart(2, "0")}`;
+        const actual: Record<string, number> = {};
+        actual[yearStr] = Math.round(
+          monthlyExpenses
+            .filter((e) => e.month === monthStr && e.category === childName)
+            .reduce((s, e) => s + e.amount, 0) * 100
+        ) / 100;
+        actual[prevYearStr] = Math.round(
+          monthlyExpenses
+            .filter((e) => e.month === prevMonthStr && e.category === childName)
+            .reduce((s, e) => s + e.amount, 0) * 100
+        ) / 100;
+        return { period: p, budgeted: childMonthly, actual };
+      });
+
+      const totalBudgeted = childMonthly * 12;
+      const totalActual = periods.reduce((s, p) => s + (p.actual[yearStr] ?? 0), 0);
+
+      return {
+        accountGuid: childGuid,
+        accountName: childName,
+        fullPath: `${cat.name}:${childName}`,
+        budgeted: totalBudgeted,
+        actual: Math.round(totalActual * 100) / 100,
+        variance: Math.round((totalBudgeted - totalActual) * 100) / 100,
+        variancePct: totalBudgeted > 0 ? Math.round(((totalBudgeted - totalActual) / totalBudgeted) * 10000) / 100 : 0,
+        periods,
+        parentAccountGuid: parentGuid,
+        depth: 1,
+        hasChildren: false,
+        hasExplicitBudget: true,
+        childBudgetTotal: 0,
+        imbalance: 0,
+      };
+    });
+
+    // Build parent row
+    const parentPeriods = Array.from({ length: 12 }, (_, p) => {
       const monthStr = `${currentYear}-${String(p + 1).padStart(2, "0")}`;
       const prevMonthStr = `${currentYear - 1}-${String(p + 1).padStart(2, "0")}`;
       const actual: Record<string, number> = {};
@@ -544,23 +590,31 @@ function generateBudgetData(
           .filter((e) => e.month === prevMonthStr && cat.children.includes(e.category))
           .reduce((s, e) => s + e.amount, 0) * 100
       ) / 100;
-      return { period: p, budgeted: monthlyBudget, actual };
+      return { period: p, budgeted: parentMonthlyBudget, actual };
     });
 
-    const totalBudgeted = monthlyBudget * 12;
-    const totalActual = periods.reduce((s, p) => s + (p.actual[yearStr] ?? 0), 0);
+    const totalBudgeted = parentMonthlyBudget * 12;
+    const totalActual = parentPeriods.reduce((s, p) => s + (p.actual[yearStr] ?? 0), 0);
+    const childBudgetTotal = childRows.reduce((s, c) => s + c.budgeted, 0);
 
-    return {
-      accountGuid,
+    expenseCategories.push({
+      accountGuid: parentGuid,
       accountName: cat.name,
       fullPath: cat.name,
       budgeted: totalBudgeted,
       actual: Math.round(totalActual * 100) / 100,
       variance: Math.round((totalBudgeted - totalActual) * 100) / 100,
       variancePct: totalBudgeted > 0 ? Math.round(((totalBudgeted - totalActual) / totalBudgeted) * 10000) / 100 : 0,
-      periods,
-    };
-  });
+      periods: parentPeriods,
+      parentAccountGuid: null,
+      depth: 0,
+      hasChildren: true,
+      hasExplicitBudget: true,
+      childBudgetTotal,
+      imbalance: totalBudgeted - childBudgetTotal,
+    });
+    expenseCategories.push(...childRows);
+  }
 
   // Build income budget categories
   const incomeCategories: BudgetCategoryRow[] = incomeAccounts
@@ -599,11 +653,19 @@ function generateBudgetData(
         variance: Math.round((totalBudgeted - totalActual) * 100) / 100,
         variancePct: totalBudgeted > 0 ? Math.round(((totalBudgeted - totalActual) / totalBudgeted) * 10000) / 100 : 0,
         periods,
+        parentAccountGuid: null,
+        depth: 0,
+        hasChildren: false,
+        hasExplicitBudget: true,
+        childBudgetTotal: 0,
+        imbalance: 0,
       };
     });
 
+  const budgetEntry = { expenseCategories, incomeCategories };
   return {
     budgets: [{ guid: budgetGuid, name: "2026 Budget", description: "Annual household budget", numPeriods: 12 }],
+    categoriesByBudget: { [budgetGuid]: budgetEntry },
     expenseCategories,
     incomeCategories,
     availableYears: [currentYear, currentYear - 1],

--- a/app/src/lib/gnucash/__tests__/__snapshots__/index.test.ts.snap
+++ b/app/src/lib/gnucash/__tests__/__snapshots__/index.test.ts.snap
@@ -310,13 +310,936 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
         "numPeriods": 12,
       },
     ],
+    "categoriesByBudget": {
+      "00000034000000340000003400000034": {
+        "expenseCategories": [
+          {
+            "accountGuid": "00000010000000100000001000000010",
+            "accountName": "Expenses",
+            "actual": 0,
+            "budgeted": 1050,
+            "childBudgetTotal": 1050,
+            "depth": 0,
+            "fullPath": "",
+            "hasChildren": true,
+            "hasExplicitBudget": false,
+            "imbalance": 0,
+            "parentAccountGuid": null,
+            "periods": [
+              {
+                "actual": {
+                  "2025": 330,
+                },
+                "budgeted": 350,
+                "period": 0,
+              },
+              {
+                "actual": {
+                  "2025": 270,
+                },
+                "budgeted": 350,
+                "period": 1,
+              },
+              {
+                "actual": {
+                  "2025": 40,
+                },
+                "budgeted": 350,
+                "period": 2,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 3,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 4,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 5,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 6,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 7,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 8,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 9,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 10,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 11,
+              },
+            ],
+            "variance": 1050,
+            "variancePct": 100,
+          },
+          {
+            "accountGuid": "00000011000000110000001100000011",
+            "accountName": "Food",
+            "actual": 0,
+            "budgeted": 750,
+            "childBudgetTotal": 750,
+            "depth": 1,
+            "fullPath": "Food",
+            "hasChildren": true,
+            "hasExplicitBudget": false,
+            "imbalance": 0,
+            "parentAccountGuid": "00000010000000100000001000000010",
+            "periods": [
+              {
+                "actual": {
+                  "2025": 245,
+                },
+                "budgeted": 250,
+                "period": 0,
+              },
+              {
+                "actual": {
+                  "2025": 180,
+                },
+                "budgeted": 250,
+                "period": 1,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 250,
+                "period": 2,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 3,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 4,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 5,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 6,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 7,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 8,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 9,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 10,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 11,
+              },
+            ],
+            "variance": 750,
+            "variancePct": 100,
+          },
+          {
+            "accountGuid": "00000012000000120000001200000012",
+            "accountName": "Groceries",
+            "actual": 0,
+            "budgeted": 750,
+            "childBudgetTotal": 0,
+            "depth": 2,
+            "fullPath": "Food:Groceries",
+            "hasChildren": false,
+            "hasExplicitBudget": true,
+            "imbalance": 0,
+            "parentAccountGuid": "00000011000000110000001100000011",
+            "periods": [
+              {
+                "actual": {
+                  "2025": 200,
+                },
+                "budgeted": 250,
+                "period": 0,
+              },
+              {
+                "actual": {
+                  "2025": 180,
+                },
+                "budgeted": 250,
+                "period": 1,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 250,
+                "period": 2,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 3,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 4,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 5,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 6,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 7,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 8,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 9,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 10,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 11,
+              },
+            ],
+            "variance": 750,
+            "variancePct": 100,
+          },
+          {
+            "accountGuid": "00000014000000140000001400000014",
+            "accountName": "Utilities",
+            "actual": 0,
+            "budgeted": 300,
+            "childBudgetTotal": 300,
+            "depth": 1,
+            "fullPath": "Utilities",
+            "hasChildren": true,
+            "hasExplicitBudget": false,
+            "imbalance": 0,
+            "parentAccountGuid": "00000010000000100000001000000010",
+            "periods": [
+              {
+                "actual": {
+                  "2025": 85,
+                },
+                "budgeted": 100,
+                "period": 0,
+              },
+              {
+                "actual": {
+                  "2025": 90,
+                },
+                "budgeted": 100,
+                "period": 1,
+              },
+              {
+                "actual": {
+                  "2025": 40,
+                },
+                "budgeted": 100,
+                "period": 2,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 3,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 4,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 5,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 6,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 7,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 8,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 9,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 10,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 11,
+              },
+            ],
+            "variance": 300,
+            "variancePct": 100,
+          },
+          {
+            "accountGuid": "00000015000000150000001500000015",
+            "accountName": "Electric",
+            "actual": 0,
+            "budgeted": 300,
+            "childBudgetTotal": 0,
+            "depth": 2,
+            "fullPath": "Utilities:Electric",
+            "hasChildren": false,
+            "hasExplicitBudget": true,
+            "imbalance": 0,
+            "parentAccountGuid": "00000014000000140000001400000014",
+            "periods": [
+              {
+                "actual": {
+                  "2025": 85,
+                },
+                "budgeted": 100,
+                "period": 0,
+              },
+              {
+                "actual": {
+                  "2025": 90,
+                },
+                "budgeted": 100,
+                "period": 1,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 100,
+                "period": 2,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 3,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 4,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 5,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 6,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 7,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 8,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 9,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 10,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 11,
+              },
+            ],
+            "variance": 300,
+            "variancePct": 100,
+          },
+        ],
+        "incomeCategories": [
+          {
+            "accountGuid": "0000000d0000000d0000000d0000000d",
+            "accountName": "Income",
+            "actual": 0,
+            "budgeted": 9000,
+            "childBudgetTotal": 9000,
+            "depth": 0,
+            "fullPath": "",
+            "hasChildren": true,
+            "hasExplicitBudget": false,
+            "imbalance": 0,
+            "parentAccountGuid": null,
+            "periods": [
+              {
+                "actual": {
+                  "2025": 3000,
+                },
+                "budgeted": 3000,
+                "period": 0,
+              },
+              {
+                "actual": {
+                  "2025": 3500,
+                },
+                "budgeted": 3000,
+                "period": 1,
+              },
+              {
+                "actual": {
+                  "2025": 3000,
+                },
+                "budgeted": 3000,
+                "period": 2,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 3,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 4,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 5,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 6,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 7,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 8,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 9,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 10,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 11,
+              },
+            ],
+            "variance": 9000,
+            "variancePct": 100,
+          },
+          {
+            "accountGuid": "0000000e0000000e0000000e0000000e",
+            "accountName": "Salary",
+            "actual": 0,
+            "budgeted": 9000,
+            "childBudgetTotal": 0,
+            "depth": 1,
+            "fullPath": "Salary",
+            "hasChildren": false,
+            "hasExplicitBudget": true,
+            "imbalance": 0,
+            "parentAccountGuid": "0000000d0000000d0000000d0000000d",
+            "periods": [
+              {
+                "actual": {
+                  "2025": 3000,
+                },
+                "budgeted": 3000,
+                "period": 0,
+              },
+              {
+                "actual": {
+                  "2025": 3000,
+                },
+                "budgeted": 3000,
+                "period": 1,
+              },
+              {
+                "actual": {
+                  "2025": 3000,
+                },
+                "budgeted": 3000,
+                "period": 2,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 3,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 4,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 5,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 6,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 7,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 8,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 9,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 10,
+              },
+              {
+                "actual": {
+                  "2025": 0,
+                },
+                "budgeted": 0,
+                "period": 11,
+              },
+            ],
+            "variance": 9000,
+            "variancePct": 100,
+          },
+        ],
+      },
+    },
     "expenseCategories": [
+      {
+        "accountGuid": "00000010000000100000001000000010",
+        "accountName": "Expenses",
+        "actual": 0,
+        "budgeted": 1050,
+        "childBudgetTotal": 1050,
+        "depth": 0,
+        "fullPath": "",
+        "hasChildren": true,
+        "hasExplicitBudget": false,
+        "imbalance": 0,
+        "parentAccountGuid": null,
+        "periods": [
+          {
+            "actual": {
+              "2025": 330,
+            },
+            "budgeted": 350,
+            "period": 0,
+          },
+          {
+            "actual": {
+              "2025": 270,
+            },
+            "budgeted": 350,
+            "period": 1,
+          },
+          {
+            "actual": {
+              "2025": 40,
+            },
+            "budgeted": 350,
+            "period": 2,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 3,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 4,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 5,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 6,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 7,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 8,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 9,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 10,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 11,
+          },
+        ],
+        "variance": 1050,
+        "variancePct": 100,
+      },
+      {
+        "accountGuid": "00000011000000110000001100000011",
+        "accountName": "Food",
+        "actual": 0,
+        "budgeted": 750,
+        "childBudgetTotal": 750,
+        "depth": 1,
+        "fullPath": "Food",
+        "hasChildren": true,
+        "hasExplicitBudget": false,
+        "imbalance": 0,
+        "parentAccountGuid": "00000010000000100000001000000010",
+        "periods": [
+          {
+            "actual": {
+              "2025": 245,
+            },
+            "budgeted": 250,
+            "period": 0,
+          },
+          {
+            "actual": {
+              "2025": 180,
+            },
+            "budgeted": 250,
+            "period": 1,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 250,
+            "period": 2,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 3,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 4,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 5,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 6,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 7,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 8,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 9,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 10,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 11,
+          },
+        ],
+        "variance": 750,
+        "variancePct": 100,
+      },
       {
         "accountGuid": "00000012000000120000001200000012",
         "accountName": "Groceries",
         "actual": 0,
         "budgeted": 750,
+        "childBudgetTotal": 0,
+        "depth": 2,
         "fullPath": "Food:Groceries",
+        "hasChildren": false,
+        "hasExplicitBudget": true,
+        "imbalance": 0,
+        "parentAccountGuid": "00000011000000110000001100000011",
         "periods": [
           {
             "actual": {
@@ -407,11 +1330,118 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
         "variancePct": 100,
       },
       {
+        "accountGuid": "00000014000000140000001400000014",
+        "accountName": "Utilities",
+        "actual": 0,
+        "budgeted": 300,
+        "childBudgetTotal": 300,
+        "depth": 1,
+        "fullPath": "Utilities",
+        "hasChildren": true,
+        "hasExplicitBudget": false,
+        "imbalance": 0,
+        "parentAccountGuid": "00000010000000100000001000000010",
+        "periods": [
+          {
+            "actual": {
+              "2025": 85,
+            },
+            "budgeted": 100,
+            "period": 0,
+          },
+          {
+            "actual": {
+              "2025": 90,
+            },
+            "budgeted": 100,
+            "period": 1,
+          },
+          {
+            "actual": {
+              "2025": 40,
+            },
+            "budgeted": 100,
+            "period": 2,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 3,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 4,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 5,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 6,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 7,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 8,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 9,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 10,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 11,
+          },
+        ],
+        "variance": 300,
+        "variancePct": 100,
+      },
+      {
         "accountGuid": "00000015000000150000001500000015",
         "accountName": "Electric",
         "actual": 0,
         "budgeted": 300,
+        "childBudgetTotal": 0,
+        "depth": 2,
         "fullPath": "Utilities:Electric",
+        "hasChildren": false,
+        "hasExplicitBudget": true,
+        "imbalance": 0,
+        "parentAccountGuid": "00000014000000140000001400000014",
         "periods": [
           {
             "actual": {
@@ -504,11 +1534,118 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
     ],
     "incomeCategories": [
       {
+        "accountGuid": "0000000d0000000d0000000d0000000d",
+        "accountName": "Income",
+        "actual": 0,
+        "budgeted": 9000,
+        "childBudgetTotal": 9000,
+        "depth": 0,
+        "fullPath": "",
+        "hasChildren": true,
+        "hasExplicitBudget": false,
+        "imbalance": 0,
+        "parentAccountGuid": null,
+        "periods": [
+          {
+            "actual": {
+              "2025": 3000,
+            },
+            "budgeted": 3000,
+            "period": 0,
+          },
+          {
+            "actual": {
+              "2025": 3500,
+            },
+            "budgeted": 3000,
+            "period": 1,
+          },
+          {
+            "actual": {
+              "2025": 3000,
+            },
+            "budgeted": 3000,
+            "period": 2,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 3,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 4,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 5,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 6,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 7,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 8,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 9,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 10,
+          },
+          {
+            "actual": {
+              "2025": 0,
+            },
+            "budgeted": 0,
+            "period": 11,
+          },
+        ],
+        "variance": 9000,
+        "variancePct": 100,
+      },
+      {
         "accountGuid": "0000000e0000000e0000000e0000000e",
         "accountName": "Salary",
         "actual": 0,
         "budgeted": 9000,
+        "childBudgetTotal": 0,
+        "depth": 1,
         "fullPath": "Salary",
+        "hasChildren": false,
+        "hasExplicitBudget": true,
+        "imbalance": 0,
+        "parentAccountGuid": "0000000d0000000d0000000d0000000d",
         "periods": [
           {
             "actual": {

--- a/app/src/lib/gnucash/__tests__/domain/__snapshots__/budgets.test.ts.snap
+++ b/app/src/lib/gnucash/__tests__/domain/__snapshots__/budgets.test.ts.snap
@@ -13,13 +13,936 @@ exports[`computeBudgetData > snapshot 1`] = `
       "numPeriods": 12,
     },
   ],
+  "categoriesByBudget": {
+    "00000034000000340000003400000034": {
+      "expenseCategories": [
+        {
+          "accountGuid": "00000010000000100000001000000010",
+          "accountName": "Expenses",
+          "actual": 0,
+          "budgeted": 1050,
+          "childBudgetTotal": 1050,
+          "depth": 0,
+          "fullPath": "",
+          "hasChildren": true,
+          "hasExplicitBudget": false,
+          "imbalance": 0,
+          "parentAccountGuid": null,
+          "periods": [
+            {
+              "actual": {
+                "2025": 330,
+              },
+              "budgeted": 350,
+              "period": 0,
+            },
+            {
+              "actual": {
+                "2025": 270,
+              },
+              "budgeted": 350,
+              "period": 1,
+            },
+            {
+              "actual": {
+                "2025": 40,
+              },
+              "budgeted": 350,
+              "period": 2,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 3,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 4,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 5,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 6,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 7,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 8,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 9,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 10,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 11,
+            },
+          ],
+          "variance": 1050,
+          "variancePct": 100,
+        },
+        {
+          "accountGuid": "00000011000000110000001100000011",
+          "accountName": "Food",
+          "actual": 0,
+          "budgeted": 750,
+          "childBudgetTotal": 750,
+          "depth": 1,
+          "fullPath": "Food",
+          "hasChildren": true,
+          "hasExplicitBudget": false,
+          "imbalance": 0,
+          "parentAccountGuid": "00000010000000100000001000000010",
+          "periods": [
+            {
+              "actual": {
+                "2025": 245,
+              },
+              "budgeted": 250,
+              "period": 0,
+            },
+            {
+              "actual": {
+                "2025": 180,
+              },
+              "budgeted": 250,
+              "period": 1,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 250,
+              "period": 2,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 3,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 4,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 5,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 6,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 7,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 8,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 9,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 10,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 11,
+            },
+          ],
+          "variance": 750,
+          "variancePct": 100,
+        },
+        {
+          "accountGuid": "00000012000000120000001200000012",
+          "accountName": "Groceries",
+          "actual": 0,
+          "budgeted": 750,
+          "childBudgetTotal": 0,
+          "depth": 2,
+          "fullPath": "Food:Groceries",
+          "hasChildren": false,
+          "hasExplicitBudget": true,
+          "imbalance": 0,
+          "parentAccountGuid": "00000011000000110000001100000011",
+          "periods": [
+            {
+              "actual": {
+                "2025": 200,
+              },
+              "budgeted": 250,
+              "period": 0,
+            },
+            {
+              "actual": {
+                "2025": 180,
+              },
+              "budgeted": 250,
+              "period": 1,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 250,
+              "period": 2,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 3,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 4,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 5,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 6,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 7,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 8,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 9,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 10,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 11,
+            },
+          ],
+          "variance": 750,
+          "variancePct": 100,
+        },
+        {
+          "accountGuid": "00000014000000140000001400000014",
+          "accountName": "Utilities",
+          "actual": 0,
+          "budgeted": 300,
+          "childBudgetTotal": 300,
+          "depth": 1,
+          "fullPath": "Utilities",
+          "hasChildren": true,
+          "hasExplicitBudget": false,
+          "imbalance": 0,
+          "parentAccountGuid": "00000010000000100000001000000010",
+          "periods": [
+            {
+              "actual": {
+                "2025": 85,
+              },
+              "budgeted": 100,
+              "period": 0,
+            },
+            {
+              "actual": {
+                "2025": 90,
+              },
+              "budgeted": 100,
+              "period": 1,
+            },
+            {
+              "actual": {
+                "2025": 40,
+              },
+              "budgeted": 100,
+              "period": 2,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 3,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 4,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 5,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 6,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 7,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 8,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 9,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 10,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 11,
+            },
+          ],
+          "variance": 300,
+          "variancePct": 100,
+        },
+        {
+          "accountGuid": "00000015000000150000001500000015",
+          "accountName": "Electric",
+          "actual": 0,
+          "budgeted": 300,
+          "childBudgetTotal": 0,
+          "depth": 2,
+          "fullPath": "Utilities:Electric",
+          "hasChildren": false,
+          "hasExplicitBudget": true,
+          "imbalance": 0,
+          "parentAccountGuid": "00000014000000140000001400000014",
+          "periods": [
+            {
+              "actual": {
+                "2025": 85,
+              },
+              "budgeted": 100,
+              "period": 0,
+            },
+            {
+              "actual": {
+                "2025": 90,
+              },
+              "budgeted": 100,
+              "period": 1,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 100,
+              "period": 2,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 3,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 4,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 5,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 6,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 7,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 8,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 9,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 10,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 11,
+            },
+          ],
+          "variance": 300,
+          "variancePct": 100,
+        },
+      ],
+      "incomeCategories": [
+        {
+          "accountGuid": "0000000d0000000d0000000d0000000d",
+          "accountName": "Income",
+          "actual": 0,
+          "budgeted": 9000,
+          "childBudgetTotal": 9000,
+          "depth": 0,
+          "fullPath": "",
+          "hasChildren": true,
+          "hasExplicitBudget": false,
+          "imbalance": 0,
+          "parentAccountGuid": null,
+          "periods": [
+            {
+              "actual": {
+                "2025": 3000,
+              },
+              "budgeted": 3000,
+              "period": 0,
+            },
+            {
+              "actual": {
+                "2025": 3500,
+              },
+              "budgeted": 3000,
+              "period": 1,
+            },
+            {
+              "actual": {
+                "2025": 3000,
+              },
+              "budgeted": 3000,
+              "period": 2,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 3,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 4,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 5,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 6,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 7,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 8,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 9,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 10,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 11,
+            },
+          ],
+          "variance": 9000,
+          "variancePct": 100,
+        },
+        {
+          "accountGuid": "0000000e0000000e0000000e0000000e",
+          "accountName": "Salary",
+          "actual": 0,
+          "budgeted": 9000,
+          "childBudgetTotal": 0,
+          "depth": 1,
+          "fullPath": "Salary",
+          "hasChildren": false,
+          "hasExplicitBudget": true,
+          "imbalance": 0,
+          "parentAccountGuid": "0000000d0000000d0000000d0000000d",
+          "periods": [
+            {
+              "actual": {
+                "2025": 3000,
+              },
+              "budgeted": 3000,
+              "period": 0,
+            },
+            {
+              "actual": {
+                "2025": 3000,
+              },
+              "budgeted": 3000,
+              "period": 1,
+            },
+            {
+              "actual": {
+                "2025": 3000,
+              },
+              "budgeted": 3000,
+              "period": 2,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 3,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 4,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 5,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 6,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 7,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 8,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 9,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 10,
+            },
+            {
+              "actual": {
+                "2025": 0,
+              },
+              "budgeted": 0,
+              "period": 11,
+            },
+          ],
+          "variance": 9000,
+          "variancePct": 100,
+        },
+      ],
+    },
+  },
   "expenseCategories": [
+    {
+      "accountGuid": "00000010000000100000001000000010",
+      "accountName": "Expenses",
+      "actual": 0,
+      "budgeted": 1050,
+      "childBudgetTotal": 1050,
+      "depth": 0,
+      "fullPath": "",
+      "hasChildren": true,
+      "hasExplicitBudget": false,
+      "imbalance": 0,
+      "parentAccountGuid": null,
+      "periods": [
+        {
+          "actual": {
+            "2025": 330,
+          },
+          "budgeted": 350,
+          "period": 0,
+        },
+        {
+          "actual": {
+            "2025": 270,
+          },
+          "budgeted": 350,
+          "period": 1,
+        },
+        {
+          "actual": {
+            "2025": 40,
+          },
+          "budgeted": 350,
+          "period": 2,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 3,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 4,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 5,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 6,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 7,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 8,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 9,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 10,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 11,
+        },
+      ],
+      "variance": 1050,
+      "variancePct": 100,
+    },
+    {
+      "accountGuid": "00000011000000110000001100000011",
+      "accountName": "Food",
+      "actual": 0,
+      "budgeted": 750,
+      "childBudgetTotal": 750,
+      "depth": 1,
+      "fullPath": "Food",
+      "hasChildren": true,
+      "hasExplicitBudget": false,
+      "imbalance": 0,
+      "parentAccountGuid": "00000010000000100000001000000010",
+      "periods": [
+        {
+          "actual": {
+            "2025": 245,
+          },
+          "budgeted": 250,
+          "period": 0,
+        },
+        {
+          "actual": {
+            "2025": 180,
+          },
+          "budgeted": 250,
+          "period": 1,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 250,
+          "period": 2,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 3,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 4,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 5,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 6,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 7,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 8,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 9,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 10,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 11,
+        },
+      ],
+      "variance": 750,
+      "variancePct": 100,
+    },
     {
       "accountGuid": "00000012000000120000001200000012",
       "accountName": "Groceries",
       "actual": 0,
       "budgeted": 750,
+      "childBudgetTotal": 0,
+      "depth": 2,
       "fullPath": "Food:Groceries",
+      "hasChildren": false,
+      "hasExplicitBudget": true,
+      "imbalance": 0,
+      "parentAccountGuid": "00000011000000110000001100000011",
       "periods": [
         {
           "actual": {
@@ -110,11 +1033,118 @@ exports[`computeBudgetData > snapshot 1`] = `
       "variancePct": 100,
     },
     {
+      "accountGuid": "00000014000000140000001400000014",
+      "accountName": "Utilities",
+      "actual": 0,
+      "budgeted": 300,
+      "childBudgetTotal": 300,
+      "depth": 1,
+      "fullPath": "Utilities",
+      "hasChildren": true,
+      "hasExplicitBudget": false,
+      "imbalance": 0,
+      "parentAccountGuid": "00000010000000100000001000000010",
+      "periods": [
+        {
+          "actual": {
+            "2025": 85,
+          },
+          "budgeted": 100,
+          "period": 0,
+        },
+        {
+          "actual": {
+            "2025": 90,
+          },
+          "budgeted": 100,
+          "period": 1,
+        },
+        {
+          "actual": {
+            "2025": 40,
+          },
+          "budgeted": 100,
+          "period": 2,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 3,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 4,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 5,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 6,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 7,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 8,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 9,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 10,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 11,
+        },
+      ],
+      "variance": 300,
+      "variancePct": 100,
+    },
+    {
       "accountGuid": "00000015000000150000001500000015",
       "accountName": "Electric",
       "actual": 0,
       "budgeted": 300,
+      "childBudgetTotal": 0,
+      "depth": 2,
       "fullPath": "Utilities:Electric",
+      "hasChildren": false,
+      "hasExplicitBudget": true,
+      "imbalance": 0,
+      "parentAccountGuid": "00000014000000140000001400000014",
       "periods": [
         {
           "actual": {
@@ -207,11 +1237,118 @@ exports[`computeBudgetData > snapshot 1`] = `
   ],
   "incomeCategories": [
     {
+      "accountGuid": "0000000d0000000d0000000d0000000d",
+      "accountName": "Income",
+      "actual": 0,
+      "budgeted": 9000,
+      "childBudgetTotal": 9000,
+      "depth": 0,
+      "fullPath": "",
+      "hasChildren": true,
+      "hasExplicitBudget": false,
+      "imbalance": 0,
+      "parentAccountGuid": null,
+      "periods": [
+        {
+          "actual": {
+            "2025": 3000,
+          },
+          "budgeted": 3000,
+          "period": 0,
+        },
+        {
+          "actual": {
+            "2025": 3500,
+          },
+          "budgeted": 3000,
+          "period": 1,
+        },
+        {
+          "actual": {
+            "2025": 3000,
+          },
+          "budgeted": 3000,
+          "period": 2,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 3,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 4,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 5,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 6,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 7,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 8,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 9,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 10,
+        },
+        {
+          "actual": {
+            "2025": 0,
+          },
+          "budgeted": 0,
+          "period": 11,
+        },
+      ],
+      "variance": 9000,
+      "variancePct": 100,
+    },
+    {
       "accountGuid": "0000000e0000000e0000000e0000000e",
       "accountName": "Salary",
       "actual": 0,
       "budgeted": 9000,
+      "childBudgetTotal": 0,
+      "depth": 1,
       "fullPath": "Salary",
+      "hasChildren": false,
+      "hasExplicitBudget": true,
+      "imbalance": 0,
+      "parentAccountGuid": "0000000d0000000d0000000d0000000d",
       "periods": [
         {
           "actual": {

--- a/app/src/lib/gnucash/domain/budgets.ts
+++ b/app/src/lib/gnucash/domain/budgets.ts
@@ -1,9 +1,9 @@
-import type { BudgetData, BudgetInfo, BudgetCategoryRow } from "@/lib/types/gnucash";
+import type { BudgetData, BudgetDataForBudget, BudgetInfo, BudgetCategoryRow } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { sqlYear, sqlMonthNum } from "../shared/dates";
 
 export function computeBudgetData(ctx: ParseContext): BudgetData | null {
-  const { db, accounts, accountMap, rootAccount } = ctx;
+  const { db, accounts, accountMap, rootAccount, topExpenseGuids, topIncomeGuids } = ctx;
 
   // Check if budgets table exists
   const tableCheck = db
@@ -33,32 +33,7 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
     )
     .all() as { budget_guid: string; account_guid: string; period_num: number; amount: number }[];
 
-  const topContainerGuids = new Set(
-    accounts
-      .filter(
-        (a) =>
-          (a.account_type === "EXPENSE" || a.account_type === "INCOME") &&
-          a.parent_guid === rootAccount.guid
-      )
-      .map((a) => a.guid)
-  );
-
-  function getAccountPath(accountGuid: string): string {
-    const parts: string[] = [];
-    let current = accountMap.get(accountGuid);
-    while (
-      current &&
-      !topContainerGuids.has(current.guid) &&
-      current.account_type !== "ROOT"
-    ) {
-      parts.unshift(current.name);
-      current = current.parent_guid
-        ? accountMap.get(current.parent_guid)
-        : undefined;
-    }
-    return parts.join(":");
-  }
-
+  // Fetch actuals for all expense/income leaf accounts
   const actualRows = db
     .prepare(
       `SELECT
@@ -86,6 +61,7 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
   }
   const availableYears = [...allYears].sort((a, b) => b - a);
 
+  // Build account children map (full account tree)
   const childrenMap = new Map<string, string[]>();
   for (const a of accounts) {
     if (a.parent_guid) {
@@ -103,6 +79,7 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
     return result;
   }
 
+  // Build budget amounts map: budgetGuid -> accountGuid -> periodNum -> amount
   const budgetAmountsMap = new Map<string, Map<string, Map<number, number>>>();
   for (const row of amountRows) {
     if (!budgetAmountsMap.has(row.budget_guid)) budgetAmountsMap.set(row.budget_guid, new Map());
@@ -111,42 +88,173 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
     accountAmounts.get(row.account_guid)!.set(row.period_num, row.amount);
   }
 
-  const defaultBudget = budgets[0];
-  const defaultAmounts = budgetAmountsMap.get(defaultBudget.guid);
-  const expenseCategories: BudgetCategoryRow[] = [];
-  const incomeCategories: BudgetCategoryRow[] = [];
+  /**
+   * Walk from an account up to its top-level container (direct child of
+   * Expenses or Income root), returning the path of account GUIDs from
+   * top-level down to (but not including) the account itself.
+   * Returns null if the account is already a top-level container or root.
+   */
+  function getAncestorPath(accountGuid: string): string[] | null {
+    const path: string[] = [];
+    let current = accountMap.get(accountGuid);
+    if (!current) return null;
 
-  if (defaultAmounts) {
-    for (const [accountGuid, periodAmounts] of defaultAmounts) {
+    // Walk up, collecting ancestors until we hit a top-level container
+    while (current) {
+      if (topExpenseGuids.has(current.guid) || topIncomeGuids.has(current.guid)) {
+        // current is the top-level category — it's the root of our hierarchy
+        path.unshift(current.guid);
+        return path;
+      }
+      if (current.account_type === "ROOT" || current.guid === rootAccount.guid) return null;
+      path.unshift(current.guid);
+      current = current.parent_guid ? accountMap.get(current.parent_guid) : undefined;
+    }
+    return null;
+  }
+
+  function getAccountPath(accountGuid: string): string {
+    const parts: string[] = [];
+    let current = accountMap.get(accountGuid);
+    const topGuids = new Set([...topExpenseGuids, ...topIncomeGuids]);
+    while (
+      current &&
+      !topGuids.has(current.guid) &&
+      current.account_type !== "ROOT"
+    ) {
+      parts.unshift(current.name);
+      current = current.parent_guid
+        ? accountMap.get(current.parent_guid)
+        : undefined;
+    }
+    return parts.join(":");
+  }
+
+  // Compute rolled-up actuals for a given account (including all descendants)
+  function getRolledUpActuals(accountGuid: string): Map<string, Map<number, number>> {
+    const descendantGuids = getDescendants(accountGuid);
+    const rolledUp = new Map<string, Map<number, number>>();
+    for (const dGuid of descendantGuids) {
+      const dYearMap = actualsMap.get(dGuid);
+      if (dYearMap) {
+        for (const [year, periodMap] of dYearMap) {
+          if (!rolledUp.has(year)) rolledUp.set(year, new Map());
+          const target = rolledUp.get(year)!;
+          for (const [period, amount] of periodMap) {
+            target.set(period, (target.get(period) ?? 0) + amount);
+          }
+        }
+      }
+    }
+    return rolledUp;
+  }
+
+  // Build categories for each budget
+  const categoriesByBudget: Record<string, BudgetDataForBudget> = {};
+
+  for (const budget of budgets) {
+    const budgetAmounts = budgetAmountsMap.get(budget.guid);
+    if (!budgetAmounts) {
+      categoriesByBudget[budget.guid] = { expenseCategories: [], incomeCategories: [] };
+      continue;
+    }
+
+    const budgetedAccountGuids = new Set(budgetAmounts.keys());
+    const currentYear = new Date().getFullYear().toString();
+
+    // Collect all account GUIDs that need rows: budgeted accounts + all
+    // ancestors up to the top-level container. This ensures we always
+    // present a hierarchy starting at the top level.
+    const allNeededGuids = new Set<string>();
+    for (const accGuid of budgetedAccountGuids) {
+      const path = getAncestorPath(accGuid);
+      if (path) {
+        for (const guid of path) allNeededGuids.add(guid);
+      }
+    }
+
+    // For each needed account, determine its direct parent in the hierarchy
+    // (the nearest ancestor that is also in allNeededGuids).
+    function findHierarchyParent(accountGuid: string): string | null {
+      const account = accountMap.get(accountGuid);
+      if (!account || !account.parent_guid) return null;
+      let current = accountMap.get(account.parent_guid);
+      while (current) {
+        if (current.account_type === "ROOT" || current.guid === rootAccount.guid) return null;
+        if (topExpenseGuids.has(current.guid) || topIncomeGuids.has(current.guid)) {
+          // If the account itself IS a top-level guid, its parent is null
+          if (accountGuid === current.guid) return null;
+          // Otherwise, the top-level guid is the parent if it's in allNeededGuids
+          return allNeededGuids.has(current.guid) ? current.guid : null;
+        }
+        if (allNeededGuids.has(current.guid)) return current.guid;
+        current = current.parent_guid ? accountMap.get(current.parent_guid) : undefined;
+      }
+      return null;
+    }
+
+    // Build a map of direct hierarchy children for each node
+    const hierarchyChildrenMap = new Map<string, string[]>();
+    for (const guid of allNeededGuids) {
+      const parent = findHierarchyParent(guid);
+      if (parent) {
+        if (!hierarchyChildrenMap.has(parent)) hierarchyChildrenMap.set(parent, []);
+        hierarchyChildrenMap.get(parent)!.push(guid);
+      }
+    }
+
+    // Compute depth in the hierarchy
+    function computeDepth(accountGuid: string): number {
+      let depth = 0;
+      let parent = findHierarchyParent(accountGuid);
+      while (parent) {
+        depth++;
+        parent = findHierarchyParent(parent);
+      }
+      return depth;
+    }
+
+    // Build rows for all needed accounts
+    const expenseCategories: BudgetCategoryRow[] = [];
+    const incomeCategories: BudgetCategoryRow[] = [];
+
+    for (const accountGuid of allNeededGuids) {
       const account = accountMap.get(accountGuid);
       if (!account) continue;
       if (account.account_type !== "EXPENSE" && account.account_type !== "INCOME") continue;
 
-      const descendantGuids = getDescendants(accountGuid);
-      const rolledUpActuals = new Map<string, Map<number, number>>();
-      for (const dGuid of descendantGuids) {
-        const dYearMap = actualsMap.get(dGuid);
-        if (dYearMap) {
-          for (const [year, periodMap] of dYearMap) {
-            if (!rolledUpActuals.has(year)) rolledUpActuals.set(year, new Map());
-            const target = rolledUpActuals.get(year)!;
-            for (const [period, amount] of periodMap) {
-              target.set(period, (target.get(period) ?? 0) + amount);
+      const isIncome = account.account_type === "INCOME";
+      const rolledUpActuals = getRolledUpActuals(accountGuid);
+      const ownBudgetAmounts = budgetAmounts.get(accountGuid);
+
+      // If this account has an explicit budget, use it.
+      // Otherwise, sum up all budgeted descendants' amounts (rollup).
+      let periodBudgets: Map<number, number>;
+      if (ownBudgetAmounts) {
+        periodBudgets = ownBudgetAmounts;
+      } else {
+        // Synthesise budget by summing all budgeted descendants
+        periodBudgets = new Map<number, number>();
+        const descendants = getDescendants(accountGuid);
+        for (const dGuid of descendants) {
+          if (dGuid === accountGuid) continue;
+          const dBudget = budgetAmounts.get(dGuid);
+          if (dBudget) {
+            for (const [p, amt] of dBudget) {
+              periodBudgets.set(p, (periodBudgets.get(p) ?? 0) + amt);
             }
           }
         }
       }
 
       const fullPath = getAccountPath(accountGuid);
-      const currentYear = new Date().getFullYear().toString();
-      const isIncome = account.account_type === "INCOME";
 
       let totalBudgeted = 0;
       let totalActual = 0;
       const periods: { period: number; budgeted: number; actual: Record<string, number> }[] = [];
 
-      for (let p = 0; p < defaultBudget.numPeriods; p++) {
-        const rawBudgeted = periodAmounts.get(p) ?? 0;
+      for (let p = 0; p < budget.numPeriods; p++) {
+        const rawBudgeted = periodBudgets.get(p) ?? 0;
         const budgeted = isIncome ? Math.abs(rawBudgeted) : rawBudgeted;
         const actualByYear: Record<string, number> = {};
         for (const year of allYears) {
@@ -161,6 +269,44 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
 
       if (totalBudgeted === 0 && totalActual === 0) continue;
 
+      // Compute child budget totals for imbalance detection
+      const directChildren = hierarchyChildrenMap.get(accountGuid) ?? [];
+      // Only count children that will actually appear as rows (non-zero budget or actual)
+      const hasChildren = directChildren.length > 0;
+      let childBudgetTotal = 0;
+      if (hasChildren) {
+        for (const childGuid of directChildren) {
+          const childAccount = accountMap.get(childGuid);
+          const childIsIncome = childAccount?.account_type === "INCOME";
+          // Child budget: explicit or rolled-up
+          const childOwnBudget = budgetAmounts.get(childGuid);
+          if (childOwnBudget) {
+            for (let p = 0; p < budget.numPeriods; p++) {
+              const raw = childOwnBudget.get(p) ?? 0;
+              childBudgetTotal += childIsIncome ? Math.abs(raw) : raw;
+            }
+          } else {
+            // Child is a synthesised parent — sum its budgeted descendants
+            const childDescendants = getDescendants(childGuid);
+            for (const dGuid of childDescendants) {
+              if (dGuid === childGuid) continue;
+              const dBudget = budgetAmounts.get(dGuid);
+              if (dBudget) {
+                for (let p = 0; p < budget.numPeriods; p++) {
+                  const raw = dBudget.get(p) ?? 0;
+                  childBudgetTotal += childIsIncome ? Math.abs(raw) : raw;
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // Only show imbalance when the account has its own explicit budget
+      // AND children with budgets. Synthesised parents always balance by definition.
+      const hasExplicitBudget = budgetedAccountGuids.has(accountGuid);
+      const imbalance = hasExplicitBudget && hasChildren ? totalBudgeted - childBudgetTotal : 0;
+
       const row: BudgetCategoryRow = {
         accountGuid,
         accountName: account.name,
@@ -170,6 +316,12 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
         variance: totalBudgeted - totalActual,
         variancePct: totalBudgeted > 0 ? ((totalBudgeted - totalActual) / totalBudgeted) * 100 : 0,
         periods,
+        parentAccountGuid: findHierarchyParent(accountGuid),
+        depth: computeDepth(accountGuid),
+        hasChildren,
+        hasExplicitBudget,
+        childBudgetTotal,
+        imbalance,
       };
 
       if (isIncome) incomeCategories.push(row);
@@ -178,7 +330,18 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
 
     expenseCategories.sort((a, b) => b.actual - a.actual);
     incomeCategories.sort((a, b) => b.actual - a.actual);
+
+    categoriesByBudget[budget.guid] = { expenseCategories, incomeCategories };
   }
 
-  return { budgets, expenseCategories, incomeCategories, availableYears };
+  // Default to first budget for backward compat
+  const defaultData = categoriesByBudget[budgets[0].guid] ?? { expenseCategories: [], incomeCategories: [] };
+
+  return {
+    budgets,
+    categoriesByBudget,
+    expenseCategories: defaultData.expenseCategories,
+    incomeCategories: defaultData.incomeCategories,
+    availableYears,
+  };
 }

--- a/app/src/lib/types/gnucash.ts
+++ b/app/src/lib/types/gnucash.ts
@@ -225,10 +225,24 @@ export interface BudgetCategoryRow {
   variance: number; // budgeted - actual (positive = under budget)
   variancePct: number; // variance / budgeted * 100
   periods: { period: number; budgeted: number; actual: Record<string, number> }[]; // actual keyed by year
+  parentAccountGuid: string | null; // nearest ancestor in the budget hierarchy (null = top-level)
+  depth: number; // 0 = top-level budget category
+  hasChildren: boolean; // true if child accounts also appear in the budget hierarchy
+  hasExplicitBudget: boolean; // true if this account has its own budget_amounts entry
+  childBudgetTotal: number; // sum of direct children's budgeted amounts
+  imbalance: number; // this.budgeted - childBudgetTotal (only non-zero for explicit budgets with children)
+}
+
+export interface BudgetDataForBudget {
+  expenseCategories: BudgetCategoryRow[];
+  incomeCategories: BudgetCategoryRow[];
 }
 
 export interface BudgetData {
   budgets: BudgetInfo[];
+  /** Categories keyed by budget guid */
+  categoriesByBudget: Record<string, BudgetDataForBudget>;
+  /** @deprecated Use categoriesByBudget instead — kept for convenience as alias to first budget */
   expenseCategories: BudgetCategoryRow[];
   incomeCategories: BudgetCategoryRow[];
   availableYears: number[];


### PR DESCRIPTION
… selector

- Build hierarchical budget view that rolls up to top-level categories (matching spending/income page behavior) even when only child accounts have budget amounts, by synthesising parent rows from the account tree
- Add clickable drill-down on progress bars and variance table with breadcrumb navigation inside the Category Progress card
- Detect and display budget imbalances when a parent has an explicit budget that doesn't match the sum of its children's budgets
- Fix budget selector dropdown to actually switch between budgets by computing categories per budget in categoriesByBudget map

Closes #12 