### PR TITLE
Fix .gnucash file loading for XML/gzip formats

### DIFF
--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -8,7 +8,7 @@ import { FileUpload } from "@/components/upload/file-upload";
 import { Sidebar } from "@/components/dashboard/sidebar";
 
 function DashboardInner({ children }: { children: React.ReactNode }) {
-  const { data, isWritable, toggleWritable } = useDashboard();
+  const { data, isWritable, isXmlSource, toggleWritable } = useDashboard();
   const { hideValues, toggleHideValues } = usePrivacy();
   const [sidebarOpen, setSidebarOpen] = useState(false);
 
@@ -48,7 +48,16 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
             <h1 className="text-sm font-medium text-[#1A1D1F] sm:text-[15px]">Home page</h1>
           </div>
           <div className="flex items-center gap-2 sm:gap-3">
-            {isWritable && (
+            {isXmlSource && data && (
+              <span
+                className="flex items-center gap-1.5 rounded-lg border border-[#EFEFEF] px-3 py-1.5 text-xs font-medium text-[#9A9FA5]"
+                title="XML files are read-only. Re-save as SQLite3 in GNUCash to enable editing."
+              >
+                <Lock className="h-3 w-3" />
+                <span className="hidden sm:inline">XML &middot; Read-only</span>
+              </span>
+            )}
+            {!isXmlSource && isWritable && (
               <button
                 onClick={toggleWritable}
                 className="flex items-center gap-1.5 rounded-lg border border-[#3B6B8A] bg-[#3B6B8A]/10 px-3 py-1.5 text-xs font-medium text-[#3B6B8A] transition-colors hover:bg-[#3B6B8A]/20"
@@ -58,7 +67,7 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
                 <span className="hidden sm:inline">Editing</span>
               </button>
             )}
-            {!isWritable && data && (
+            {!isXmlSource && !isWritable && data && (
               <button
                 onClick={toggleWritable}
                 className="flex items-center gap-1.5 rounded-lg border border-[#EFEFEF] px-3 py-1.5 text-xs font-medium text-[#9A9FA5] transition-colors hover:bg-[#F4F5F7] hover:text-[#6F767E]"

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -86,6 +86,7 @@ export default function DashboardPage() {
         onExternalPeriodChange={setPeriod}
         onExternalCustomRangeChange={setCustomRange}
         externalDataRange={dataRange}
+        seriesExcludingClosing={data.cashFlowSeriesExcludingClosing}
       />
 
       {/* Row 4: Assets + Liabilities */}

--- a/app/src/app/(dashboard)/sankey/page.tsx
+++ b/app/src/app/(dashboard)/sankey/page.tsx
@@ -4,8 +4,9 @@ import { useState, useMemo, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PeriodSelector } from "@/components/ui/period-selector";
-import { DepthSlider, CategoryFilter, LinkColorControl } from "@/components/sankey/sankey-controls";
+import { DepthSlider, CategoryFilter } from "@/components/sankey/sankey-controls";
 import { useDashboard } from "@/lib/dashboard-context";
+import { ExcludeClosingToggle } from "@/components/ui/exclude-closing-toggle";
 import { type CustomRange, getDataRange } from "@/lib/period-utils";
 import {
   buildSankeyData,
@@ -13,7 +14,6 @@ import {
   getTopLevelCategories,
   SANKEY_PERIOD_LABELS,
   type SankeyPeriod,
-  type LinkColorMode,
 } from "@/lib/sankey-utils";
 
 const SankeyECharts = dynamic(
@@ -35,16 +35,26 @@ export default function SankeyPage() {
   const [period, setPeriod] = useState<SankeyPeriod>("last-6m");
   const [customRange, setCustomRange] = useState<CustomRange | null>(null);
   const [depth, setDepth] = useState(1);
-  const [linkColorMode, setLinkColorMode] = useState<LinkColorMode>("source");
-  const [greyColor, setGreyColor] = useState("#9A9FA5");
+  const [excludeClosing, setExcludeClosing] = useState(!!data?.hasClosingTransactions);
+
+  const activeIncome = excludeClosing && data?.monthlyIncomeByCategoryExcludingClosing
+    ? data.monthlyIncomeByCategoryExcludingClosing : data?.monthlyIncomeByCategory ?? [];
+  const activeExpenses = excludeClosing && data?.monthlyExpensesByCategoryExcludingClosing
+    ? data.monthlyExpensesByCategoryExcludingClosing : data?.monthlyExpensesByCategory ?? [];
+  const activeCashFlow = excludeClosing && data?.cashFlowSeriesExcludingClosing
+    ? data.cashFlowSeriesExcludingClosing : data?.cashFlowSeries ?? [];
+  const activeIncomeColors = excludeClosing && data?.incomeCategoryColorsExcludingClosing
+    ? data.incomeCategoryColorsExcludingClosing : data?.incomeCategoryColors ?? {};
+  const activeExpenseColors = excludeClosing && data?.expenseCategoryColorsExcludingClosing
+    ? data.expenseCategoryColorsExcludingClosing : data?.expenseCategoryColors ?? {};
 
   const incomeCategories = useMemo(
-    () => (data ? getTopLevelCategories(data.monthlyIncomeByCategory) : []),
-    [data],
+    () => getTopLevelCategories(activeIncome),
+    [activeIncome],
   );
   const expenseCategories = useMemo(
-    () => (data ? getTopLevelCategories(data.monthlyExpensesByCategory) : []),
-    [data],
+    () => getTopLevelCategories(activeExpenses),
+    [activeExpenses],
   );
 
   const [selectedIncome, setSelectedIncome] = useState<Set<string>>(new Set());
@@ -63,18 +73,18 @@ export default function SankeyPage() {
   const expenseKey = Array.from(selectedExpense).sort().join(",");
 
   const dataRange = useMemo(
-    () => getDataRange(data?.cashFlowSeries ?? []) ?? { min: "2020-01", max: "2026-01" },
-    [data],
+    () => getDataRange(activeCashFlow) ?? { min: "2020-01", max: "2026-01" },
+    [activeCashFlow],
   );
 
   const sankeyData = useMemo(() => {
     if (!data || !initialized) return null;
     return buildSankeyData({
-      incomeByCategory: data.monthlyIncomeByCategory,
-      expenseByCategory: data.monthlyExpensesByCategory,
-      cashFlowSeries: data.cashFlowSeries,
-      incomeCategoryColors: data.incomeCategoryColors,
-      expenseCategoryColors: data.expenseCategoryColors,
+      incomeByCategory: activeIncome,
+      expenseByCategory: activeExpenses,
+      cashFlowSeries: activeCashFlow,
+      incomeCategoryColors: activeIncomeColors,
+      expenseCategoryColors: activeExpenseColors,
       period,
       depth,
       selectedIncomeCategories: selectedIncome,
@@ -82,11 +92,11 @@ export default function SankeyPage() {
       customRange: customRange ?? undefined,
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, period, customRange, depth, incomeKey, expenseKey, initialized]);
+  }, [data, period, customRange, depth, incomeKey, expenseKey, initialized, excludeClosing]);
 
   const echartsData = useMemo(
-    () => (sankeyData ? toEChartsFormat(sankeyData, linkColorMode, greyColor) : null),
-    [sankeyData, linkColorMode, greyColor],
+    () => (sankeyData ? toEChartsFormat(sankeyData, "source", "#9A9FA5") : null),
+    [sankeyData],
   );
 
   if (!data) return null;
@@ -102,13 +112,10 @@ export default function SankeyPage() {
           </CardTitle>
 
           <div className="flex items-center gap-3">
+            {data.hasClosingTransactions && (
+              <ExcludeClosingToggle checked={excludeClosing} onChange={setExcludeClosing} />
+            )}
             <DepthSlider depth={depth} onChange={setDepth} />
-            <LinkColorControl
-              mode={linkColorMode}
-              greyColor={greyColor}
-              onModeChange={setLinkColorMode}
-              onGreyColorChange={setGreyColor}
-            />
             <PeriodSelector
               period={period}
               labels={SANKEY_PERIOD_LABELS}
@@ -128,14 +135,14 @@ export default function SankeyPage() {
               categories={incomeCategories}
               selected={selectedIncome}
               onChange={setSelectedIncome}
-              colors={data.incomeCategoryColors}
+              colors={activeIncomeColors}
             />
             <CategoryFilter
               label="Expenses"
               categories={expenseCategories}
               selected={selectedExpense}
               onChange={setSelectedExpense}
-              colors={data.expenseCategoryColors}
+              colors={activeExpenseColors}
             />
           </div>
 

--- a/app/src/app/(dashboard)/sankey/page.tsx
+++ b/app/src/app/(dashboard)/sankey/page.tsx
@@ -111,20 +111,14 @@ export default function SankeyPage() {
             Cash Flow Sankey
           </CardTitle>
 
-          <div className="flex items-center gap-3">
-            {data.hasClosingTransactions && (
-              <ExcludeClosingToggle checked={excludeClosing} onChange={setExcludeClosing} />
-            )}
-            <DepthSlider depth={depth} onChange={setDepth} />
-            <PeriodSelector
-              period={period}
-              labels={SANKEY_PERIOD_LABELS}
-              onChange={setPeriod}
-              customRange={customRange}
-              onCustomRangeChange={setCustomRange}
-              dataRange={dataRange}
-            />
-          </div>
+          <PeriodSelector
+            period={period}
+            labels={SANKEY_PERIOD_LABELS}
+            onChange={setPeriod}
+            customRange={customRange}
+            onCustomRangeChange={setCustomRange}
+            dataRange={dataRange}
+          />
         </CardHeader>
 
         <CardContent>
@@ -152,7 +146,18 @@ export default function SankeyPage() {
               No data for the selected period and categories.
             </div>
           ) : (
-            <SankeyECharts data={echartsData} currency={data.currency} />
+            <SankeyECharts
+              data={echartsData}
+              currency={data.currency}
+              bottomBarLeft={
+                <div className="flex items-center gap-3">
+                  {data.hasClosingTransactions && (
+                    <ExcludeClosingToggle checked={excludeClosing} onChange={setExcludeClosing} />
+                  )}
+                  <DepthSlider depth={depth} onChange={setDepth} />
+                </div>
+              }
+            />
           )}
         </CardContent>
       </Card>

--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -13,8 +13,9 @@ import {
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PeriodSelector } from "@/components/ui/period-selector";
+import { ExcludeClosingToggle } from "@/components/ui/exclude-closing-toggle";
 import { formatCurrency, formatCurrencyShort } from "@/lib/format";
-import { type CustomRange, getDataRange } from "@/lib/period-utils";
+import { type CustomRange, getDataRange, dateToMonth } from "@/lib/period-utils";
 import type { MonthlyCashFlow } from "@/lib/types/gnucash";
 
 type TimePeriod = "this-month" | "last-month" | "last-6m" | "last-12m" | "custom";
@@ -42,7 +43,7 @@ function getSlice(series: MonthlyCashFlow[], period: string, customRange?: Custo
     case "all-time": return series;
     case "custom":
       if (!customRange) return series;
-      return series.filter((s) => s.month >= customRange.start && s.month <= customRange.end);
+      return series.filter((s) => s.month >= dateToMonth(customRange.start) && s.month <= dateToMonth(customRange.end));
     default: return series;
   }
 }
@@ -64,19 +65,24 @@ interface CashFlowChartProps {
   onExternalPeriodChange?: (p: string) => void;
   onExternalCustomRangeChange?: (r: CustomRange) => void;
   externalDataRange?: { min: string; max: string };
+  /** Alternate series with closing transactions excluded (shown when toggle is on). */
+  seriesExcludingClosing?: MonthlyCashFlow[];
 }
 
-export function CashFlowChart({ series, currency, externalPeriod, externalCustomRange, onExternalPeriodChange, onExternalCustomRangeChange, externalDataRange }: CashFlowChartProps) {
+export function CashFlowChart({ series, currency, externalPeriod, externalCustomRange, onExternalPeriodChange, onExternalCustomRangeChange, externalDataRange, seriesExcludingClosing }: CashFlowChartProps) {
   const [localPeriod, setLocalPeriod] = useState<TimePeriod>("last-6m");
   const [localCustomRange, setLocalCustomRange] = useState<CustomRange | null>(null);
+  const [excludeClosing, setExcludeClosing] = useState(!!seriesExcludingClosing);
 
   const isExternal = externalPeriod !== undefined;
   const isSynced = isExternal && !!onExternalPeriodChange;
   const period = (isExternal ? externalPeriod : localPeriod) as TimePeriod;
   const customRange = isExternal ? (externalCustomRange ?? null) : localCustomRange;
 
-  const dataRange = useMemo(() => getDataRange(series) ?? { min: "2020-01", max: "2026-01" }, [series]);
-  const filtered = useMemo(() => getSlice(series, period, customRange), [series, period, customRange]);
+  const activeSeries = excludeClosing && seriesExcludingClosing ? seriesExcludingClosing : series;
+
+  const dataRange = useMemo(() => getDataRange(activeSeries) ?? { min: "2020-01", max: "2026-01" }, [activeSeries]);
+  const filtered = useMemo(() => getSlice(activeSeries, period, customRange), [activeSeries, period, customRange]);
   const totalNet = filtered.reduce((sum, s) => sum + s.net, 0);
   const showChart = filtered.length > 1;
 
@@ -86,6 +92,10 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
         <CardTitle className="text-lg font-semibold text-[#1A1D1F]">
           Cash Flow
         </CardTitle>
+        <div className="flex items-center gap-3">
+          {seriesExcludingClosing && (
+            <ExcludeClosingToggle checked={excludeClosing} onChange={setExcludeClosing} />
+          )}
         {isSynced ? (
           <PeriodSelector
             period={period}
@@ -105,6 +115,7 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
             dataRange={dataRange}
           />
         ) : null}
+        </div>
       </CardHeader>
       <CardContent>
         <div className="mb-1">

--- a/app/src/components/dashboard/charts/income-overview.tsx
+++ b/app/src/components/dashboard/charts/income-overview.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PeriodSelector } from "@/components/ui/period-selector";
 import { formatCurrency } from "@/lib/format";
 import { assignShades } from "@/lib/color-utils";
-import { type CustomRange, getDataRange, getMonthsBetween } from "@/lib/period-utils";
+import { type CustomRange, getDataRange, getMonthsForDateRange } from "@/lib/period-utils";
 import type { MonthlyExpenseByCategory } from "@/lib/types/gnucash";
 
 type TimePeriod = "this-month" | "last-month" | "this-year" | "last-12m" | "custom";
@@ -30,7 +30,7 @@ const PERIOD_LABELS: Record<string, string> = {
 
 function getMonthsForPeriod(period: string, customRange?: CustomRange | null, monthlyData?: MonthlyExpenseByCategory[]): string[] {
   if (period === "custom") {
-    return customRange ? getMonthsBetween(customRange.start, customRange.end) : [];
+    return customRange ? getMonthsForDateRange(customRange.start, customRange.end) : [];
   }
   if (period === "all-time") {
     const seen = new Set<string>();

--- a/app/src/components/dashboard/charts/net-worth-chart.tsx
+++ b/app/src/components/dashboard/charts/net-worth-chart.tsx
@@ -14,7 +14,7 @@ import {
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PeriodSelector } from "@/components/ui/period-selector";
 import { formatCurrency, formatCurrencyShort } from "@/lib/format";
-import { type CustomRange, getDataRange } from "@/lib/period-utils";
+import { type CustomRange, getDataRange, dateToMonth } from "@/lib/period-utils";
 import type { MonthlyNetWorth } from "@/lib/types/gnucash";
 
 type TimePeriod = "last-6m" | "last-12m" | "all-time" | "custom";
@@ -78,7 +78,7 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
       case "all-time": return series;
       case "custom":
         if (!customRange) return series;
-        return series.filter((s) => s.month >= customRange.start && s.month <= customRange.end);
+        return series.filter((s) => s.month >= dateToMonth(customRange.start) && s.month <= dateToMonth(customRange.end));
       default: {
         // Handle periods from the dashboard selector (this-month, last-month)
         if (period === "this-month") return series.slice(-1);

--- a/app/src/components/dashboard/charts/spending-overview.tsx
+++ b/app/src/components/dashboard/charts/spending-overview.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { PeriodSelector } from "@/components/ui/period-selector";
 import { formatCurrency } from "@/lib/format";
 import { assignShades } from "@/lib/color-utils";
-import { type CustomRange, getDataRange, getMonthsBetween } from "@/lib/period-utils";
+import { type CustomRange, getDataRange, getMonthsForDateRange } from "@/lib/period-utils";
 import type { MonthlyExpenseByCategory } from "@/lib/types/gnucash";
 
 type TimePeriod = "this-month" | "last-month" | "this-year" | "last-12m" | "custom";
@@ -30,7 +30,7 @@ const PERIOD_LABELS: Record<string, string> = {
 
 function getMonthsForPeriod(period: string, customRange?: CustomRange | null, monthlyData?: MonthlyExpenseByCategory[]): string[] {
   if (period === "custom") {
-    return customRange ? getMonthsBetween(customRange.start, customRange.end) : [];
+    return customRange ? getMonthsForDateRange(customRange.start, customRange.end) : [];
   }
   if (period === "all-time") {
     // Return all unique months from the data

--- a/app/src/components/sankey/sankey-controls.tsx
+++ b/app/src/components/sankey/sankey-controls.tsx
@@ -1,11 +1,8 @@
 "use client";
 
 import { useState } from "react";
-import {
-  type LinkColorMode,
-} from "@/lib/sankey-utils";
 
-// ── Depth slider ──────────────────────────────────────────────────────
+// ── Depth control ─────────────────────────────────────────────────────
 
 interface DepthSliderProps {
   depth: number;
@@ -14,17 +11,23 @@ interface DepthSliderProps {
 
 export function DepthSlider({ depth, onChange }: DepthSliderProps) {
   return (
-    <div className="flex items-center gap-2">
+    <div className="flex items-center gap-1.5">
       <span className="text-xs text-[#6F767E] whitespace-nowrap">Depth</span>
-      <input
-        type="range"
-        min={1}
-        max={6}
-        value={depth}
-        onChange={(e) => onChange(Number(e.target.value))}
-        className="h-1.5 w-20 cursor-pointer appearance-none rounded-full bg-[#EFEFEF] accent-[#6C9B8B]"
-      />
+      <button
+        onClick={() => onChange(Math.max(1, depth - 1))}
+        disabled={depth <= 1}
+        className="flex h-6 w-6 items-center justify-center rounded border border-[#EFEFEF] text-sm text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:cursor-default"
+      >
+        −
+      </button>
       <span className="w-4 text-center text-xs font-medium text-[#1A1D1F]">{depth}</span>
+      <button
+        onClick={() => onChange(Math.min(6, depth + 1))}
+        disabled={depth >= 6}
+        className="flex h-6 w-6 items-center justify-center rounded border border-[#EFEFEF] text-sm text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:cursor-default"
+      >
+        +
+      </button>
     </div>
   );
 }
@@ -109,50 +112,3 @@ export function CategoryFilter({ label, categories, selected, onChange, colors }
   );
 }
 
-// ── Link colour control ───────────────────────────────────────────────
-
-interface LinkColorControlProps {
-  mode: LinkColorMode;
-  greyColor: string;
-  onModeChange: (m: LinkColorMode) => void;
-  onGreyColorChange: (c: string) => void;
-}
-
-export function LinkColorControl({ mode, greyColor, onModeChange, onGreyColorChange }: LinkColorControlProps) {
-  return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs text-[#6F767E] whitespace-nowrap">Flows</span>
-      <div className="flex rounded-lg border border-[#EFEFEF] overflow-hidden">
-        <button
-          onClick={() => onModeChange("source")}
-          className={`px-2.5 py-1 text-xs transition-colors ${
-            mode === "source"
-              ? "bg-[#6C9B8B] text-white"
-              : "text-[#6F767E] hover:bg-[#F4F5F7]"
-          }`}
-        >
-          Colour
-        </button>
-        <button
-          onClick={() => onModeChange("grey")}
-          className={`px-2.5 py-1 text-xs transition-colors ${
-            mode === "grey"
-              ? "bg-[#6C9B8B] text-white"
-              : "text-[#6F767E] hover:bg-[#F4F5F7]"
-          }`}
-        >
-          Grey
-        </button>
-      </div>
-      {mode === "grey" && (
-        <input
-          type="color"
-          value={greyColor}
-          onChange={(e) => onGreyColorChange(e.target.value)}
-          className="h-6 w-6 cursor-pointer rounded border border-[#EFEFEF] p-0.5"
-          title="Pick flow grey shade"
-        />
-      )}
-    </div>
-  );
-}

--- a/app/src/components/sankey/sankey-echarts.tsx
+++ b/app/src/components/sankey/sankey-echarts.tsx
@@ -46,9 +46,11 @@ function computeIdealHeight(data: EChartsSankeyData): number {
 interface SankeyEChartsProps {
   data: EChartsSankeyData;
   currency: string;
+  /** Extra controls rendered on the left side of the bottom bar */
+  bottomBarLeft?: React.ReactNode;
 }
 
-export function SankeyECharts({ data, currency }: SankeyEChartsProps) {
+export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsProps) {
   const chartRef = useRef<ReactEChartsCore>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [containerHeight, setContainerHeight] = useState(600);
@@ -189,7 +191,7 @@ export function SankeyECharts({ data, currency }: SankeyEChartsProps) {
       </div>
 
       <div className="mt-3 flex items-center justify-between">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <span className="text-xs text-[#9A9FA5]">
             {zoom !== 1
               ? `${Math.round(effectiveScale * 100)}%`
@@ -204,6 +206,12 @@ export function SankeyECharts({ data, currency }: SankeyEChartsProps) {
             >
               Reset
             </button>
+          )}
+          {bottomBarLeft && (
+            <>
+              <div className="h-4 w-px bg-[#EFEFEF]" />
+              {bottomBarLeft}
+            </>
           )}
         </div>
         <div className="flex gap-2">

--- a/app/src/components/sankey/sankey-echarts.tsx
+++ b/app/src/components/sankey/sankey-echarts.tsx
@@ -91,13 +91,19 @@ export function SankeyECharts({ data, currency }: SankeyEChartsProps) {
     [],
   );
 
-  const handleWheel = useCallback((e: React.WheelEvent) => {
-    if (!e.ctrlKey && !e.metaKey) return;
-    e.preventDefault();
-    setZoom((prev) => {
-      const delta = e.deltaY > 0 ? -0.1 : 0.1;
-      return Math.min(3, Math.max(0.5, prev + delta));
-    });
+  // Attach non-passive wheel listener so we can preventDefault and capture scroll
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    function onWheel(e: WheelEvent) {
+      e.preventDefault();
+      setZoom((prev) => {
+        const delta = e.deltaY > 0 ? -0.005 : 0.005;
+        return Math.min(3, Math.max(0.5, prev + delta));
+      });
+    }
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
   }, []);
 
   const resetZoom = useCallback(() => setZoom(1), []);
@@ -161,7 +167,6 @@ export function SankeyECharts({ data, currency }: SankeyEChartsProps) {
     <div>
       <div
         ref={containerRef}
-        onWheel={handleWheel}
         className="overflow-hidden rounded-lg"
         style={{ height: `${visibleHeight}px` }}
       >
@@ -189,8 +194,8 @@ export function SankeyECharts({ data, currency }: SankeyEChartsProps) {
             {zoom !== 1
               ? `${Math.round(effectiveScale * 100)}%`
               : autoScale < 1
-                ? `Fit ${Math.round(autoScale * 100)}% · Ctrl + scroll to zoom`
-                : "Ctrl + scroll to zoom"}
+                ? `Fit ${Math.round(autoScale * 100)}% · Scroll to zoom`
+                : "Scroll to zoom"}
           </span>
           {zoom !== 1 && (
             <button

--- a/app/src/components/ui/exclude-closing-toggle.tsx
+++ b/app/src/components/ui/exclude-closing-toggle.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+interface ExcludeClosingToggleProps {
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+}
+
+export function ExcludeClosingToggle({ checked, onChange }: ExcludeClosingToggleProps) {
+  return (
+    <label className="flex items-center gap-1.5 cursor-pointer select-none" title="Exclude book-closing transactions">
+      <div
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(!checked); } }}
+        tabIndex={0}
+        className={`relative h-4 w-7 rounded-full transition-colors ${
+          checked ? "bg-[#6C9B8B]" : "bg-[#D0D5DD]"
+        }`}
+      >
+        <div
+          className={`absolute top-0.5 h-3 w-3 rounded-full bg-white shadow transition-transform ${
+            checked ? "translate-x-3.5" : "translate-x-0.5"
+          }`}
+        />
+      </div>
+      <span className="text-[11px] text-[#6F767E] whitespace-nowrap">Exclude closing</span>
+    </label>
+  );
+}

--- a/app/src/components/ui/period-selector.tsx
+++ b/app/src/components/ui/period-selector.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import {
   type CustomRange,
   formatDate,
+  isValidDate,
   monthToFirstDay,
   monthToLastDay,
 } from "@/lib/period-utils";
@@ -74,42 +75,7 @@ export function PeriodSelector<T extends string>({
   const presetKeys = Object.keys(labels).filter((k) => k !== "custom") as T[];
 
   return (
-    <div ref={containerRef} className="relative">
-      <button
-        onClick={() => setOpen(!open)}
-        className="flex items-center gap-1.5 rounded-lg border border-[#EFEFEF] px-3 py-1.5 transition-colors hover:bg-[#F4F5F7]"
-      >
-        <span className="text-xs font-medium text-[#6F767E] whitespace-nowrap">{displayLabel}</span>
-        <svg className="h-3.5 w-3.5 text-[#9A9FA5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-        </svg>
-      </button>
-
-      {open && (
-        <div className="absolute right-0 top-full z-10 mt-1 w-44 rounded-lg border border-[#EFEFEF] bg-white py-1 shadow-lg">
-          {presetKeys.map((p) => (
-            <button
-              key={p}
-              onClick={() => handlePresetClick(p)}
-              className={`w-full px-3 py-2 text-left text-xs transition-colors hover:bg-[#F4F5F7] ${
-                period === p ? "font-medium text-[#6C9B8B]" : "text-[#6F767E]"
-              }`}
-            >
-              {labels[p]}
-            </button>
-          ))}
-          <div className="mx-2 my-1 border-t border-[#EFEFEF]" />
-          <button
-            onClick={handleCustomClick}
-            className={`w-full px-3 py-2 text-left text-xs transition-colors hover:bg-[#F4F5F7] ${
-              isCustom ? "font-medium text-[#6C9B8B]" : "text-[#6F767E]"
-            }`}
-          >
-            Custom
-          </button>
-        </div>
-      )}
-
+    <div className="flex items-center gap-2">
       {isCustom && customRange && (
         <CustomDateRange
           range={customRange}
@@ -117,6 +83,45 @@ export function PeriodSelector<T extends string>({
           dataRange={dataRange}
         />
       )}
+
+      <div ref={containerRef} className="relative">
+        <button
+          onClick={() => setOpen(!open)}
+          className="flex items-center gap-1.5 rounded-lg border border-[#EFEFEF] px-3 py-1.5 transition-colors hover:bg-[#F4F5F7]"
+        >
+          <span className="text-xs font-medium text-[#6F767E] whitespace-nowrap">
+            {isCustom ? "Custom" : displayLabel}
+          </span>
+          <svg className="h-3.5 w-3.5 text-[#9A9FA5]" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        {open && (
+          <div className="absolute right-0 top-full z-10 mt-1 w-44 rounded-lg border border-[#EFEFEF] bg-white py-1 shadow-lg">
+            {presetKeys.map((p) => (
+              <button
+                key={p}
+                onClick={() => handlePresetClick(p)}
+                className={`w-full px-3 py-2 text-left text-xs transition-colors hover:bg-[#F4F5F7] ${
+                  period === p ? "font-medium text-[#6C9B8B]" : "text-[#6F767E]"
+                }`}
+              >
+                {labels[p]}
+              </button>
+            ))}
+            <div className="mx-2 my-1 border-t border-[#EFEFEF]" />
+            <button
+              onClick={handleCustomClick}
+              className={`w-full px-3 py-2 text-left text-xs transition-colors hover:bg-[#F4F5F7] ${
+                isCustom ? "font-medium text-[#6C9B8B]" : "text-[#6F767E]"
+              }`}
+            >
+              Custom
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
@@ -131,6 +136,7 @@ interface CustomDateRangeProps {
 
 function CustomDateRange({ range, onChange, dataRange }: CustomDateRangeProps) {
   const [editingField, setEditingField] = useState<"start" | "end" | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const minDate = monthToFirstDay(dataRange.min);
   const maxDate = monthToLastDay(dataRange.max);
@@ -147,45 +153,120 @@ function CustomDateRange({ range, onChange, dataRange }: CustomDateRangeProps) {
     [editingField, range, onChange],
   );
 
+  // Close calendar on click outside
+  useEffect(() => {
+    if (!editingField) return;
+    function handleClick(e: MouseEvent) {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        setEditingField(null);
+      }
+    }
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [editingField]);
+
   return (
-    <div className="mt-2 flex flex-col gap-2">
-      <div className="flex items-center gap-2">
-        <DateButton
-          label={formatDate(range.start)}
-          active={editingField === "start"}
-          onClick={() => setEditingField(editingField === "start" ? null : "start")}
-        />
-        <span className="text-xs text-[#9A9FA5]">to</span>
-        <DateButton
-          label={formatDate(range.end)}
-          active={editingField === "end"}
-          onClick={() => setEditingField(editingField === "end" ? null : "end")}
-        />
-      </div>
+    <div ref={containerRef} className="relative flex items-center gap-2">
+      <DateInput
+        value={range.start}
+        active={editingField === "start"}
+        onClick={() => setEditingField(editingField === "start" ? null : "start")}
+        onDateChange={(date) => {
+          onChange({ ...range, start: date <= range.end ? date : range.end });
+          setEditingField(null);
+        }}
+        minDate={minDate}
+        maxDate={range.end}
+      />
+      <span className="text-xs text-[#9A9FA5]">to</span>
+      <DateInput
+        value={range.end}
+        active={editingField === "end"}
+        onClick={() => setEditingField(editingField === "end" ? null : "end")}
+        onDateChange={(date) => {
+          onChange({ ...range, end: date >= range.start ? date : range.start });
+          setEditingField(null);
+        }}
+        minDate={range.start}
+        maxDate={maxDate}
+      />
 
       {editingField && (
-        <CalendarPicker
-          selected={editingField === "start" ? range.start : range.end}
-          minDate={editingField === "start" ? minDate : range.start}
-          maxDate={editingField === "end" ? maxDate : range.end}
-          onSelect={handleDateSelect}
-        />
+        <div className="absolute right-0 top-full z-20 mt-1">
+          <CalendarPicker
+            selected={editingField === "start" ? range.start : range.end}
+            minDate={editingField === "start" ? minDate : range.start}
+            maxDate={editingField === "end" ? maxDate : range.end}
+            onSelect={handleDateSelect}
+          />
+        </div>
       )}
     </div>
   );
 }
 
-function DateButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+function DateInput({
+  value,
+  active,
+  onClick,
+  onDateChange,
+  minDate,
+  maxDate,
+}: {
+  value: string; // YYYY-MM-DD
+  active: boolean;
+  onClick: () => void;
+  onDateChange: (date: string) => void;
+  minDate: string;
+  maxDate: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function startEditing() {
+    setText(value);
+    setEditing(true);
+    // Focus after render
+    setTimeout(() => inputRef.current?.select(), 0);
+  }
+
+  function commit() {
+    if (isValidDate(text) && text >= minDate && text <= maxDate) {
+      onDateChange(text);
+    }
+    setEditing(false);
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        onBlur={commit}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit();
+          if (e.key === "Escape") setEditing(false);
+        }}
+        placeholder="YYYY-MM-DD"
+        className="w-[7.5rem] rounded-md border border-[#6C9B8B] bg-[#F0F7F5] px-2 py-1.5 text-xs text-[#4A7A6B] font-medium outline-none"
+      />
+    );
+  }
+
   return (
     <button
       onClick={onClick}
-      className={`flex-1 rounded-md border px-2 py-1.5 text-xs transition-colors cursor-pointer ${
+      onDoubleClick={startEditing}
+      className={`w-[7.5rem] whitespace-nowrap rounded-md border px-2 py-1.5 text-xs transition-colors cursor-pointer ${
         active
           ? "border-[#6C9B8B] bg-[#F0F7F5] text-[#4A7A6B] font-medium"
           : "border-[#EFEFEF] text-[#6F767E] hover:border-[#D0D5DD]"
       }`}
     >
-      {label}
+      {formatDate(value)}
     </button>
   );
 }

--- a/app/src/components/ui/period-selector.tsx
+++ b/app/src/components/ui/period-selector.tsx
@@ -3,10 +3,9 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import {
   type CustomRange,
-  monthToIndex,
-  indexToMonth,
-  formatMonth,
-  isValidMonth,
+  formatDate,
+  monthToFirstDay,
+  monthToLastDay,
 } from "@/lib/period-utils";
 
 interface PeriodSelectorProps<T extends string> {
@@ -55,7 +54,10 @@ export function PeriodSelector<T extends string>({
 
   const handleCustomClick = useCallback(() => {
     if (!customRange) {
-      onCustomRangeChange({ start: dataRange.min, end: dataRange.max });
+      onCustomRangeChange({
+        start: monthToFirstDay(dataRange.min),
+        end: monthToLastDay(dataRange.max),
+      });
     }
     onChange("custom" as T);
     onPeriodSideEffect?.();
@@ -66,7 +68,7 @@ export function PeriodSelector<T extends string>({
 
   // Display label
   const displayLabel = isCustom && customRange
-    ? `${formatMonth(customRange.start)} – ${formatMonth(customRange.end)}`
+    ? `${formatDate(customRange.start)} – ${formatDate(customRange.end)}`
     : labels[period] ?? period;
 
   const presetKeys = Object.keys(labels).filter((k) => k !== "custom") as T[];
@@ -109,7 +111,7 @@ export function PeriodSelector<T extends string>({
       )}
 
       {isCustom && customRange && (
-        <CustomRangeSlider
+        <CustomDateRange
           range={customRange}
           onChange={onCustomRangeChange}
           dataRange={dataRange}
@@ -119,101 +121,180 @@ export function PeriodSelector<T extends string>({
   );
 }
 
-// ── Dual-handle range slider ──────────────────────────────────────────
+// ── Custom date range with calendar pickers ──────────────────────────
 
-interface CustomRangeSliderProps {
+interface CustomDateRangeProps {
   range: CustomRange;
   onChange: (range: CustomRange) => void;
   dataRange: { min: string; max: string };
 }
 
-function CustomRangeSlider({ range, onChange, dataRange }: CustomRangeSliderProps) {
-  const totalMonths = monthToIndex(dataRange.min, dataRange.max);
-  const startIdx = monthToIndex(dataRange.min, range.start);
-  const endIdx = monthToIndex(dataRange.min, range.end);
+function CustomDateRange({ range, onChange, dataRange }: CustomDateRangeProps) {
+  const [editingField, setEditingField] = useState<"start" | "end" | null>(null);
 
-  function handleStartSlider(e: React.ChangeEvent<HTMLInputElement>) {
-    const idx = Math.min(Number(e.target.value), endIdx);
-    const month = indexToMonth(dataRange.min, idx);
-    onChange({ ...range, start: month });
-  }
+  const minDate = monthToFirstDay(dataRange.min);
+  const maxDate = monthToLastDay(dataRange.max);
 
-  function handleEndSlider(e: React.ChangeEvent<HTMLInputElement>) {
-    const idx = Math.max(Number(e.target.value), startIdx);
-    const month = indexToMonth(dataRange.min, idx);
-    onChange({ ...range, end: month });
-  }
-
-  function handleStartMonth(e: React.ChangeEvent<HTMLInputElement>) {
-    const v = e.target.value;
-    if (isValidMonth(v) && v >= dataRange.min && v <= range.end) {
-      onChange({ ...range, start: v });
-    }
-  }
-
-  function handleEndMonth(e: React.ChangeEvent<HTMLInputElement>) {
-    const v = e.target.value;
-    if (isValidMonth(v) && v <= dataRange.max && v >= range.start) {
-      onChange({ ...range, end: v });
-    }
-  }
-
-  // Percentage positions for the filled track
-  const leftPct = totalMonths > 0 ? (startIdx / totalMonths) * 100 : 0;
-  const rightPct = totalMonths > 0 ? ((totalMonths - endIdx) / totalMonths) * 100 : 0;
+  const handleDateSelect = useCallback(
+    (date: string) => {
+      if (editingField === "start") {
+        onChange({ ...range, start: date <= range.end ? date : range.end });
+      } else if (editingField === "end") {
+        onChange({ ...range, end: date >= range.start ? date : range.start });
+      }
+      setEditingField(null);
+    },
+    [editingField, range, onChange],
+  );
 
   return (
     <div className="mt-2 flex flex-col gap-2">
-      {/* Slider */}
-      <div className="relative h-6 flex items-center min-w-[200px]">
-        {/* Track background */}
-        <div className="absolute inset-x-0 h-1.5 rounded-full bg-[#EFEFEF]" />
-        {/* Filled track */}
-        <div
-          className="absolute h-1.5 rounded-full bg-[#6C9B8B]"
-          style={{ left: `${leftPct}%`, right: `${rightPct}%` }}
+      <div className="flex items-center gap-2">
+        <DateButton
+          label={formatDate(range.start)}
+          active={editingField === "start"}
+          onClick={() => setEditingField(editingField === "start" ? null : "start")}
         />
-        {/* Start handle */}
-        <input
-          type="range"
-          min={0}
-          max={totalMonths}
-          value={startIdx}
-          onChange={handleStartSlider}
-          className="absolute inset-x-0 h-1.5 w-full appearance-none bg-transparent pointer-events-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#6C9B8B] [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:cursor-pointer [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-[#6C9B8B] [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:shadow [&::-moz-range-thumb]:cursor-pointer"
-          style={{ zIndex: startIdx > totalMonths - 5 ? 5 : 3 }}
-        />
-        {/* End handle */}
-        <input
-          type="range"
-          min={0}
-          max={totalMonths}
-          value={endIdx}
-          onChange={handleEndSlider}
-          className="absolute inset-x-0 h-1.5 w-full appearance-none bg-transparent pointer-events-none [&::-webkit-slider-thumb]:pointer-events-auto [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-[#6C9B8B] [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-white [&::-webkit-slider-thumb]:shadow [&::-webkit-slider-thumb]:cursor-pointer [&::-moz-range-thumb]:pointer-events-auto [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:appearance-none [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:bg-[#6C9B8B] [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-white [&::-moz-range-thumb]:shadow [&::-moz-range-thumb]:cursor-pointer"
-          style={{ zIndex: 4 }}
+        <span className="text-xs text-[#9A9FA5]">to</span>
+        <DateButton
+          label={formatDate(range.end)}
+          active={editingField === "end"}
+          onClick={() => setEditingField(editingField === "end" ? null : "end")}
         />
       </div>
 
-      {/* Month pickers */}
-      <div className="flex items-center gap-2">
-        <input
-          type="month"
-          value={range.start}
-          min={dataRange.min}
-          max={range.end}
-          onChange={handleStartMonth}
-          className="h-7 flex-1 rounded-md border border-[#EFEFEF] px-1.5 text-xs text-[#6F767E] outline-none focus:border-[#6C9B8B] cursor-pointer"
+      {editingField && (
+        <CalendarPicker
+          selected={editingField === "start" ? range.start : range.end}
+          minDate={editingField === "start" ? minDate : range.start}
+          maxDate={editingField === "end" ? maxDate : range.end}
+          onSelect={handleDateSelect}
         />
-        <span className="text-xs text-[#9A9FA5]">to</span>
-        <input
-          type="month"
-          value={range.end}
-          min={range.start}
-          max={dataRange.max}
-          onChange={handleEndMonth}
-          className="h-7 flex-1 rounded-md border border-[#EFEFEF] px-1.5 text-xs text-[#6F767E] outline-none focus:border-[#6C9B8B] cursor-pointer"
-        />
+      )}
+    </div>
+  );
+}
+
+function DateButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className={`flex-1 rounded-md border px-2 py-1.5 text-xs transition-colors cursor-pointer ${
+        active
+          ? "border-[#6C9B8B] bg-[#F0F7F5] text-[#4A7A6B] font-medium"
+          : "border-[#EFEFEF] text-[#6F767E] hover:border-[#D0D5DD]"
+      }`}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ── Calendar picker ─────────────────────────────────────────────────
+
+const MONTH_NAMES = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+const DAY_HEADERS = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+interface CalendarPickerProps {
+  selected: string; // YYYY-MM-DD
+  minDate: string;
+  maxDate: string;
+  onSelect: (date: string) => void;
+}
+
+function CalendarPicker({ selected, minDate, maxDate, onSelect }: CalendarPickerProps) {
+  const [sy, sm] = selected.split("-").map(Number);
+  const [viewYear, setViewYear] = useState(sy);
+  const [viewMonth, setViewMonth] = useState(sm); // 1-indexed
+
+  const firstDayOfWeek = new Date(viewYear, viewMonth - 1, 1).getDay();
+  const daysInMonth = new Date(viewYear, viewMonth, 0).getDate();
+
+  const canPrev = `${viewYear}-${String(viewMonth).padStart(2, "0")}` > minDate.slice(0, 7);
+  const canNext = `${viewYear}-${String(viewMonth).padStart(2, "0")}` < maxDate.slice(0, 7);
+
+  function prev() {
+    if (!canPrev) return;
+    if (viewMonth === 1) { setViewYear(viewYear - 1); setViewMonth(12); }
+    else setViewMonth(viewMonth - 1);
+  }
+
+  function next() {
+    if (!canNext) return;
+    if (viewMonth === 12) { setViewYear(viewYear + 1); setViewMonth(1); }
+    else setViewMonth(viewMonth + 1);
+  }
+
+  function toDateStr(day: number): string {
+    return `${viewYear}-${String(viewMonth).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+  }
+
+  const days: (number | null)[] = [];
+  for (let i = 0; i < firstDayOfWeek; i++) days.push(null);
+  for (let d = 1; d <= daysInMonth; d++) days.push(d);
+
+  return (
+    <div className="rounded-lg border border-[#EFEFEF] bg-white p-3 shadow-lg">
+      {/* Header */}
+      <div className="mb-2 flex items-center justify-between">
+        <button
+          onClick={prev}
+          disabled={!canPrev}
+          className="flex h-6 w-6 items-center justify-center rounded text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:cursor-default"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <span className="text-xs font-medium text-[#1A1D1F]">
+          {MONTH_NAMES[viewMonth - 1]} {viewYear}
+        </span>
+        <button
+          onClick={next}
+          disabled={!canNext}
+          className="flex h-6 w-6 items-center justify-center rounded text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:cursor-default"
+        >
+          <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Day headers */}
+      <div className="grid grid-cols-7 mb-1">
+        {DAY_HEADERS.map((d) => (
+          <div key={d} className="text-center text-[10px] font-medium text-[#9A9FA5] py-0.5">
+            {d}
+          </div>
+        ))}
+      </div>
+
+      {/* Day grid */}
+      <div className="grid grid-cols-7">
+        {days.map((day, i) => {
+          if (day === null) return <div key={`empty-${i}`} />;
+
+          const dateStr = toDateStr(day);
+          const isSelected = dateStr === selected;
+          const isDisabled = dateStr < minDate || dateStr > maxDate;
+
+          return (
+            <button
+              key={day}
+              onClick={() => !isDisabled && onSelect(dateStr)}
+              disabled={isDisabled}
+              className={`flex h-7 w-7 items-center justify-center rounded-full text-[11px] transition-colors mx-auto ${
+                isSelected
+                  ? "bg-[#6C9B8B] text-white font-medium"
+                  : isDisabled
+                    ? "text-[#D0D5DD] cursor-default"
+                    : "text-[#1A1D1F] hover:bg-[#F0F7F5] cursor-pointer"
+              }`}
+            >
+              {day}
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -25,6 +25,7 @@ interface DashboardContextType {
   error: string | null;
   uploadedAt: Date | null;
   isWritable: boolean;
+  isXmlSource: boolean;
   toggleWritable: () => Promise<void>;
   uploadFile: (file: File, writable?: boolean) => Promise<void>;
   loadDemo: () => Promise<void>;
@@ -47,6 +48,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [error, setError] = useState<string | null>(null);
   const [uploadedAt, setUploadedAt] = useState<Date | null>(null);
   const [isWritable, setIsWritable] = useState(false);
+  const [isXmlSource, setIsXmlSource] = useState(false);
   const clientRef = useRef<GnuCashWorkerClient | null>(null);
 
   function getClient(): GnuCashWorkerClient {
@@ -143,14 +145,15 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     try {
       const client = getClient();
       await client.waitForReady();
-      await client.openFile(file, writable);
+      const { isXml } = await client.openFile(file, writable);
       const dashboardData = await client.getFullDashboardData();
       const now = new Date();
       setData(dashboardData);
       setUploadedAt(now);
-      setIsWritable(writable);
+      setIsXmlSource(isXml);
+      setIsWritable(isXml ? false : writable);
       sessionStorage.setItem(UPLOADED_AT_KEY, now.toISOString());
-      sessionStorage.setItem(WRITABLE_KEY, String(writable));
+      sessionStorage.setItem(WRITABLE_KEY, String(isXml ? false : writable));
     } catch (err) {
       setError(err instanceof Error ? err.message : "Upload failed");
     } finally {
@@ -178,6 +181,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setError(null);
     setUploadedAt(null);
     setIsWritable(false);
+    setIsXmlSource(false);
     sessionStorage.removeItem(STORAGE_KEY);
     sessionStorage.removeItem(UPLOADED_AT_KEY);
     sessionStorage.removeItem(WRITABLE_KEY);
@@ -250,7 +254,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
   return (
     <DashboardContext.Provider
-      value={{ data, isLoading, error, uploadedAt, isWritable, toggleWritable, uploadFile, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, exportFile }}
+      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, toggleWritable, uploadFile, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, exportFile }}
     >
       {children}
     </DashboardContext.Provider>

--- a/app/src/lib/demo-data.ts
+++ b/app/src/lib/demo-data.ts
@@ -464,6 +464,7 @@ export function generateDemoData(): DashboardData {
     savingsRate,
     budgetData,
     ledgerTransactions,
+    hasClosingTransactions: false,
   };
 }
 

--- a/app/src/lib/gnucash/__tests__/__snapshots__/index.test.ts.snap
+++ b/app/src/lib/gnucash/__tests__/__snapshots__/index.test.ts.snap
@@ -1757,6 +1757,7 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
       "net": 2960,
     },
   ],
+  "cashFlowSeriesExcludingClosing": undefined,
   "commodities": [
     {
       "fraction": 100,
@@ -1807,10 +1808,12 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
       "name": "Utilities",
     },
   ],
+  "expenseBreakdownExcludingClosing": undefined,
   "expenseCategoryColors": {
     "Food": "#4A7A6B",
     "Utilities": "#5C8C7C",
   },
+  "expenseCategoryColorsExcludingClosing": undefined,
   "expenseTransactions": [
     {
       "accountName": "Water",
@@ -1879,10 +1882,12 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
       ],
     },
   ],
+  "hasClosingTransactions": false,
   "incomeCategoryColors": {
     "Freelance": "#4A7A9A",
     "Salary": "#3B6B8A",
   },
+  "incomeCategoryColorsExcludingClosing": undefined,
   "incomeTransactions": [
     {
       "accountName": "Salary",
@@ -2525,6 +2530,7 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
       ],
     },
   ],
+  "monthlyExpensesByCategoryExcludingClosing": undefined,
   "monthlyIncomeByCategory": [
     {
       "amount": 3000,
@@ -2563,6 +2569,7 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
       ],
     },
   ],
+  "monthlyIncomeByCategoryExcludingClosing": undefined,
   "netWorthSeries": [
     {
       "assets": 17760,

--- a/app/src/lib/gnucash/domain/cash-flow.ts
+++ b/app/src/lib/gnucash/domain/cash-flow.ts
@@ -1,8 +1,12 @@
 import type { MonthlyCashFlow } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { sqlMonth } from "../shared/dates";
+import { EXCLUDE_CLOSING_JOIN, EXCLUDE_CLOSING_WHERE } from "./closing";
 
-export function computeCashFlowSeries(ctx: ParseContext): MonthlyCashFlow[] {
+export function computeCashFlowSeries(ctx: ParseContext, excludeClosing = false): MonthlyCashFlow[] {
+  const closingJoin = excludeClosing ? EXCLUDE_CLOSING_JOIN : "";
+  const closingWhere = excludeClosing ? `AND ${EXCLUDE_CLOSING_WHERE}` : "";
+
   const rows = ctx.db
     .prepare(
       `SELECT
@@ -14,7 +18,9 @@ export function computeCashFlowSeries(ctx: ParseContext): MonthlyCashFlow[] {
       FROM splits s
       JOIN accounts a ON s.account_guid = a.guid
       JOIN transactions t ON s.tx_guid = t.guid
+      ${closingJoin}
       WHERE a.account_type IN ('INCOME', 'EXPENSE')
+      ${closingWhere}
       GROUP BY ${sqlMonth("t.post_date")}
       ORDER BY month`
     )

--- a/app/src/lib/gnucash/domain/closing.ts
+++ b/app/src/lib/gnucash/domain/closing.ts
@@ -2,7 +2,7 @@ import type { ParseContext } from "../context";
 
 /** SQL fragment to exclude book-closing transactions via LEFT JOIN. */
 export const EXCLUDE_CLOSING_JOIN =
-  `LEFT JOIN slots cl ON cl.obj_guid = t.guid AND cl.name = 'book-closing'`;
+  `LEFT JOIN slots cl ON cl.obj_guid = t.guid AND cl.name IN ('book-closing', 'book_closing')`;
 
 export const EXCLUDE_CLOSING_WHERE = `cl.id IS NULL`;
 
@@ -15,7 +15,7 @@ export function hasClosingTransactions(ctx: ParseContext): boolean {
   if (!tableExists) return false;
 
   const row = ctx.db
-    .prepare(`SELECT 1 FROM slots WHERE name = 'book-closing' LIMIT 1`)
+    .prepare(`SELECT 1 FROM slots WHERE name IN ('book-closing', 'book_closing') LIMIT 1`)
     .get();
   return !!row;
 }

--- a/app/src/lib/gnucash/domain/closing.ts
+++ b/app/src/lib/gnucash/domain/closing.ts
@@ -1,0 +1,21 @@
+import type { ParseContext } from "../context";
+
+/** SQL fragment to exclude book-closing transactions via LEFT JOIN. */
+export const EXCLUDE_CLOSING_JOIN =
+  `LEFT JOIN slots cl ON cl.obj_guid = t.guid AND cl.name = 'book-closing'`;
+
+export const EXCLUDE_CLOSING_WHERE = `cl.id IS NULL`;
+
+/** Check whether the database contains any book-closing transactions. */
+export function hasClosingTransactions(ctx: ParseContext): boolean {
+  // The slots table may not exist in older GNUCash files
+  const tableExists = ctx.db
+    .prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='slots'`)
+    .get();
+  if (!tableExists) return false;
+
+  const row = ctx.db
+    .prepare(`SELECT 1 FROM slots WHERE name = 'book-closing' LIMIT 1`)
+    .get();
+  return !!row;
+}

--- a/app/src/lib/gnucash/domain/expenses.ts
+++ b/app/src/lib/gnucash/domain/expenses.ts
@@ -2,9 +2,11 @@ import type { ExpenseCategory, MonthlyExpenseByCategory, ExpenseTransaction } fr
 import type { ParseContext } from "../context";
 import { getAccountPath } from "../shared/accounts";
 import { parseGnuCashDate, formatISODate, sqlMonth } from "../shared/dates";
+import { EXCLUDE_CLOSING_JOIN, EXCLUDE_CLOSING_WHERE } from "./closing";
 
 export function computeExpenseBreakdown(
-  ctx: ParseContext
+  ctx: ParseContext,
+  excludeClosing = false,
 ): { categories: ExpenseCategory[]; monthly: MonthlyExpenseByCategory[]; colors: Record<string, string> } {
   const { db, accounts, accountMap, rootAccount, topExpenseGuids } = ctx;
 
@@ -21,6 +23,9 @@ export function computeExpenseBreakdown(
     colorMap[cat.name] = colorPalette[i % colorPalette.length];
   });
 
+  const closingJoin = excludeClosing ? EXCLUDE_CLOSING_JOIN : "";
+  const closingWhere = excludeClosing ? `AND ${EXCLUDE_CLOSING_WHERE}` : "";
+
   const rows = db
     .prepare(
       `SELECT
@@ -30,7 +35,9 @@ export function computeExpenseBreakdown(
       FROM splits s
       JOIN accounts a ON s.account_guid = a.guid
       JOIN transactions t ON s.tx_guid = t.guid
+      ${closingJoin}
       WHERE a.account_type = 'EXPENSE'
+      ${closingWhere}
       GROUP BY s.account_guid, ${sqlMonth("t.post_date")}
       ORDER BY month`
     )

--- a/app/src/lib/gnucash/domain/income.ts
+++ b/app/src/lib/gnucash/domain/income.ts
@@ -2,9 +2,11 @@ import type { MonthlyExpenseByCategory, ExpenseTransaction } from "@/lib/types/g
 import type { ParseContext } from "../context";
 import { getAccountPath } from "../shared/accounts";
 import { parseGnuCashDate, formatISODate, sqlMonth } from "../shared/dates";
+import { EXCLUDE_CLOSING_JOIN, EXCLUDE_CLOSING_WHERE } from "./closing";
 
 export function computeIncomeBreakdown(
-  ctx: ParseContext
+  ctx: ParseContext,
+  excludeClosing = false,
 ): { monthly: MonthlyExpenseByCategory[]; colors: Record<string, string> } {
   const { db, accounts, accountMap, rootAccount, topIncomeGuids } = ctx;
 
@@ -20,6 +22,9 @@ export function computeIncomeBreakdown(
     colorMap[cat.name] = colorPalette[i % colorPalette.length];
   });
 
+  const closingJoin = excludeClosing ? EXCLUDE_CLOSING_JOIN : "";
+  const closingWhere = excludeClosing ? `AND ${EXCLUDE_CLOSING_WHERE}` : "";
+
   const rows = db
     .prepare(
       `SELECT
@@ -29,7 +34,9 @@ export function computeIncomeBreakdown(
       FROM splits s
       JOIN accounts a ON s.account_guid = a.guid
       JOIN transactions t ON s.tx_guid = t.guid
+      ${closingJoin}
       WHERE a.account_type = 'INCOME'
+      ${closingWhere}
       GROUP BY s.account_guid, ${sqlMonth("t.post_date")}
       ORDER BY month`
     )

--- a/app/src/lib/gnucash/index.ts
+++ b/app/src/lib/gnucash/index.ts
@@ -11,6 +11,7 @@ import { computeTopBalances } from "./domain/balances";
 import { getLedgerTransactions, getRecentTransactions } from "./domain/ledger";
 import { computeBudgetData } from "./domain/budgets";
 import { getUpcomingBills } from "./domain/bills";
+import { hasClosingTransactions } from "./domain/closing";
 import { formatMonth } from "./shared/dates";
 
 export function parseGnuCashFile(filePath: string): DashboardData {
@@ -46,6 +47,26 @@ export function parseGnuCashFile(filePath: string): DashboardData {
         ? ((currentIncome - currentExpenses) / currentIncome) * 100
         : 0;
 
+    const hasClosing = hasClosingTransactions(ctx);
+
+    let cashFlowSeriesExcludingClosing: typeof cashFlowSeries | undefined;
+    let expenseBreakdownExcludingClosing: typeof expenseBreakdown | undefined;
+    let monthlyExpensesByCategoryExcludingClosing: typeof monthlyExpensesByCategory | undefined;
+    let expenseCategoryColorsExcludingClosing: typeof expenseCategoryColors | undefined;
+    let monthlyIncomeByCategoryExcludingClosing: typeof monthlyIncomeByCategory | undefined;
+    let incomeCategoryColorsExcludingClosing: typeof incomeCategoryColors | undefined;
+
+    if (hasClosing) {
+      cashFlowSeriesExcludingClosing = computeCashFlowSeries(ctx, true);
+      const excExpense = computeExpenseBreakdown(ctx, true);
+      expenseBreakdownExcludingClosing = excExpense.categories;
+      monthlyExpensesByCategoryExcludingClosing = excExpense.monthly;
+      expenseCategoryColorsExcludingClosing = excExpense.colors;
+      const excIncome = computeIncomeBreakdown(ctx, true);
+      monthlyIncomeByCategoryExcludingClosing = excIncome.monthly;
+      incomeCategoryColorsExcludingClosing = excIncome.colors;
+    }
+
     const baseCommodity = ctx.commodityMap.get(ctx.baseCurrencyGuid);
 
     return {
@@ -80,6 +101,13 @@ export function parseGnuCashFile(filePath: string): DashboardData {
         fullname: c.fullname,
         fraction: c.fraction,
       })),
+      hasClosingTransactions: hasClosing,
+      cashFlowSeriesExcludingClosing,
+      expenseBreakdownExcludingClosing,
+      monthlyExpensesByCategoryExcludingClosing,
+      expenseCategoryColorsExcludingClosing,
+      monthlyIncomeByCategoryExcludingClosing,
+      incomeCategoryColorsExcludingClosing,
     };
   } finally {
     db.close();

--- a/app/src/lib/gnucash/worker/client.ts
+++ b/app/src/lib/gnucash/worker/client.ts
@@ -18,6 +18,7 @@ import type {
   DashboardData,
 } from "@/lib/types/gnucash";
 import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload } from "./messages";
+import { parseGnuCashXml } from "../xml/parser";
 
 type PendingRequest = {
   resolve: (data: unknown) => void;
@@ -135,29 +136,55 @@ export class GnuCashWorkerClient {
    *
    * GNUCash files can be SQLite3, XML, or gzip-compressed XML/SQLite.
    * We detect the format and handle accordingly:
-   *  - SQLite3: pass through
+   *  - SQLite3: pass through to worker
    *  - Gzip: decompress, then re-check (could be SQLite or XML inside)
-   *  - XML: reject with a helpful error message
+   *  - XML: parse on main thread and send structured data to worker
+   *
+   * Returns { isXml } so the caller can enforce read-only mode for XML files.
    */
-  async openFile(file: File, writable: boolean = false): Promise<void> {
+  async openFile(file: File, writable: boolean = false): Promise<{ isXml: boolean }> {
     await this.wasmReady;
 
     let buffer = await file.arrayBuffer();
-    buffer = await resolveGnuCashBuffer(buffer);
+    const resolved = await resolveGnuCashBuffer(buffer);
 
-    return new Promise<void>((resolve, reject) => {
-      // Temporarily override message handler to catch the init response
+    if (resolved.type === "xml") {
+      // Parse XML on the main thread (needs DOMParser), send structured data to worker
+      const xmlString = new TextDecoder().decode(resolved.buffer);
+      const xmlData = parseGnuCashXml(xmlString);
+
+      return new Promise<{ isXml: boolean }>((resolve, reject) => {
+        const prevHandler = this.worker.onmessage;
+        this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+          const msg = e.data;
+          if (msg.type === "ready") {
+            this.worker.onmessage = prevHandler;
+            resolve({ isXml: true });
+          } else if (msg.type === "init-error") {
+            this.worker.onmessage = prevHandler;
+            reject(new Error(msg.message));
+          } else {
+            this.handleMessage(msg);
+          }
+        };
+
+        this.send({ type: "init-xml", xmlData });
+      });
+    }
+
+    // SQLite path
+    buffer = resolved.buffer;
+    return new Promise<{ isXml: boolean }>((resolve, reject) => {
       const prevHandler = this.worker.onmessage;
       this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
         const msg = e.data;
         if (msg.type === "ready") {
           this.worker.onmessage = prevHandler;
-          resolve();
+          resolve({ isXml: false });
         } else if (msg.type === "init-error") {
           this.worker.onmessage = prevHandler;
           reject(new Error(msg.message));
         } else {
-          // Delegate other messages to normal handler
           this.handleMessage(msg);
         }
       };
@@ -372,16 +399,20 @@ async function decompressGzip(buffer: ArrayBuffer): Promise<ArrayBuffer> {
   return result.buffer;
 }
 
+type ResolvedBuffer =
+  | { type: "sqlite"; buffer: ArrayBuffer }
+  | { type: "xml"; buffer: ArrayBuffer };
+
 /**
- * Detect the format of a .gnucash file buffer and return a valid SQLite buffer,
- * or throw a descriptive error if the format is unsupported.
+ * Detect the format of a .gnucash file buffer and return a typed result.
+ * Handles SQLite3, gzip-compressed, and XML formats.
  */
-async function resolveGnuCashBuffer(buffer: ArrayBuffer): Promise<ArrayBuffer> {
+async function resolveGnuCashBuffer(buffer: ArrayBuffer): Promise<ResolvedBuffer> {
   let bytes = new Uint8Array(buffer);
 
   // Already a SQLite file — pass through
   if (startsWithMagic(bytes, SQLITE_MAGIC)) {
-    return buffer;
+    return { type: "sqlite", buffer };
   }
 
   // Gzip-compressed — decompress and re-check the inner content
@@ -390,14 +421,11 @@ async function resolveGnuCashBuffer(buffer: ArrayBuffer): Promise<ArrayBuffer> {
     bytes = new Uint8Array(decompressed);
 
     if (startsWithMagic(bytes, SQLITE_MAGIC)) {
-      return decompressed;
+      return { type: "sqlite", buffer: decompressed };
     }
 
     if (looksLikeXml(bytes)) {
-      throw new Error(
-        "This .gnucash file uses gzip-compressed XML format, which is not supported. " +
-        "Please open it in GNUCash and re-save using Edit → Preferences → General → File Format → sqlite3."
-      );
+      return { type: "xml", buffer: decompressed };
     }
 
     throw new Error(
@@ -408,12 +436,9 @@ async function resolveGnuCashBuffer(buffer: ArrayBuffer): Promise<ArrayBuffer> {
 
   // Plain XML
   if (looksLikeXml(bytes)) {
-    throw new Error(
-      "This .gnucash file uses XML format, which is not supported. " +
-      "Please open it in GNUCash and re-save using Edit → Preferences → General → File Format → sqlite3."
-    );
+    return { type: "xml", buffer };
   }
 
   // Unknown format — let SQLite WASM give its own error
-  return buffer;
+  return { type: "sqlite", buffer };
 }

--- a/app/src/lib/gnucash/worker/client.ts
+++ b/app/src/lib/gnucash/worker/client.ts
@@ -132,11 +132,18 @@ export class GnuCashWorkerClient {
   /**
    * Open a .gnucash file by reading it into an ArrayBuffer and sending to the Worker.
    * The Worker persists it to OPFS if available.
+   *
+   * GNUCash files can be SQLite3, XML, or gzip-compressed XML/SQLite.
+   * We detect the format and handle accordingly:
+   *  - SQLite3: pass through
+   *  - Gzip: decompress, then re-check (could be SQLite or XML inside)
+   *  - XML: reject with a helpful error message
    */
   async openFile(file: File, writable: boolean = false): Promise<void> {
     await this.wasmReady;
 
-    const buffer = await file.arrayBuffer();
+    let buffer = await file.arrayBuffer();
+    buffer = await resolveGnuCashBuffer(buffer);
 
     return new Promise<void>((resolve, reject) => {
       // Temporarily override message handler to catch the init response
@@ -320,4 +327,93 @@ export class GnuCashWorkerClient {
     this.send({ type: "close" });
     this.worker.terminate();
   }
+}
+
+// ── File-format detection & decompression ────────────────────────
+
+const SQLITE_MAGIC = [0x53, 0x51, 0x4c, 0x69]; // "SQLi"
+const GZIP_MAGIC = [0x1f, 0x8b];
+
+function startsWithMagic(bytes: Uint8Array, magic: number[]): boolean {
+  if (bytes.length < magic.length) return false;
+  return magic.every((b, i) => bytes[i] === b);
+}
+
+function looksLikeXml(bytes: Uint8Array): boolean {
+  // Check for "<?xm" or "<gnc" — the two common XML .gnucash openings
+  if (bytes.length < 4) return false;
+  const head = new TextDecoder().decode(bytes.slice(0, 256));
+  return head.trimStart().startsWith("<");
+}
+
+async function decompressGzip(buffer: ArrayBuffer): Promise<ArrayBuffer> {
+  const ds = new DecompressionStream("gzip");
+  const writer = ds.writable.getWriter();
+  const reader = ds.readable.getReader();
+
+  writer.write(new Uint8Array(buffer));
+  writer.close();
+
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    chunks.push(value);
+    totalLength += value.byteLength;
+  }
+
+  const result = new Uint8Array(totalLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result.buffer;
+}
+
+/**
+ * Detect the format of a .gnucash file buffer and return a valid SQLite buffer,
+ * or throw a descriptive error if the format is unsupported.
+ */
+async function resolveGnuCashBuffer(buffer: ArrayBuffer): Promise<ArrayBuffer> {
+  let bytes = new Uint8Array(buffer);
+
+  // Already a SQLite file — pass through
+  if (startsWithMagic(bytes, SQLITE_MAGIC)) {
+    return buffer;
+  }
+
+  // Gzip-compressed — decompress and re-check the inner content
+  if (startsWithMagic(bytes, GZIP_MAGIC)) {
+    const decompressed = await decompressGzip(buffer);
+    bytes = new Uint8Array(decompressed);
+
+    if (startsWithMagic(bytes, SQLITE_MAGIC)) {
+      return decompressed;
+    }
+
+    if (looksLikeXml(bytes)) {
+      throw new Error(
+        "This .gnucash file uses gzip-compressed XML format, which is not supported. " +
+        "Please open it in GNUCash and re-save using Edit → Preferences → General → File Format → sqlite3."
+      );
+    }
+
+    throw new Error(
+      "The decompressed .gnucash file is not a recognised format. " +
+      "Please re-save it in GNUCash using the sqlite3 file format."
+    );
+  }
+
+  // Plain XML
+  if (looksLikeXml(bytes)) {
+    throw new Error(
+      "This .gnucash file uses XML format, which is not supported. " +
+      "Please open it in GNUCash and re-save using Edit → Preferences → General → File Format → sqlite3."
+    );
+  }
+
+  // Unknown format — let SQLite WASM give its own error
+  return buffer;
 }

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -28,6 +28,8 @@ import { updateAccount, deleteAccountWithReallocation } from "../engine/operatio
 import { createCommodity } from "../engine/operations/commodity-ops";
 import type { AccountType } from "../engine/types";
 import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload } from "./messages";
+import type { GnuCashXmlData } from "../xml/types";
+import { GNUCASH_SCHEMA_DDL } from "../xml/schema";
 
 let sqlite3: Sqlite3Static;
 let db: WasmDatabase | null = null;
@@ -112,6 +114,109 @@ function initFromOpfs(writable: boolean): void {
     validateSchema(adapter);
     ctx = buildParseContext(adapter);
   }
+}
+
+/**
+ * Creates an in-memory SQLite DB from parsed GNUCash XML data.
+ * Always read-only — no OPFS persistence.
+ */
+function initFromXmlData(data: GnuCashXmlData): void {
+  closeDb();
+  isWritable = false;
+  writableAdapter = null;
+
+  db = new sqlite3.oo1.DB();
+  db.exec({ sql: GNUCASH_SCHEMA_DDL });
+
+  // Books
+  db.exec({
+    sql: `INSERT INTO books (guid, root_account_guid) VALUES (?, ?)`,
+    bind: [data.bookGuid, data.rootAccountGuid],
+  });
+
+  // Commodities
+  for (const c of data.commodities) {
+    db.exec({
+      sql: `INSERT INTO commodities (guid, namespace, mnemonic, fullname, cusip, fraction) VALUES (?, ?, ?, ?, ?, ?)`,
+      bind: [c.guid, c.namespace, c.mnemonic, c.fullname, c.cusip, c.fraction],
+    });
+  }
+
+  // Accounts
+  for (const a of data.accounts) {
+    db.exec({
+      sql: `INSERT INTO accounts (guid, name, account_type, commodity_guid, parent_guid, code, description, hidden, placeholder) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      bind: [a.guid, a.name, a.accountType, a.commodityGuid, a.parentGuid, a.code, a.description, a.hidden, a.placeholder],
+    });
+  }
+
+  // Transactions and splits
+  for (const t of data.transactions) {
+    db.exec({
+      sql: `INSERT INTO transactions (guid, currency_guid, num, post_date, enter_date, description) VALUES (?, ?, ?, ?, ?, ?)`,
+      bind: [t.guid, t.currencyGuid, t.num, t.postDate, t.enterDate, t.description],
+    });
+
+    for (const s of t.splits) {
+      // Parse num/denom from the "num/denom" strings
+      const valSlash = s.value.indexOf("/");
+      const valueNum = valSlash === -1 ? Number(s.value) || 0 : Number(s.value.slice(0, valSlash)) || 0;
+      const valueDenom = valSlash === -1 ? 1 : Number(s.value.slice(valSlash + 1)) || 1;
+
+      const qtySlash = s.quantity.indexOf("/");
+      const quantityNum = qtySlash === -1 ? Number(s.quantity) || 0 : Number(s.quantity.slice(0, qtySlash)) || 0;
+      const quantityDenom = qtySlash === -1 ? 1 : Number(s.quantity.slice(qtySlash + 1)) || 1;
+
+      db.exec({
+        sql: `INSERT INTO splits (guid, tx_guid, account_guid, memo, action, reconcile_state, value_num, value_denom, quantity_num, quantity_denom, lot_guid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        bind: [s.guid, t.guid, s.accountGuid, s.memo, s.action, s.reconcileState, valueNum, valueDenom, quantityNum, quantityDenom, s.lotGuid],
+      });
+    }
+  }
+
+  // Prices
+  for (const p of data.prices) {
+    db.exec({
+      sql: `INSERT INTO prices (guid, commodity_guid, currency_guid, date, source, type, value_num, value_denom) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      bind: [p.guid, p.commodityGuid, p.currencyGuid, p.date, p.source, p.type, p.valueNum, p.valueDenom],
+    });
+  }
+
+  // Scheduled transactions
+  for (const sx of data.schedxactions) {
+    db.exec({
+      sql: `INSERT INTO schedxactions (guid, name, enabled, start_date, end_date, last_occur, num_occur, rem_occur, auto_create) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      bind: [sx.guid, sx.name, sx.enabled, sx.startDate, sx.endDate, sx.lastOccur, sx.numOccur, sx.remOccur, sx.autoCreate],
+    });
+  }
+
+  // Recurrences
+  for (const r of data.recurrences) {
+    db.exec({
+      sql: `INSERT INTO recurrences (obj_guid, recurrence_mult, recurrence_period_type, recurrence_period_start) VALUES (?, ?, ?, ?)`,
+      bind: [r.objGuid, r.mult, r.periodType, r.periodStart],
+    });
+  }
+
+  // Budgets
+  for (const b of data.budgets) {
+    db.exec({
+      sql: `INSERT INTO budgets (guid, name, description, num_periods) VALUES (?, ?, ?, ?)`,
+      bind: [b.guid, b.name, b.description, b.numPeriods],
+    });
+  }
+
+  // Budget amounts
+  for (const ba of data.budgetAmounts) {
+    db.exec({
+      sql: `INSERT INTO budget_amounts (budget_guid, account_guid, period_num, amount_num, amount_denom) VALUES (?, ?, ?, ?, ?)`,
+      bind: [ba.budgetGuid, ba.accountGuid, ba.periodNum, ba.amountNum, ba.amountDenom],
+    });
+  }
+
+  const adapter = createWasmAdapter(db);
+  validateSchema(adapter);
+  ctx = buildParseContext(adapter);
 }
 
 function closeDb(): void {
@@ -366,6 +471,17 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       try {
         await initFromBuffer(msg.fileBuffer, msg.writable ?? false);
         console.log("[db-worker] DB opened from uploaded file via SQLite WASM", isWritable ? "(read-write)" : "(read-only)");
+        post({ type: "ready" });
+      } catch (err) {
+        post({ type: "init-error", message: (err as Error).message });
+      }
+      break;
+    }
+
+    case "init-xml": {
+      try {
+        initFromXmlData(msg.xmlData);
+        console.log("[db-worker] DB created from XML data (read-only)");
         post({ type: "ready" });
       } catch (err) {
         post({ type: "init-error", message: (err as Error).message });

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -16,6 +16,7 @@ import { computeTopBalances } from "../domain/balances";
 import { getLedgerTransactions, getRecentTransactions } from "../domain/ledger";
 import { computeBudgetData } from "../domain/budgets";
 import { getUpcomingBills } from "../domain/bills";
+import { hasClosingTransactions } from "../domain/closing";
 import { formatMonth } from "../shared/dates";
 import { createWritableWasmAdapter } from "../engine/db/writable-wasm-adapter";
 import { TransactionBuilder } from "../engine/builders/transaction-builder";
@@ -214,6 +215,14 @@ function initFromXmlData(data: GnuCashXmlData): void {
     });
   }
 
+  // Book-closing slots
+  for (const txGuid of data.closingTransactionGuids) {
+    db.exec({
+      sql: `INSERT INTO slots (obj_guid, name, slot_type, string_val) VALUES (?, 'book-closing', 4, 'true')`,
+      bind: [txGuid],
+    });
+  }
+
   const adapter = createWasmAdapter(db);
   validateSchema(adapter);
   ctx = buildParseContext(adapter);
@@ -258,6 +267,27 @@ function getFullDashboardData(): DashboardData {
       ? ((currentIncome - currentExpenses) / currentIncome) * 100
       : 0;
 
+  const hasClosing = hasClosingTransactions(ctx);
+
+  // If closing transactions exist, also compute versions with them excluded
+  let cashFlowSeriesExcludingClosing: typeof cashFlowSeries | undefined;
+  let expenseBreakdownExcludingClosing: typeof expenseBreakdown | undefined;
+  let monthlyExpensesByCategoryExcludingClosing: typeof monthlyExpensesByCategory | undefined;
+  let expenseCategoryColorsExcludingClosing: typeof expenseCategoryColors | undefined;
+  let monthlyIncomeByCategoryExcludingClosing: typeof monthlyIncomeByCategory | undefined;
+  let incomeCategoryColorsExcludingClosing: typeof incomeCategoryColors | undefined;
+
+  if (hasClosing) {
+    cashFlowSeriesExcludingClosing = computeCashFlowSeries(ctx, true);
+    const excExpense = computeExpenseBreakdown(ctx, true);
+    expenseBreakdownExcludingClosing = excExpense.categories;
+    monthlyExpensesByCategoryExcludingClosing = excExpense.monthly;
+    expenseCategoryColorsExcludingClosing = excExpense.colors;
+    const excIncome = computeIncomeBreakdown(ctx, true);
+    monthlyIncomeByCategoryExcludingClosing = excIncome.monthly;
+    incomeCategoryColorsExcludingClosing = excIncome.colors;
+  }
+
   const baseCommodity = ctx.commodityMap.get(ctx.baseCurrencyGuid);
 
   return {
@@ -292,6 +322,13 @@ function getFullDashboardData(): DashboardData {
       fullname: c.fullname,
       fraction: c.fraction,
     })),
+    hasClosingTransactions: hasClosing,
+    cashFlowSeriesExcludingClosing,
+    expenseBreakdownExcludingClosing,
+    monthlyExpensesByCategoryExcludingClosing,
+    expenseCategoryColorsExcludingClosing,
+    monthlyIncomeByCategoryExcludingClosing,
+    incomeCategoryColorsExcludingClosing,
   };
 }
 

--- a/app/src/lib/gnucash/worker/messages.ts
+++ b/app/src/lib/gnucash/worker/messages.ts
@@ -3,8 +3,11 @@
  * Messages are at the domain-function level, not raw SQL.
  */
 
+import type { GnuCashXmlData } from "../xml/types";
+
 export type WorkerRequest =
   | { type: "init"; fileBuffer: ArrayBuffer; writable?: boolean }
+  | { type: "init-xml"; xmlData: GnuCashXmlData }
   | { type: "init-opfs"; fileName: string; writable?: boolean }
   | { type: "query"; id: string; fn: DomainFunction }
   | { type: "mutation"; id: string; action: MutationAction; payload: unknown }

--- a/app/src/lib/gnucash/xml/parser.ts
+++ b/app/src/lib/gnucash/xml/parser.ts
@@ -227,6 +227,7 @@ export function parseGnuCashXml(xmlString: string): GnuCashXmlData {
 
   // ── 3. Transactions ─────────────────────────────────────────────
   const transactions: XmlParsedTransaction[] = [];
+  const closingTransactionGuids: string[] = [];
 
   // Only parse transactions directly under gnc:book, skip template-transactions
   const transactionEls = bookEl.getElementsByTagNameNS(NS.gnc, "transaction");
@@ -241,6 +242,18 @@ export function parseGnuCashXml(xmlString: string): GnuCashXmlData {
     if (inTemplate) continue;
 
     const guid = childText(el, NS.trn, "id");
+
+    // Check for book-closing slot
+    const slotsEl = childEl(el, NS.trn, "slots");
+    if (slotsEl) {
+      const slotKeys = slotsEl.getElementsByTagNameNS(NS.slot, "key");
+      for (const keyEl of Array.from(slotKeys)) {
+        if (keyEl.textContent?.trim() === "book-closing") {
+          closingTransactionGuids.push(guid);
+          break;
+        }
+      }
+    }
 
     // Resolve currency
     const currencyEl = childEl(el, NS.trn, "currency");
@@ -443,5 +456,6 @@ export function parseGnuCashXml(xmlString: string): GnuCashXmlData {
     budgetAmounts,
     schedxactions,
     recurrences,
+    closingTransactionGuids,
   };
 }

--- a/app/src/lib/gnucash/xml/parser.ts
+++ b/app/src/lib/gnucash/xml/parser.ts
@@ -248,7 +248,8 @@ export function parseGnuCashXml(xmlString: string): GnuCashXmlData {
     if (slotsEl) {
       const slotKeys = slotsEl.getElementsByTagNameNS(NS.slot, "key");
       for (const keyEl of Array.from(slotKeys)) {
-        if (keyEl.textContent?.trim() === "book-closing") {
+        const slotKey = keyEl.textContent?.trim() ?? "";
+        if (slotKey === "book-closing" || slotKey === "book_closing") {
           closingTransactionGuids.push(guid);
           break;
         }

--- a/app/src/lib/gnucash/xml/parser.ts
+++ b/app/src/lib/gnucash/xml/parser.ts
@@ -1,0 +1,447 @@
+/**
+ * GNUCash XML parser.
+ *
+ * Parses a GNUCash v2 XML file into structured data that can be inserted
+ * into an in-memory SQLite DB matching the GNUCash schema.
+ *
+ * Uses the browser DOMParser API — must run on the main thread.
+ */
+import type { GnuCashXmlData, XmlParsedSplit, XmlParsedTransaction } from "./types";
+import { generateGuid } from "../engine/guid";
+
+// ── GNUCash XML namespace URIs ──────────────────────────────────────
+const NS = {
+  gnc: "http://www.gnucash.org/XML/gnc",
+  act: "http://www.gnucash.org/XML/act",
+  book: "http://www.gnucash.org/XML/book",
+  cmdty: "http://www.gnucash.org/XML/cmdty",
+  price: "http://www.gnucash.org/XML/price",
+  slot: "http://www.gnucash.org/XML/slot",
+  split: "http://www.gnucash.org/XML/split",
+  sx: "http://www.gnucash.org/XML/sx",
+  trn: "http://www.gnucash.org/XML/trn",
+  ts: "http://www.gnucash.org/XML/ts",
+  bgt: "http://www.gnucash.org/XML/bgt",
+  recurrence: "http://www.gnucash.org/XML/recurrence",
+} as const;
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+/** Get text content of the first child element matching ns:localName. */
+function childText(parent: Element, ns: string, localName: string): string {
+  const el = parent.getElementsByTagNameNS(ns, localName)[0];
+  return el?.textContent?.trim() ?? "";
+}
+
+/** Get the first child element matching ns:localName, or null. */
+function childEl(parent: Element, ns: string, localName: string): Element | null {
+  return parent.getElementsByTagNameNS(ns, localName)[0] ?? null;
+}
+
+/** Parse a "num/denom" string → { num, denom }. */
+function parseNumDenom(s: string): { num: number; denom: number } {
+  const slash = s.indexOf("/");
+  if (slash === -1) return { num: Number(s) || 0, denom: 1 };
+  return {
+    num: Number(s.slice(0, slash)) || 0,
+    denom: Number(s.slice(slash + 1)) || 1,
+  };
+}
+
+/**
+ * Normalise a GNUCash XML date string to the format the SQLite schema uses.
+ * Input:  "2025-01-01 10:59:00 +0200" or "2025-01-01 10:59:00 +0000"
+ * Output: "2025-01-01 10:59:00"   (timezone stripped)
+ */
+function normaliseDate(raw: string): string {
+  // Strip timezone suffix (e.g. " +0200")
+  return raw.replace(/\s*[+-]\d{4}$/, "");
+}
+
+/**
+ * Resolve a commodity reference (cmdty:space + cmdty:id pair inside a parent element)
+ * to a GUID from the commodity lookup map.
+ */
+function resolveCommodity(
+  parent: Element,
+  commodityKey: Map<string, string>,
+): string {
+  const space = childText(parent, NS.cmdty, "space");
+  const id = childText(parent, NS.cmdty, "id");
+  const key = `${space}:${id}`;
+  return commodityKey.get(key) ?? "";
+}
+
+/**
+ * Check account slots for placeholder/hidden boolean flags.
+ * Returns { hidden: 0|1, placeholder: 0|1 }.
+ */
+function parseAccountSlots(accountEl: Element): { hidden: number; placeholder: number } {
+  let hidden = 0;
+  let placeholder = 0;
+
+  const slotsEl = childEl(accountEl, NS.act, "slots");
+  if (!slotsEl) return { hidden, placeholder };
+
+  // Slots are direct <slot> children (no namespace)
+  const slotEls = slotsEl.getElementsByTagNameNS(NS.slot, "key");
+  for (const keyEl of Array.from(slotEls)) {
+    const key = keyEl.textContent?.trim() ?? "";
+    const valueEl = keyEl.parentElement?.getElementsByTagNameNS(NS.slot, "value")[0];
+    const value = valueEl?.textContent?.trim() ?? "";
+
+    if (key === "placeholder" && value === "true") placeholder = 1;
+    if (key === "hidden" && value === "true") hidden = 1;
+  }
+
+  return { hidden, placeholder };
+}
+
+// ── Main parser ─────────────────────────────────────────────────────
+
+export function parseGnuCashXml(xmlString: string): GnuCashXmlData {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xmlString, "text/xml");
+
+  // Check for XML parse errors
+  const parseError = doc.querySelector("parsererror");
+  if (parseError) {
+    throw new Error(`XML parse error: ${parseError.textContent}`);
+  }
+
+  // Find the book element
+  const bookEl = doc.getElementsByTagNameNS(NS.gnc, "book")[0];
+  if (!bookEl) {
+    throw new Error("XML parse error: no gnc:book element found");
+  }
+
+  const bookGuid = childText(bookEl, NS.book, "id");
+  if (!bookGuid) {
+    throw new Error("XML parse error: book has no book:id");
+  }
+
+  // ── 1. Commodities ──────────────────────────────────────────────
+  // Build a (space:mnemonic) → GUID lookup map.
+  // XML commodities don't have GUIDs — we generate them.
+  const commodityKey = new Map<string, string>(); // "CURRENCY:USD" → guid
+  const commodities: GnuCashXmlData["commodities"] = [];
+
+  const commodityEls = bookEl.getElementsByTagNameNS(NS.gnc, "commodity");
+  for (const el of Array.from(commodityEls)) {
+    const space = childText(el, NS.cmdty, "space");
+    const mnemonic = childText(el, NS.cmdty, "id");
+    const key = `${space}:${mnemonic}`;
+
+    // Skip duplicates (XML can declare same commodity in multiple places)
+    if (commodityKey.has(key)) continue;
+
+    // Map ISO4217 → CURRENCY to match GNUCash SQLite convention
+    const namespace = space === "ISO4217" ? "CURRENCY" : space;
+
+    const guid = generateGuid();
+    commodityKey.set(key, guid);
+    // Also register with the normalised namespace key
+    if (space === "ISO4217") {
+      commodityKey.set(`CURRENCY:${mnemonic}`, guid);
+    }
+
+    commodities.push({
+      guid,
+      namespace,
+      mnemonic,
+      fullname: childText(el, NS.cmdty, "name") || childText(el, NS.cmdty, "fullname"),
+      cusip: childText(el, NS.cmdty, "xcode") || childText(el, NS.cmdty, "cusip"),
+      fraction: Number(childText(el, NS.cmdty, "fraction")) || 100,
+    });
+  }
+
+  // ── 2. Accounts ─────────────────────────────────────────────────
+  // Only parse accounts inside <gnc:book>, not template-transactions
+  const accounts: GnuCashXmlData["accounts"] = [];
+  let rootAccountGuid = "";
+
+  const accountEls = bookEl.getElementsByTagNameNS(NS.gnc, "account");
+  for (const el of Array.from(accountEls)) {
+    // Skip accounts inside <gnc:template-transactions>
+    if (el.closest("template-transactions")) continue;
+    // Also skip if the parent chain includes a template-transactions element
+    let inTemplate = false;
+    let p: Element | null = el.parentElement;
+    while (p && p !== bookEl) {
+      if (p.localName === "template-transactions") { inTemplate = true; break; }
+      p = p.parentElement;
+    }
+    if (inTemplate) continue;
+
+    const guid = childText(el, NS.act, "id");
+    const accountType = childText(el, NS.act, "type");
+
+    // Resolve the commodity for this account
+    const commodityEl = childEl(el, NS.act, "commodity");
+    let commodityGuid = "";
+    if (commodityEl) {
+      commodityGuid = resolveCommodity(commodityEl, commodityKey);
+      // If commodity wasn't declared, auto-register it
+      if (!commodityGuid) {
+        const space = childText(commodityEl, NS.cmdty, "space");
+        const id = childText(commodityEl, NS.cmdty, "id");
+        const namespace = space === "ISO4217" ? "CURRENCY" : space;
+        const key = `${space}:${id}`;
+        commodityGuid = generateGuid();
+        commodityKey.set(key, commodityGuid);
+        if (space === "ISO4217") commodityKey.set(`CURRENCY:${id}`, commodityGuid);
+        commodities.push({
+          guid: commodityGuid,
+          namespace,
+          mnemonic: id,
+          fullname: "",
+          cusip: "",
+          fraction: Number(childText(el, NS.act, "commodity-scu")) || 100,
+        });
+      }
+    }
+
+    const parentGuid = childText(el, NS.act, "parent") || null;
+    const { hidden, placeholder } = parseAccountSlots(el);
+
+    if (accountType === "ROOT" && !rootAccountGuid) {
+      rootAccountGuid = guid;
+    }
+
+    accounts.push({
+      guid,
+      name: childText(el, NS.act, "name"),
+      accountType,
+      commodityGuid,
+      parentGuid,
+      code: childText(el, NS.act, "code"),
+      description: childText(el, NS.act, "description"),
+      hidden,
+      placeholder,
+    });
+  }
+
+  if (!rootAccountGuid) {
+    throw new Error("XML parse error: no ROOT account found");
+  }
+
+  // ── 3. Transactions ─────────────────────────────────────────────
+  const transactions: XmlParsedTransaction[] = [];
+
+  // Only parse transactions directly under gnc:book, skip template-transactions
+  const transactionEls = bookEl.getElementsByTagNameNS(NS.gnc, "transaction");
+  for (const el of Array.from(transactionEls)) {
+    // Skip template transactions
+    let inTemplate = false;
+    let p: Element | null = el.parentElement;
+    while (p && p !== bookEl) {
+      if (p.localName === "template-transactions") { inTemplate = true; break; }
+      p = p.parentElement;
+    }
+    if (inTemplate) continue;
+
+    const guid = childText(el, NS.trn, "id");
+
+    // Resolve currency
+    const currencyEl = childEl(el, NS.trn, "currency");
+    const currencyGuid = currencyEl ? resolveCommodity(currencyEl, commodityKey) : "";
+
+    // Dates
+    const postDateEl = childEl(el, NS.trn, "date-posted");
+    const postDate = postDateEl ? normaliseDate(childText(postDateEl, NS.ts, "date")) : "";
+    const enterDateEl = childEl(el, NS.trn, "date-entered");
+    const enterDate = enterDateEl ? normaliseDate(childText(enterDateEl, NS.ts, "date")) : "";
+
+    // Splits
+    const splits: XmlParsedSplit[] = [];
+    const splitEls = el.getElementsByTagNameNS(NS.trn, "split");
+    for (const splitEl of Array.from(splitEls)) {
+      splits.push({
+        guid: childText(splitEl, NS.split, "id"),
+        reconcileState: childText(splitEl, NS.split, "reconciled-state") || "n",
+        value: childText(splitEl, NS.split, "value"),
+        quantity: childText(splitEl, NS.split, "quantity"),
+        accountGuid: childText(splitEl, NS.split, "account"),
+        memo: childText(splitEl, NS.split, "memo"),
+        action: childText(splitEl, NS.split, "action"),
+        lotGuid: childText(splitEl, NS.split, "lot") || null,
+      });
+    }
+
+    transactions.push({
+      guid,
+      currencyGuid,
+      num: childText(el, NS.trn, "num"),
+      postDate,
+      enterDate,
+      description: childText(el, NS.trn, "description"),
+      splits,
+    });
+  }
+
+  // ── 4. Prices ───────────────────────────────────────────────────
+  const prices: GnuCashXmlData["prices"] = [];
+
+  // Prices live inside <gnc:pricedb> > <price>
+  const pricedbEl = bookEl.getElementsByTagNameNS(NS.gnc, "pricedb")[0];
+  if (pricedbEl) {
+    // <price> elements are not namespaced
+    const priceEls = pricedbEl.getElementsByTagName("price");
+    for (const el of Array.from(priceEls)) {
+      const commodityEl = childEl(el, NS.price, "commodity");
+      const currencyEl = childEl(el, NS.price, "currency");
+
+      const commodityGuid = commodityEl ? resolveCommodity(commodityEl, commodityKey) : "";
+      const currencyGuid = currencyEl ? resolveCommodity(currencyEl, commodityKey) : "";
+
+      const timeEl = childEl(el, NS.price, "time");
+      const date = timeEl ? normaliseDate(childText(timeEl, NS.ts, "date")) : "";
+
+      const valueStr = childText(el, NS.price, "value");
+      const { num, denom } = parseNumDenom(valueStr);
+
+      prices.push({
+        guid: childText(el, NS.price, "id") || generateGuid(),
+        commodityGuid,
+        currencyGuid,
+        date,
+        source: childText(el, NS.price, "source"),
+        type: childText(el, NS.price, "type"),
+        valueNum: num,
+        valueDenom: denom,
+      });
+    }
+  }
+
+  // ── 5. Scheduled Transactions ───────────────────────────────────
+  const schedxactions: GnuCashXmlData["schedxactions"] = [];
+  const recurrences: GnuCashXmlData["recurrences"] = [];
+
+  const sxEls = bookEl.getElementsByTagNameNS(NS.gnc, "schedxaction");
+  for (const el of Array.from(sxEls)) {
+    const guid = childText(el, NS.sx, "id");
+    const enabled = childText(el, NS.sx, "enabled") === "y" ? 1 : 0;
+    const autoCreate = childText(el, NS.sx, "autoCreate") === "y" ? 1 : 0;
+
+    const startEl = childEl(el, NS.sx, "start");
+    const startDate = startEl ? (startEl.getElementsByTagName("gdate")[0]?.textContent?.trim() ?? "") : "";
+
+    const endEl = childEl(el, NS.sx, "end");
+    const endDate = endEl ? (endEl.getElementsByTagName("gdate")[0]?.textContent?.trim() ?? null) : null;
+
+    const lastEl = childEl(el, NS.sx, "last");
+    const lastOccur = lastEl ? (lastEl.getElementsByTagName("gdate")[0]?.textContent?.trim() ?? null) : null;
+
+    schedxactions.push({
+      guid,
+      name: childText(el, NS.sx, "name"),
+      enabled,
+      startDate,
+      endDate,
+      lastOccur,
+      numOccur: Number(childText(el, NS.sx, "num-occur")) || 0,
+      remOccur: Number(childText(el, NS.sx, "rem-occur")) || 0,
+      autoCreate,
+    });
+
+    // Parse recurrences within this schedxaction
+    const scheduleEl = childEl(el, NS.sx, "schedule");
+    if (scheduleEl) {
+      const recEls = scheduleEl.getElementsByTagNameNS(NS.gnc, "recurrence");
+      for (const recEl of Array.from(recEls)) {
+        const recStartEl = childEl(recEl, NS.recurrence, "start");
+        const recStart = recStartEl
+          ? (recStartEl.getElementsByTagName("gdate")[0]?.textContent?.trim() ?? "")
+          : "";
+
+        recurrences.push({
+          objGuid: guid,
+          mult: Number(childText(recEl, NS.recurrence, "mult")) || 1,
+          periodType: childText(recEl, NS.recurrence, "period_type") || "month",
+          periodStart: recStart,
+        });
+      }
+    }
+  }
+
+  // ── 6. Budgets ──────────────────────────────────────────────────
+  const budgets: GnuCashXmlData["budgets"] = [];
+  const budgetAmounts: GnuCashXmlData["budgetAmounts"] = [];
+
+  const budgetEls = bookEl.getElementsByTagNameNS(NS.gnc, "budget");
+  for (const el of Array.from(budgetEls)) {
+    const budgetGuid = childText(el, NS.bgt, "id");
+    const numPeriods = Number(childText(el, NS.bgt, "num-periods")) || 12;
+
+    budgets.push({
+      guid: budgetGuid,
+      name: childText(el, NS.bgt, "name"),
+      description: childText(el, NS.bgt, "description"),
+      numPeriods,
+    });
+
+    // Budget amounts are stored in bgt:slots as nested KVP:
+    // <bgt:slots>
+    //   <slot>
+    //     <slot:key>{account-guid}</slot:key>
+    //     <slot:value type="frame">
+    //       <slot>
+    //         <slot:key>{period-num}</slot:key>
+    //         <slot:value type="numeric">num/denom</slot:value>
+    //       </slot>
+    //     </slot:value>
+    //   </slot>
+    // </bgt:slots>
+    const bgtSlotsEl = childEl(el, NS.bgt, "slots");
+    if (bgtSlotsEl) {
+      // Top-level slots — each key is an account GUID
+      const topSlots = Array.from(bgtSlotsEl.children).filter(
+        (c) => c.localName === "slot"
+      );
+      for (const accountSlot of topSlots) {
+        const accountGuid = accountSlot.getElementsByTagNameNS(NS.slot, "key")[0]
+          ?.textContent?.trim() ?? "";
+        if (!accountGuid) continue;
+
+        const frameEl = accountSlot.getElementsByTagNameNS(NS.slot, "value")[0];
+        if (!frameEl || frameEl.getAttribute("type") !== "frame") continue;
+
+        // Inner slots — each key is a period number
+        const periodSlots = Array.from(frameEl.children).filter(
+          (c) => c.localName === "slot"
+        );
+        for (const periodSlot of periodSlots) {
+          const periodStr = periodSlot.getElementsByTagNameNS(NS.slot, "key")[0]
+            ?.textContent?.trim() ?? "";
+          const periodNum = Number(periodStr);
+          if (isNaN(periodNum)) continue;
+
+          const amountStr = periodSlot.getElementsByTagNameNS(NS.slot, "value")[0]
+            ?.textContent?.trim() ?? "0/1";
+          const { num, denom } = parseNumDenom(amountStr);
+
+          budgetAmounts.push({
+            budgetGuid,
+            accountGuid,
+            periodNum,
+            amountNum: num,
+            amountDenom: denom,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    bookGuid,
+    rootAccountGuid,
+    commodities,
+    accounts,
+    transactions,
+    prices,
+    budgets,
+    budgetAmounts,
+    schedxactions,
+    recurrences,
+  };
+}

--- a/app/src/lib/gnucash/xml/schema.ts
+++ b/app/src/lib/gnucash/xml/schema.ts
@@ -1,0 +1,104 @@
+/**
+ * GNUCash SQLite schema DDL, extracted from create-fixture.ts.
+ * Used by the XML-to-SQLite bridge to create an in-memory DB
+ * that matches the schema the domain layer expects.
+ */
+export const GNUCASH_SCHEMA_DDL = `
+  CREATE TABLE books (
+    guid TEXT PRIMARY KEY,
+    root_account_guid TEXT NOT NULL,
+    root_template_guid TEXT,
+    num_periods INTEGER DEFAULT 0
+  );
+
+  CREATE TABLE commodities (
+    guid TEXT PRIMARY KEY,
+    namespace TEXT NOT NULL,
+    mnemonic TEXT NOT NULL,
+    fullname TEXT DEFAULT '',
+    cusip TEXT DEFAULT '',
+    fraction INTEGER DEFAULT 100
+  );
+
+  CREATE TABLE accounts (
+    guid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    account_type TEXT NOT NULL,
+    commodity_guid TEXT NOT NULL,
+    parent_guid TEXT,
+    code TEXT DEFAULT '',
+    description TEXT DEFAULT '',
+    hidden INTEGER DEFAULT 0,
+    placeholder INTEGER DEFAULT 0
+  );
+
+  CREATE TABLE transactions (
+    guid TEXT PRIMARY KEY,
+    currency_guid TEXT NOT NULL,
+    num TEXT DEFAULT '',
+    post_date TEXT NOT NULL,
+    enter_date TEXT DEFAULT '',
+    description TEXT DEFAULT ''
+  );
+
+  CREATE TABLE splits (
+    guid TEXT PRIMARY KEY,
+    tx_guid TEXT NOT NULL,
+    account_guid TEXT NOT NULL,
+    memo TEXT DEFAULT '',
+    action TEXT DEFAULT '',
+    reconcile_state TEXT DEFAULT 'n',
+    value_num INTEGER NOT NULL,
+    value_denom INTEGER NOT NULL DEFAULT 100,
+    quantity_num INTEGER NOT NULL,
+    quantity_denom INTEGER NOT NULL DEFAULT 100,
+    lot_guid TEXT
+  );
+
+  CREATE TABLE prices (
+    guid TEXT PRIMARY KEY,
+    commodity_guid TEXT NOT NULL,
+    currency_guid TEXT NOT NULL,
+    date TEXT NOT NULL,
+    source TEXT DEFAULT '',
+    type TEXT DEFAULT '',
+    value_num INTEGER NOT NULL,
+    value_denom INTEGER NOT NULL DEFAULT 100
+  );
+
+  CREATE TABLE schedxactions (
+    guid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    enabled INTEGER DEFAULT 1,
+    start_date TEXT DEFAULT '',
+    end_date TEXT,
+    last_occur TEXT,
+    num_occur INTEGER DEFAULT 0,
+    rem_occur INTEGER DEFAULT 0,
+    auto_create INTEGER DEFAULT 0
+  );
+
+  CREATE TABLE recurrences (
+    id INTEGER PRIMARY KEY,
+    obj_guid TEXT NOT NULL,
+    recurrence_mult INTEGER DEFAULT 1,
+    recurrence_period_type TEXT DEFAULT 'month',
+    recurrence_period_start TEXT DEFAULT ''
+  );
+
+  CREATE TABLE budgets (
+    guid TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    description TEXT DEFAULT '',
+    num_periods INTEGER DEFAULT 12
+  );
+
+  CREATE TABLE budget_amounts (
+    id INTEGER PRIMARY KEY,
+    budget_guid TEXT NOT NULL,
+    account_guid TEXT NOT NULL,
+    period_num INTEGER NOT NULL,
+    amount_num INTEGER NOT NULL,
+    amount_denom INTEGER NOT NULL DEFAULT 100
+  );
+`;

--- a/app/src/lib/gnucash/xml/schema.ts
+++ b/app/src/lib/gnucash/xml/schema.ts
@@ -101,4 +101,19 @@ export const GNUCASH_SCHEMA_DDL = `
     amount_num INTEGER NOT NULL,
     amount_denom INTEGER NOT NULL DEFAULT 100
   );
+
+  CREATE TABLE IF NOT EXISTS slots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    obj_guid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    slot_type INTEGER NOT NULL DEFAULT 4,
+    int64_val INTEGER,
+    string_val TEXT,
+    double_val REAL,
+    timespec_val TEXT,
+    guid_val TEXT,
+    numeric_val_num INTEGER,
+    numeric_val_denom INTEGER,
+    gdate_val TEXT
+  );
 `;

--- a/app/src/lib/gnucash/xml/types.ts
+++ b/app/src/lib/gnucash/xml/types.ts
@@ -1,0 +1,90 @@
+/**
+ * Intermediate types for GNUCash XML data, parsed before insertion into SQLite.
+ * These mirror the SQLite schema columns so insertion is straightforward.
+ */
+
+export interface XmlParsedSplit {
+  guid: string;
+  reconcileState: string;
+  value: string; // "num/denom" string
+  quantity: string; // "num/denom" string
+  accountGuid: string;
+  memo: string;
+  action: string;
+  lotGuid: string | null;
+}
+
+export interface XmlParsedTransaction {
+  guid: string;
+  currencyGuid: string;
+  num: string;
+  postDate: string;
+  enterDate: string;
+  description: string;
+  splits: XmlParsedSplit[];
+}
+
+export interface GnuCashXmlData {
+  bookGuid: string;
+  rootAccountGuid: string;
+  commodities: {
+    guid: string;
+    namespace: string;
+    mnemonic: string;
+    fullname: string;
+    cusip: string;
+    fraction: number;
+  }[];
+  accounts: {
+    guid: string;
+    name: string;
+    accountType: string;
+    commodityGuid: string;
+    parentGuid: string | null;
+    code: string;
+    description: string;
+    hidden: number;
+    placeholder: number;
+  }[];
+  transactions: XmlParsedTransaction[];
+  prices: {
+    guid: string;
+    commodityGuid: string;
+    currencyGuid: string;
+    date: string;
+    source: string;
+    type: string;
+    valueNum: number;
+    valueDenom: number;
+  }[];
+  budgets: {
+    guid: string;
+    name: string;
+    description: string;
+    numPeriods: number;
+  }[];
+  budgetAmounts: {
+    budgetGuid: string;
+    accountGuid: string;
+    periodNum: number;
+    amountNum: number;
+    amountDenom: number;
+  }[];
+  schedxactions: {
+    guid: string;
+    name: string;
+    enabled: number;
+    startDate: string;
+    endDate: string | null;
+    lastOccur: string | null;
+    numOccur: number;
+    remOccur: number;
+    autoCreate: number;
+  }[];
+  recurrences: {
+    objGuid: string;
+    mult: number;
+    periodType: string;
+    periodStart: string;
+  }[];
+}

--- a/app/src/lib/gnucash/xml/types.ts
+++ b/app/src/lib/gnucash/xml/types.ts
@@ -87,4 +87,6 @@ export interface GnuCashXmlData {
     periodType: string;
     periodStart: string;
   }[];
+  /** Transaction GUIDs that have a book-closing slot. */
+  closingTransactionGuids: string[];
 }

--- a/app/src/lib/period-utils.ts
+++ b/app/src/lib/period-utils.ts
@@ -1,7 +1,7 @@
-/** Represents a user-defined custom date range in YYYY-MM format. */
+/** Represents a user-defined custom date range in YYYY-MM-DD format. */
 export interface CustomRange {
-  start: string; // "YYYY-MM"
-  end: string;   // "YYYY-MM"
+  start: string; // "YYYY-MM-DD"
+  end: string;   // "YYYY-MM-DD"
 }
 
 /** Generate all YYYY-MM strings from start to end inclusive. */
@@ -55,4 +55,38 @@ export function formatMonth(month: string): string {
 /** Validate a YYYY-MM string. */
 export function isValidMonth(value: string): boolean {
   return /^\d{4}-(?:0[1-9]|1[0-2])$/.test(value);
+}
+
+/** Extract YYYY-MM from a YYYY-MM-DD date string. */
+export function dateToMonth(date: string): string {
+  return date.slice(0, 7);
+}
+
+/** Convert YYYY-MM to YYYY-MM-01. */
+export function monthToFirstDay(month: string): string {
+  return `${month}-01`;
+}
+
+/** Convert YYYY-MM to the last day of that month. */
+export function monthToLastDay(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  const lastDay = new Date(y, m, 0).getDate();
+  return `${month}-${String(lastDay).padStart(2, "0")}`;
+}
+
+/** Format YYYY-MM-DD as "Jan 6, 2024" for display. */
+export function formatDate(date: string): string {
+  const [y, m, d] = date.split("-");
+  const names = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${names[parseInt(m) - 1]} ${parseInt(d)}, ${y}`;
+}
+
+/** Validate a YYYY-MM-DD string. */
+export function isValidDate(value: string): boolean {
+  return /^\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01])$/.test(value);
+}
+
+/** Get all months (YYYY-MM) that overlap a YYYY-MM-DD date range. */
+export function getMonthsForDateRange(start: string, end: string): string[] {
+  return getMonthsBetween(dateToMonth(start), dateToMonth(end));
 }

--- a/app/src/lib/sankey-utils.ts
+++ b/app/src/lib/sankey-utils.ts
@@ -1,6 +1,6 @@
 import type { MonthlyExpenseByCategory, MonthlyCashFlow } from "@/lib/types/gnucash";
 import { formatCurrencyShort } from "@/lib/format";
-import type { CustomRange } from "@/lib/period-utils";
+import { type CustomRange, dateToMonth } from "@/lib/period-utils";
 
 // ── Library-agnostic intermediate format ──────────────────────────────
 
@@ -72,7 +72,7 @@ function getMonthsForPeriod(
     case "custom":
       if (!customRange) return new Set();
       slice = cashFlowSeries.filter(
-        (s) => s.month >= customRange.start && s.month <= customRange.end,
+        (s) => s.month >= dateToMonth(customRange.start) && s.month <= dateToMonth(customRange.end),
       );
       break;
   }

--- a/app/src/lib/spending-utils.ts
+++ b/app/src/lib/spending-utils.ts
@@ -1,4 +1,4 @@
-import { type CustomRange, getMonthsBetween } from "@/lib/period-utils";
+import { type CustomRange, getMonthsForDateRange } from "@/lib/period-utils";
 
 export type TimePeriod = "this-month" | "last-month" | "last-6m" | "this-year" | "last-12m" | "custom";
 
@@ -47,6 +47,6 @@ export function getMonthsForPeriod(period: TimePeriod, customRange?: CustomRange
       return months;
     }
     case "custom":
-      return customRange ? getMonthsBetween(customRange.start, customRange.end) : [];
+      return customRange ? getMonthsForDateRange(customRange.start, customRange.end) : [];
   }
 }

--- a/app/src/lib/types/gnucash.ts
+++ b/app/src/lib/types/gnucash.ts
@@ -275,4 +275,17 @@ export interface DashboardData {
   budgetData: BudgetData | null;
   ledgerTransactions: LedgerTransaction[];
   commodities: CommodityInfo[];
+  hasClosingTransactions: boolean;
+  /** Cash flow series with closing transactions excluded (only present when hasClosingTransactions is true). */
+  cashFlowSeriesExcludingClosing?: MonthlyCashFlow[];
+  /** Monthly expenses by category with closing transactions excluded. */
+  monthlyExpensesByCategoryExcludingClosing?: MonthlyExpenseByCategory[];
+  /** Expense categories with closing transactions excluded. */
+  expenseBreakdownExcludingClosing?: ExpenseCategory[];
+  /** Expense category colors with closing transactions excluded. */
+  expenseCategoryColorsExcludingClosing?: Record<string, string>;
+  /** Monthly income by category with closing transactions excluded. */
+  monthlyIncomeByCategoryExcludingClosing?: MonthlyExpenseByCategory[];
+  /** Income category colors with closing transactions excluded. */
+  incomeCategoryColorsExcludingClosing?: Record<string, string>;
 }


### PR DESCRIPTION
## Summary
- Detects `.gnucash` file format (SQLite3, XML, or gzip-compressed) before passing to SQLite WASM
- Transparently decompresses gzip-compressed SQLite files so they load correctly
- Parses XML-based `.gnucash` files into an in-memory SQLite DB (read-only)
- Adds day-level granularity to custom date range selection with calendar date picker
- Detects and excludes GNUCash book-closing transactions from Cash Flow and Sankey charts (toggle only appears when closing transactions are present)
- Parses `book-closing` transaction slots from XML imports
- Replaces Sankey depth slider with +/- buttons
- Removes Sankey link colour mode toggle (always uses source colour)
- Changes Sankey zoom from ctrl+scroll to plain scroll over chart area

Fixes #23

## Test plan
- [ ] Upload a SQLite3 `.gnucash` file — should load as before
- [ ] Upload a gzip-compressed SQLite `.gnucash` file — should decompress and load
- [ ] Upload an XML `.gnucash` file — should parse and display dashboard
- [ ] Custom date range — click date text to open calendar, select specific days
- [ ] Upload a file with closed books — "Exclude closing" toggle should appear on Cash Flow and Sankey charts
- [ ] Toggle excludes closing transactions — Sankey should show actual income/expense flows
- [ ] Sankey depth +/- buttons work (range 1–6)
- [ ] Scroll over Sankey chart to zoom in/out
- [ ] Demo data still works