### PR TITLE
Add unbudgeted spending rows when drilling into budget categories

### DIFF
--- a/app/src/app/(dashboard)/budget/page.tsx
+++ b/app/src/app/(dashboard)/budget/page.tsx
@@ -379,7 +379,7 @@ function ProgressBars({
                 onClick={cat.hasChildren ? () => onDrillDown(cat.accountGuid) : undefined}
               >
                 <div className="flex items-center justify-between text-xs">
-                  <span className="flex items-center gap-1.5 font-medium text-[#1A1D1F]" data-l>
+                  <span className={`flex items-center gap-1.5 font-medium ${cat.isUnbudgeted ? "italic text-[#9A9FA5]" : "text-[#1A1D1F]"}`} data-l>
                     {cat.accountName}
                     {cat.hasChildren && (
                       <svg className="h-3 w-3 text-[#9A9FA5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -526,7 +526,7 @@ function VarianceTable({
                   className={`border-b border-[#EFEFEF]/50 last:border-0 ${cat.hasChildren ? "cursor-pointer transition-colors hover:bg-[#F4F5F7]" : ""}`}
                   onClick={cat.hasChildren ? () => onDrillDown(cat.accountGuid) : undefined}
                 >
-                  <td className="py-2.5 pr-4 font-medium text-[#1A1D1F]" data-l>
+                  <td className={`py-2.5 pr-4 font-medium ${cat.isUnbudgeted ? "italic text-[#9A9FA5]" : "text-[#1A1D1F]"}`} data-l>
                     <span className="flex items-center gap-1.5">
                       {cat.accountName}
                       {cat.hasChildren && (
@@ -635,7 +635,7 @@ function computeFilteredCategories(
       let childBudgetTotal = cat.childBudgetTotal;
       let imbalance = cat.imbalance;
       if (cat.hasChildren && sourceCategories) {
-        const children = sourceCategories.filter((c) => c.parentAccountGuid === cat.accountGuid);
+        const children = sourceCategories.filter((c) => c.parentAccountGuid === cat.accountGuid && !c.isUnbudgeted);
         childBudgetTotal = children.reduce((sum, c) => {
           const cp = c.periods.find((p) => p.period === selectedMonth);
           return sum + (cp?.budgeted ?? 0);
@@ -673,7 +673,7 @@ function computeFilteredCategories(
     let childBudgetTotal = cat.childBudgetTotal;
     let imbalance = cat.imbalance;
     if (cat.hasChildren && sourceCategories) {
-      const children = sourceCategories.filter((c) => c.parentAccountGuid === cat.accountGuid);
+      const children = sourceCategories.filter((c) => c.parentAccountGuid === cat.accountGuid && !c.isUnbudgeted);
       childBudgetTotal = children.reduce((sum, c) => {
         let cb = 0;
         for (const p of c.periods) {

--- a/app/src/lib/demo-data.ts
+++ b/app/src/lib/demo-data.ts
@@ -16,6 +16,7 @@ import type {
   BudgetData,
   BudgetCategoryRow,
 } from "@/lib/types/gnucash";
+import { addUnbudgetedRows } from "@/lib/gnucash/domain/budgets";
 
 // Seeded PRNG for reproducible "random" data
 function seededRandom(seed: number) {
@@ -524,16 +525,27 @@ function generateBudgetData(
   const prevYearStr = (currentYear - 1).toString();
 
   // Build expense budget categories with sub-budgets
+  // For "Food", only budget "Groceries" to demo unbudgeted spending rows
+  const partialBudgetCategory = "Food";
+  const partialBudgetChildren = new Set(["Groceries"]);
+
   const expenseCategories: BudgetCategoryRow[] = [];
   for (const cat of expenseAccounts) {
     const parentGuid = guidFn();
-    const childRanges = cat.children.map((c) => expenseRanges[c] ?? [10, 50]);
-    // Parent budget = slightly above sum of children (creates a small imbalance to demo the feature)
+    const isPartial = cat.name === partialBudgetCategory;
+
+    // Determine which children get budgets
+    const budgetedChildren = isPartial
+      ? cat.children.filter((c) => partialBudgetChildren.has(c))
+      : cat.children;
+
+    const childRanges = budgetedChildren.map((c) => expenseRanges[c] ?? [10, 50]);
     const childMonthlyBudgets = childRanges.map(([min, max]) => Math.round((min + max) / 2));
+    // Parent budget = slightly above sum of budgeted children
     const parentMonthlyBudget = Math.round(childMonthlyBudgets.reduce((s, b) => s + b, 0) * 1.05);
 
-    // Build child rows first
-    const childRows: BudgetCategoryRow[] = cat.children.map((childName, ci) => {
+    // Build child rows only for budgeted children
+    const childRows: BudgetCategoryRow[] = budgetedChildren.map((childName, ci) => {
       const childGuid = guidFn();
       const childMonthly = childMonthlyBudgets[ci];
 
@@ -575,7 +587,7 @@ function generateBudgetData(
       };
     });
 
-    // Build parent row
+    // Build parent row — actual always rolls up ALL children (including unbudgeted ones)
     const parentPeriods = Array.from({ length: 12 }, (_, p) => {
       const monthStr = `${currentYear}-${String(p + 1).padStart(2, "0")}`;
       const prevMonthStr = `${currentYear - 1}-${String(p + 1).padStart(2, "0")}`;
@@ -615,6 +627,9 @@ function generateBudgetData(
     });
     expenseCategories.push(...childRows);
   }
+
+  // Add unbudgeted rows for parents with unaccounted spending
+  addUnbudgetedRows(expenseCategories, yearStr);
 
   // Build income budget categories
   const incomeCategories: BudgetCategoryRow[] = incomeAccounts

--- a/app/src/lib/gnucash/domain/budgets.ts
+++ b/app/src/lib/gnucash/domain/budgets.ts
@@ -328,6 +328,9 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
       else expenseCategories.push(row);
     }
 
+    addUnbudgetedRows(expenseCategories, currentYear);
+    addUnbudgetedRows(incomeCategories, currentYear);
+
     expenseCategories.sort((a, b) => b.actual - a.actual);
     incomeCategories.sort((a, b) => b.actual - a.actual);
 
@@ -344,4 +347,78 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
     incomeCategories: defaultData.incomeCategories,
     availableYears,
   };
+}
+
+/**
+ * Add synthetic "Unbudgeted" rows for parents whose children don't fully
+ * account for all actuals or budget. Mutates the array in place.
+ */
+export function addUnbudgetedRows(categories: BudgetCategoryRow[], currentYear: string) {
+  const childrenOf = new Map<string, BudgetCategoryRow[]>();
+  for (const cat of categories) {
+    if (cat.parentAccountGuid) {
+      if (!childrenOf.has(cat.parentAccountGuid)) childrenOf.set(cat.parentAccountGuid, []);
+      childrenOf.get(cat.parentAccountGuid)!.push(cat);
+    }
+  }
+
+  const toAdd: BudgetCategoryRow[] = [];
+  for (const parent of categories) {
+    if (!parent.hasChildren) continue;
+    const children = childrenOf.get(parent.accountGuid) ?? [];
+    if (children.length === 0) continue;
+
+    const periods: { period: number; budgeted: number; actual: Record<string, number> }[] = [];
+    let totalBudgeted = 0;
+    let totalActual = 0;
+
+    for (let p = 0; p < parent.periods.length; p++) {
+      const parentPeriod = parent.periods[p];
+      let childBudgetSum = 0;
+      const childActualByYear: Record<string, number> = {};
+
+      for (const child of children) {
+        const cp = child.periods[p];
+        if (cp) {
+          childBudgetSum += cp.budgeted;
+          for (const [yr, amt] of Object.entries(cp.actual)) {
+            childActualByYear[yr] = (childActualByYear[yr] ?? 0) + amt;
+          }
+        }
+      }
+
+      const unbudgetedBudget = parentPeriod.budgeted - childBudgetSum;
+      const unbudgetedActual: Record<string, number> = {};
+      for (const [yr, parentAmt] of Object.entries(parentPeriod.actual)) {
+        unbudgetedActual[yr] = parentAmt - (childActualByYear[yr] ?? 0);
+      }
+
+      totalBudgeted += unbudgetedBudget;
+      totalActual += unbudgetedActual[currentYear] ?? 0;
+      periods.push({ period: parentPeriod.period, budgeted: unbudgetedBudget, actual: unbudgetedActual });
+    }
+
+    if (totalBudgeted === 0 && totalActual === 0) continue;
+
+    toAdd.push({
+      accountGuid: `__unbudgeted__${parent.accountGuid}`,
+      accountName: "Unbudgeted",
+      fullPath: parent.fullPath ? `${parent.fullPath}:Unbudgeted` : "Unbudgeted",
+      budgeted: totalBudgeted,
+      actual: totalActual,
+      variance: totalBudgeted - totalActual,
+      variancePct: totalBudgeted > 0 ? ((totalBudgeted - totalActual) / totalBudgeted) * 100 : 0,
+      periods,
+      parentAccountGuid: parent.accountGuid,
+      depth: parent.depth + 1,
+      hasChildren: false,
+      hasExplicitBudget: false,
+      childBudgetTotal: 0,
+      imbalance: 0,
+      isUnbudgeted: true,
+    });
+
+  }
+
+  categories.push(...toAdd);
 }

--- a/app/src/lib/types/gnucash.ts
+++ b/app/src/lib/types/gnucash.ts
@@ -231,6 +231,7 @@ export interface BudgetCategoryRow {
   hasExplicitBudget: boolean; // true if this account has its own budget_amounts entry
   childBudgetTotal: number; // sum of direct children's budgeted amounts
   imbalance: number; // this.budgeted - childBudgetTotal (only non-zero for explicit budgets with children)
+  isUnbudgeted?: boolean; // true for synthetic "Unbudgeted" rows
 }
 
 export interface BudgetDataForBudget {


### PR DESCRIPTION
When a parent account has children with actual spending but no budget, a synthetic "Unbudgeted" row now appears showing the difference. This makes hidden spending visible during drill-down. The amber imbalance banner is preserved alongside the new row.

Resolves issue #15 