### PR TITLE
Rename Cash Flow card to Net Income

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# Project Instructions
+
+## Deployment
+
+When asked to deploy to Cloudflare with wrangler:
+
+1. Checkout `main` and pull latest: `git checkout main && git pull`
+2. Build the app: `cd app && npm run build`
+3. Deploy to Cloudflare Pages using the `dev` production branch:
+   ```
+   npx wrangler pages deploy ./out --project-name=gnudash --branch=dev
+   ```
+
+The production branch in Cloudflare Pages is configured as `dev` (not `main`). Using `--branch=dev` ensures the deployment goes to **production** rather than preview.
+
+## Upcoming Features
+
+### Dedicated Cash Flow Page
+Build a dedicated cash flow page that shows true cash flow — net inflows and outflows of cash accounts (BANK, CASH type accounts), tracked against their budgets. This is distinct from the current "Net Income" card on the dashboard which shows income minus expenses.

--- a/app/src/app/(dashboard)/page.tsx
+++ b/app/src/app/(dashboard)/page.tsx
@@ -75,7 +75,7 @@ export default function DashboardPage() {
         />
       </div>
 
-      {/* Row 3: Cash Flow */}
+      {/* Row 3: Net Income */}
       <CashFlowChart
         series={data.cashFlowSeries}
         currentIncome={data.currentMonthIncome}

--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -89,9 +89,12 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
   return (
     <Card className="shadow-sm border-[#EFEFEF] h-full">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-lg font-semibold text-[#1A1D1F]">
-          Net Income
-        </CardTitle>
+        <div>
+          <CardTitle className="text-lg font-semibold text-[#1A1D1F]">
+            Income / Expense Flow
+          </CardTitle>
+          <p className="text-xs text-[#9A9FA5]">Net income</p>
+        </div>
         <div className="flex items-center gap-3">
           {seriesExcludingClosing && (
             <ExcludeClosingToggle checked={excludeClosing} onChange={setExcludeClosing} />
@@ -122,7 +125,6 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
           <span className="text-3xl font-bold tracking-tight text-[#1A1D1F]" data-v>
             {formatCurrency(totalNet, currency)}
           </span>
-          <p className="mt-0.5 text-xs text-[#9A9FA5]">Net income</p>
         </div>
 
         <div className="mb-4 flex items-center gap-5">

--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -90,7 +90,7 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
     <Card className="shadow-sm border-[#EFEFEF] h-full">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
         <CardTitle className="text-lg font-semibold text-[#1A1D1F]">
-          Cash Flow
+          Net Income
         </CardTitle>
         <div className="flex items-center gap-3">
           {seriesExcludingClosing && (
@@ -122,7 +122,7 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
           <span className="text-3xl font-bold tracking-tight text-[#1A1D1F]" data-v>
             {formatCurrency(totalNet, currency)}
           </span>
-          <p className="mt-0.5 text-xs text-[#9A9FA5]">Net cash flow</p>
+          <p className="mt-0.5 text-xs text-[#9A9FA5]">Net income</p>
         </div>
 
         <div className="mb-4 flex items-center gap-5">


### PR DESCRIPTION
## Summary
- Renames the "Cash Flow" dashboard card to "Net Income" to better reflect what it shows (income minus expenses)
- Adds documentation in CLAUDE.md for an upcoming dedicated Cash Flow page that will track true cash inflows/outflows of cash accounts against budgets

## Test plan
- [ ] Verify the dashboard card title now reads "Net Income"
- [ ] Verify the subtitle reads "Net income"