### PR TITLE
Show decimal places on all currency values

### DIFF
--- a/app/src/components/dashboard/charts/balance-pie.tsx
+++ b/app/src/components/dashboard/charts/balance-pie.tsx
@@ -123,7 +123,7 @@ export function BalancePie({
             <div className="flex shrink-0 flex-col items-center sm:w-[220px]">
               <div className="mb-2 text-center">
                 <span className="text-2xl font-bold text-[#1A1D1F]" data-v>
-                  {formatCurrency(activeTotal, currency, { decimals: 0 })}
+                  {formatCurrency(activeTotal, currency)}
                 </span>
                 <p className="text-[11px] text-[#9A9FA5]">Total</p>
               </div>

--- a/app/src/components/dashboard/charts/income-overview.tsx
+++ b/app/src/components/dashboard/charts/income-overview.tsx
@@ -222,7 +222,7 @@ export function IncomeOverview({ monthlyIncome, categoryColors, currency, linkTo
               )}
               <div className="mb-2 text-center">
                 <span className="text-2xl font-bold text-[#1A1D1F]" data-v>
-                  {formatCurrency(activeTotal, currency, { decimals: 0 })}
+                  {formatCurrency(activeTotal, currency)}
                 </span>
                 <p className="text-[11px] text-[#9A9FA5]" data-l>
                   {drillPath ? drillPath.split(":").slice(-1)[0] : "Total income"}

--- a/app/src/components/dashboard/charts/investment-performance.tsx
+++ b/app/src/components/dashboard/charts/investment-performance.tsx
@@ -89,19 +89,19 @@ export function InvestmentPerformance({ investments, currency }: InvestmentPerfo
           <div>
             <p className="text-xs text-[#9A9FA5]">Market Value</p>
             <p className="text-2xl font-bold tracking-tight text-[#1A1D1F]" data-v>
-              {formatCurrency(totalMarketValue, currency, { decimals: 0 })}
+              {formatCurrency(totalMarketValue, currency)}
             </p>
           </div>
           <div>
             <p className="text-xs text-[#9A9FA5]">Cost Basis</p>
             <p className="text-2xl font-bold tracking-tight text-[#6F767E]" data-v>
-              {formatCurrency(totalCostBasis, currency, { decimals: 0 })}
+              {formatCurrency(totalCostBasis, currency)}
             </p>
           </div>
           <div>
             <p className="text-xs text-[#9A9FA5]">Gain / Loss</p>
             <p className={`text-2xl font-bold tracking-tight ${totalGainLoss >= 0 ? "text-[#6C9B8B]" : "text-[#F87171]"}`} data-v>
-              {totalGainLoss >= 0 ? "+" : ""}{formatCurrency(totalGainLoss, currency, { decimals: 0 })}
+              {totalGainLoss >= 0 ? "+" : ""}{formatCurrency(totalGainLoss, currency)}
             </p>
           </div>
         </div>

--- a/app/src/components/dashboard/charts/net-worth-chart.tsx
+++ b/app/src/components/dashboard/charts/net-worth-chart.tsx
@@ -169,7 +169,7 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
       <CardContent>
         <div className="mb-1">
           <span className="text-3xl font-bold tracking-tight text-[#1A1D1F]" data-v>
-            {formatCurrency(currentNetWorth, currency, { decimals: 0 })}
+            {formatCurrency(currentNetWorth, currency)}
           </span>
         </div>
         {pctChange !== null && (
@@ -239,19 +239,19 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
                           <span className="flex items-center gap-1.5 text-[#3B6B8A]">
                             <span className="inline-block h-2 w-2 rounded-full bg-[#3B6B8A]" />Assets
                           </span>
-                          <span className="font-medium text-[#1A1D1F]">{formatCurrency(data.assets, currency, { decimals: 0 })}</span>
+                          <span className="font-medium text-[#1A1D1F]">{formatCurrency(data.assets, currency)}</span>
                         </div>
                         <div className="flex items-center justify-between gap-4">
                           <span className="flex items-center gap-1.5 text-[#F87171]">
                             <span className="inline-block h-2 w-2 rounded-full bg-[#F87171]" />Liabilities
                           </span>
-                          <span className="font-medium text-[#1A1D1F]">{formatCurrency(data.liabilities, currency, { decimals: 0 })}</span>
+                          <span className="font-medium text-[#1A1D1F]">{formatCurrency(data.liabilities, currency)}</span>
                         </div>
                         <div className="mt-0.5 flex items-center justify-between gap-4 border-t border-[#EFEFEF] pt-1">
                           <span className="flex items-center gap-1.5 text-[#6C9B8B]">
                             <span className="inline-block h-2 w-2 rounded-full bg-[#6C9B8B]" />Net Worth
                           </span>
-                          <span className="font-semibold text-[#1A1D1F]">{formatCurrency(data.netWorth, currency, { decimals: 0 })}</span>
+                          <span className="font-semibold text-[#1A1D1F]">{formatCurrency(data.netWorth, currency)}</span>
                         </div>
                       </div>
                     </div>

--- a/app/src/components/dashboard/charts/spending-overview.tsx
+++ b/app/src/components/dashboard/charts/spending-overview.tsx
@@ -307,7 +307,7 @@ export function SpendingOverview({ monthlyExpenses, categoryColors, currency, li
               )}
               <div className="mb-2 text-center">
                 <span className="text-2xl font-bold text-[#1A1D1F]" data-v>
-                  {formatCurrency(activeTotal, currency, { decimals: 0 })}
+                  {formatCurrency(activeTotal, currency)}
                 </span>
                 <p className="text-[11px] text-[#9A9FA5]" data-l>
                   {drillPath ? drillPath.split(":").slice(-1)[0] : "Total spending"}

--- a/app/src/components/dashboard/charts/top-balances.tsx
+++ b/app/src/components/dashboard/charts/top-balances.tsx
@@ -45,14 +45,14 @@ export function TopBalances({ balances, currency, filterType }: TopBalancesProps
           <div>
             <span className="text-xs text-[#9A9FA5]">Assets </span>
             <span className="text-sm font-semibold text-[#6C9B8B]" data-v>
-              {formatCurrency(totalAssets, currency, { decimals: 0 })}
+              {formatCurrency(totalAssets, currency)}
             </span>
           </div>
           {totalLiabilities !== 0 && (
             <div>
               <span className="text-xs text-[#9A9FA5]">Liabilities </span>
               <span className="text-sm font-semibold text-[#F87171]" data-v>
-                {formatCurrency(Math.abs(totalLiabilities), currency, { decimals: 0 })}
+                {formatCurrency(Math.abs(totalLiabilities), currency)}
               </span>
             </div>
           )}

--- a/app/src/components/investment/allocation-pie.tsx
+++ b/app/src/components/investment/allocation-pie.tsx
@@ -99,7 +99,7 @@ export function AllocationPie({ items, currency, selectedTicker, onSelect, group
             <div className="flex shrink-0 flex-col items-center sm:w-[200px]">
               <div className="mb-2 text-center">
                 <span className="text-2xl font-bold text-[#1A1D1F]" data-v>
-                  {formatCurrency(totalValue, currency, { decimals: 0 })}
+                  {formatCurrency(totalValue, currency)}
                 </span>
                 <p className="text-[11px] text-[#9A9FA5]">Total value</p>
               </div>
@@ -174,7 +174,7 @@ export function AllocationPie({ items, currency, selectedTicker, onSelect, group
                     </div>
                     <div className="flex shrink-0 items-center gap-2">
                       <span className="text-xs font-medium text-[#1A1D1F]" data-v>
-                        {formatCurrency(entry.value, currency, { decimals: 0 })}
+                        {formatCurrency(entry.value, currency)}
                       </span>
                       <span className="w-[36px] text-right text-[11px] text-[#9A9FA5]" data-v>
                         {pct}%

--- a/app/src/components/investment/portfolio-summary.tsx
+++ b/app/src/components/investment/portfolio-summary.tsx
@@ -22,11 +22,11 @@ export function PortfolioSummary({ holdings, currency }: PortfolioSummaryProps) 
   }, [holdings]);
 
   const cards = [
-    { label: "Market Value", value: formatCurrency(stats.totalMarketValue, currency, { decimals: 0 }) },
-    { label: "Cost Basis", value: formatCurrency(stats.totalCostBasis, currency, { decimals: 0 }) },
+    { label: "Market Value", value: formatCurrency(stats.totalMarketValue, currency) },
+    { label: "Cost Basis", value: formatCurrency(stats.totalCostBasis, currency) },
     {
       label: "Total Gain/Loss",
-      value: formatCurrency(stats.totalGainLoss, currency, { decimals: 0 }),
+      value: formatCurrency(stats.totalGainLoss, currency),
       color: stats.totalGainLoss >= 0 ? "#6C9B8B" : "#F87171",
     },
     {

--- a/app/src/components/spending/monthly-expense-bar-card.tsx
+++ b/app/src/components/spending/monthly-expense-bar-card.tsx
@@ -161,7 +161,7 @@ export function MonthlyExpenseBarCard({
                     strokeDasharray="6 4"
                     strokeWidth={1.5}
                     label={{
-                      value: `Avg: ${formatCurrency(average, currency, { decimals: 0 })}`,
+                      value: `Avg: ${formatCurrency(average, currency)}`,
                       position: "right",
                       fill: barColor,
                       fontSize: 11,

--- a/app/src/components/spending/spending-pie-card.tsx
+++ b/app/src/components/spending/spending-pie-card.tsx
@@ -169,7 +169,7 @@ export function SpendingPieCard({ monthlyExpenses, categoryColors, currency, tit
               )}
               <div className="mb-2 text-center">
                 <span className="text-2xl font-bold text-[#1A1D1F]" data-v>
-                  {formatCurrency(showAverage ? activeTotal / monthCount : activeTotal, currency, { decimals: 0 })}
+                  {formatCurrency(showAverage ? activeTotal / monthCount : activeTotal, currency)}
                 </span>
                 <p className="text-[11px] text-[#9A9FA5]" data-l>
                   {showAverage ? "Monthly average" : selectedCategory ? selectedCategory.split(":").slice(-1)[0] : `Total ${title.toLowerCase().replace("breakdown", "").trim()}`}


### PR DESCRIPTION
## Summary
- Removes `{ decimals: 0 }` from all `formatCurrency()` calls across 10 components, so all currency values now display with 2 decimal places (e.g. £1,234.56 instead of £1,234)
- Chart axis tick labels remain compact/abbreviated as before

Closes #25
## Test plan
- [ ] Verify all dashboard charts (net worth, cash flow, balance pie, income overview, top balances, spending overview) show pennies/cents
- [ ] Verify investment pages (portfolio summary, allocation pie, investment performance) show decimal places
- [ ] Verify spending pages (monthly expense bar, spending pie) show decimal places
- [ ] Verify chart tooltips display with 2 decimal places