### PR TITLE
Fix spending bar chart filter and add comprehensive documentation

### DIFF
--- a/app/src/components/spending/monthly-expense-bar-card.tsx
+++ b/app/src/components/spending/monthly-expense-bar-card.tsx
@@ -35,7 +35,7 @@ export function MonthlyExpenseBarCard({
   selectedBarColor = "#4A7A6B",
   fadedBarColor = "#D5F0E4",
 }: MonthlyExpenseBarCardProps) {
-  const { period, customRange, selectedCategory, excluded, selectedMonth, setSelectedMonth } = useSpendingFilter();
+  const { period, customRange, selectedCategory, selectedAccount, excluded, selectedMonth, setSelectedMonth } = useSpendingFilter();
 
   const handleBarClick = useCallback((data: { month: string }) => {
     // Toggle: click same month again to deselect
@@ -59,6 +59,12 @@ export function MonthlyExpenseBarCard({
     for (const row of monthlyExpenses) {
       if (!validSet.has(row.month)) continue;
       if (!row.pathParts) continue;
+
+      // Apply leaf account filter
+      if (selectedAccount) {
+        const rowPath = row.pathParts.join(":");
+        if (rowPath !== selectedAccount && !rowPath.startsWith(selectedAccount + ":")) continue;
+      }
 
       // Apply category filter
       if (selectedCategory) {
@@ -93,7 +99,7 @@ export function MonthlyExpenseBarCard({
         amount: totals.get(month) ?? 0,
       };
     });
-  }, [monthlyExpenses, period, customRange, selectedCategory, excluded]);
+  }, [monthlyExpenses, period, customRange, selectedCategory, selectedAccount, excluded]);
 
   const maxAmount = useMemo(
     () => Math.max(...barData.map((d) => d.amount), 0),
@@ -111,9 +117,9 @@ export function MonthlyExpenseBarCard({
       <CardHeader className="pb-2">
         <CardTitle className="text-lg font-semibold text-[#1A1D1F]">
           {title}
-          {selectedCategory && (
+          {(selectedAccount || selectedCategory) && (
             <span className="ml-2 text-sm font-normal" style={{ color: barColor }} data-l>
-              {selectedCategory.split(":").slice(-1)[0]}
+              {(selectedAccount ?? selectedCategory)!.split(":").slice(-1)[0]}
             </span>
           )}
         </CardTitle>

--- a/app/src/lib/gnucash/domain/accounts.ts
+++ b/app/src/lib/gnucash/domain/accounts.ts
@@ -2,6 +2,12 @@ import type { AccountNode } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { buildFullPath } from "../shared/accounts";
 
+/**
+ * Build a hierarchical account tree from the flat accounts table.
+ * Each node includes a balance in base currency (own splits + all descendants).
+ * Investment accounts (STOCK/MUTUAL) are valued at latest market price.
+ * Foreign currency accounts are converted via FX rates.
+ */
 export function buildAccountTree(ctx: ParseContext): AccountNode[] {
   const { db, accounts, accountMap, commodityMap, baseCurrencyGuid, fxRates, latestPrices, rootAccount } = ctx;
 

--- a/app/src/lib/gnucash/domain/balances.ts
+++ b/app/src/lib/gnucash/domain/balances.ts
@@ -2,6 +2,12 @@ import type { TopBalance } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { buildFullPath } from "../shared/accounts";
 
+/**
+ * Compute current balances for all non-placeholder accounts, converted to base currency.
+ * Investment accounts (STOCK/MUTUAL) are valued at their latest market price.
+ * Foreign currency accounts are converted via FX rates.
+ * Results are sorted: positive balances first (by descending value), then negative.
+ */
 export function computeTopBalances(ctx: ParseContext): TopBalance[] {
   const { db, accountMap, commodityMap, baseCurrencyGuid, fxRates, latestPrices } = ctx;
 

--- a/app/src/lib/gnucash/domain/bills.ts
+++ b/app/src/lib/gnucash/domain/bills.ts
@@ -2,6 +2,12 @@ import type { UpcomingBill } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { parseGnuCashDate } from "../shared/dates";
 
+/**
+ * Get upcoming scheduled transactions (bills) from the GNUCash schedxactions table.
+ * Estimates the next occurrence date from the recurrence rules and extracts
+ * the expected amount from the template transaction splits.
+ * Returns an empty array if the schedxactions table doesn't exist.
+ */
 export function getUpcomingBills(ctx: ParseContext): UpcomingBill[] {
   const { db } = ctx;
 

--- a/app/src/lib/gnucash/domain/budgets.ts
+++ b/app/src/lib/gnucash/domain/budgets.ts
@@ -2,6 +2,19 @@ import type { BudgetData, BudgetDataForBudget, BudgetInfo, BudgetCategoryRow } f
 import type { ParseContext } from "../context";
 import { sqlYear, sqlMonthNum } from "../shared/dates";
 
+/**
+ * Compute budget vs actual data for all budgets in the GNUCash file.
+ * Queries the budgets and budget_amounts tables, then computes actual
+ * spending/income from EXPENSE and INCOME account splits.
+ *
+ * Builds a hierarchical category tree where:
+ * - Accounts with explicit budget entries are included directly
+ * - Ancestor accounts are synthesised when children are budgeted but parents aren't
+ * - "Unbudgeted" rows are generated for the gap between parent and child budgets
+ * - Imbalance detection flags when a parent's budget doesn't match its children's total
+ *
+ * Returns null if no budgets table exists or no budgets are defined.
+ */
 export function computeBudgetData(ctx: ParseContext): BudgetData | null {
   const { db, accounts, accountMap, rootAccount, topExpenseGuids, topIncomeGuids } = ctx;
 

--- a/app/src/lib/gnucash/domain/cash-flow.ts
+++ b/app/src/lib/gnucash/domain/cash-flow.ts
@@ -3,6 +3,14 @@ import type { ParseContext } from "../context";
 import { sqlMonth } from "../shared/dates";
 import { EXCLUDE_CLOSING_JOIN, EXCLUDE_CLOSING_WHERE } from "./closing";
 
+/**
+ * Compute monthly income vs expense totals from INCOME and EXPENSE account splits.
+ * Income splits are negated (GNUCash stores them as negative values).
+ * Note: this is income/expense flow, not true cash flow — it does not track
+ * movements through bank accounts or include liability/asset transfers.
+ *
+ * @param excludeClosing - If true, exclude year-end book-closing transactions.
+ */
 export function computeCashFlowSeries(ctx: ParseContext, excludeClosing = false): MonthlyCashFlow[] {
   const closingJoin = excludeClosing ? EXCLUDE_CLOSING_JOIN : "";
   const closingWhere = excludeClosing ? `AND ${EXCLUDE_CLOSING_WHERE}` : "";

--- a/app/src/lib/gnucash/domain/expenses.ts
+++ b/app/src/lib/gnucash/domain/expenses.ts
@@ -4,6 +4,18 @@ import { getAccountPath } from "../shared/accounts";
 import { parseGnuCashDate, formatISODate, sqlMonth } from "../shared/dates";
 import { EXCLUDE_CLOSING_JOIN, EXCLUDE_CLOSING_WHERE } from "./closing";
 
+/**
+ * Compute expense breakdown from EXPENSE account splits.
+ * Returns three outputs:
+ * - `categories`: hierarchical tree for nested pie charts
+ * - `monthly`: flat rows per leaf account per month (used for drill-down pie/bar charts)
+ * - `colors`: stable colour map keyed by top-level expense category name
+ *
+ * Uses quantity (native commodity) with FX conversion, not value, for accurate
+ * multi-currency support. Amounts are always positive.
+ *
+ * @param excludeClosing - If true, exclude year-end book-closing transactions.
+ */
 export function computeExpenseBreakdown(
   ctx: ParseContext,
   excludeClosing = false,
@@ -65,6 +77,11 @@ export function computeExpenseBreakdown(
   return { categories, monthly, colors: colorMap };
 }
 
+/**
+ * Get all individual expense transactions for the expense table view.
+ * Each row represents one split on an EXPENSE account, with the full
+ * category path and amount in base currency.
+ */
 export function getExpenseTransactions(ctx: ParseContext): ExpenseTransaction[] {
   const { db, accountMap, rootAccount, topExpenseGuids } = ctx;
 

--- a/app/src/lib/gnucash/domain/fx.ts
+++ b/app/src/lib/gnucash/domain/fx.ts
@@ -7,6 +7,12 @@ export interface FxRateMap {
   rate(commodityGuid: string): number;
 }
 
+/**
+ * Build a foreign exchange rate lookup from the prices table.
+ * Uses the most recent price for each currency pair, supporting both
+ * direct rates (commodity → base) and inverse rates (base → commodity).
+ * Returns an FxRateMap with `toBase()` and `rate()` methods.
+ */
 export function buildFxRateMap(
   db: DbAdapter,
   baseCurrencyGuid: string

--- a/app/src/lib/gnucash/domain/income.ts
+++ b/app/src/lib/gnucash/domain/income.ts
@@ -4,6 +4,14 @@ import { getAccountPath } from "../shared/accounts";
 import { parseGnuCashDate, formatISODate, sqlMonth } from "../shared/dates";
 import { EXCLUDE_CLOSING_JOIN, EXCLUDE_CLOSING_WHERE } from "./closing";
 
+/**
+ * Compute income breakdown from INCOME account splits.
+ * Returns flat monthly rows per leaf account (for drill-down charts) and
+ * a stable colour map keyed by top-level income category name.
+ * Amounts are negated to positive (GNUCash stores income as negative values).
+ *
+ * @param excludeClosing - If true, exclude year-end book-closing transactions.
+ */
 export function computeIncomeBreakdown(
   ctx: ParseContext,
   excludeClosing = false,
@@ -56,6 +64,10 @@ export function computeIncomeBreakdown(
   return { monthly, colors: colorMap };
 }
 
+/**
+ * Get all individual income transactions for the income table view.
+ * Amounts are negated to positive (GNUCash stores income as negative values).
+ */
 export function getIncomeTransactions(ctx: ParseContext): ExpenseTransaction[] {
   const { db, accountMap, rootAccount, topIncomeGuids } = ctx;
 

--- a/app/src/lib/gnucash/domain/investments.ts
+++ b/app/src/lib/gnucash/domain/investments.ts
@@ -2,6 +2,11 @@ import type { InvestmentHolding, MonthlyInvestmentValue } from "@/lib/types/gnuc
 import type { ParseContext } from "../context";
 import { parseGnuCashDate, sqlMonth } from "../shared/dates";
 
+/**
+ * Compute current investment holdings for all STOCK and MUTUAL accounts.
+ * Calculates cost basis (sum of buy-side split values), market value
+ * (shares × latest price), gain/loss, and 12-month performance.
+ */
 export function computeInvestments(ctx: ParseContext): InvestmentHolding[] {
   const { db, commodityMap, prices, latestPrices } = ctx;
 
@@ -64,6 +69,12 @@ export function computeInvestments(ctx: ParseContext): InvestmentHolding[] {
   });
 }
 
+/**
+ * Compute monthly portfolio value time series for each investment ticker.
+ * For each month, calculates cumulative shares held and multiplies by the
+ * best available price at that month (carrying forward the last known price).
+ * Also tracks cumulative cost basis for gain/loss comparison over time.
+ */
 export function computeInvestmentValueSeries(ctx: ParseContext): MonthlyInvestmentValue[] {
   const { db, commodityMap } = ctx;
 

--- a/app/src/lib/gnucash/domain/ledger.ts
+++ b/app/src/lib/gnucash/domain/ledger.ts
@@ -3,6 +3,12 @@ import type { ParseContext } from "../context";
 import { buildFullPath } from "../shared/accounts";
 import { parseGnuCashDate, formatISODate } from "../shared/dates";
 
+/**
+ * Get all transactions with full split details for the ledger view.
+ * Returns every transaction in the database, grouped by transaction GUID,
+ * with each split's amount (in transaction currency) and quantity (in account commodity).
+ * Ordered by post_date descending.
+ */
 export function getLedgerTransactions(ctx: ParseContext): LedgerTransaction[] {
   const { db, accountMap, commodityMap } = ctx;
 
@@ -81,6 +87,12 @@ export function getLedgerTransactions(ctx: ParseContext): LedgerTransaction[] {
   return transactions;
 }
 
+/**
+ * Get the 50 most recent transactions from BANK, CASH, ASSET, CREDIT, and
+ * LIABILITY accounts. Each row includes the counter-account name (the other
+ * side of the split) for categorisation. Used by the dashboard's recent
+ * transactions widget.
+ */
 export function getRecentTransactions(ctx: ParseContext): RecentTransaction[] {
   const { db, accountMap } = ctx;
 

--- a/app/src/lib/gnucash/domain/net-worth.ts
+++ b/app/src/lib/gnucash/domain/net-worth.ts
@@ -2,6 +2,16 @@ import type { MonthlyNetWorth } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { sqlMonth } from "../shared/dates";
 
+/**
+ * Compute monthly net worth time series.
+ * Tracks three separate components that are summed into net worth:
+ * 1. Non-investment assets (ASSET, BANK, CASH, RECEIVABLE) — cumulative balance with FX conversion
+ * 2. Liabilities (LIABILITY, CREDIT, PAYABLE) — cumulative balance with FX conversion
+ * 3. Investments (STOCK, MUTUAL) — shares held × price at each month (mark-to-market)
+ *
+ * Uses quantity (not value) for non-investment accounts to correctly handle
+ * multi-currency accounts. Investment values fluctuate with price history.
+ */
 export function computeNetWorthSeries(ctx: ParseContext): MonthlyNetWorth[] {
   const { db, baseCurrencyGuid, fxRates, commodityMap } = ctx;
 
@@ -138,6 +148,12 @@ export function computeNetWorthSeries(ctx: ParseContext): MonthlyNetWorth[] {
   });
 }
 
+/**
+ * Compute the current total net worth as a single number.
+ * Sums all non-investment account balances (with FX conversion) plus
+ * investment market values (shares × latest price). Excludes ROOT,
+ * INCOME, EXPENSE, EQUITY, and TRADING account types.
+ */
 export function computeCurrentNetWorth(ctx: ParseContext): number {
   const { db, commodityMap, baseCurrencyGuid, fxRates } = ctx;
 

--- a/app/src/lib/spending-filter-context.tsx
+++ b/app/src/lib/spending-filter-context.tsx
@@ -15,7 +15,7 @@ interface SpendingFilterState {
   /** Selected month from bar chart (e.g. "2025-03"), null = all months in period */
   selectedMonth: string | null;
   setSelectedMonth: (month: string | null) => void;
-  /** Leaf account selected in pie chart sidebar — filters table only, not the pie */
+  /** Leaf account selected in pie chart sidebar — filters table and bar chart */
   selectedAccount: string | null;
   setSelectedAccount: (path: string | null) => void;
   /** Categories excluded from charts */

--- a/app/src/lib/types/gnucash.ts
+++ b/app/src/lib/types/gnucash.ts
@@ -1,104 +1,161 @@
 // Types matching the GNUCash SQLite schema
 // See docs/gnucash-sql-schema.md for full reference
 
+/** Raw account record from the GNUCash `accounts` table. */
 export interface GnuCashAccount {
   guid: string;
   name: string;
+  /** One of: ROOT, ASSET, BANK, CASH, CREDIT, EQUITY, EXPENSE, INCOME, LIABILITY, MUTUAL, PAYABLE, RECEIVABLE, STOCK, TRADING */
   account_type: string;
+  /** GUID of the commodity (currency or security) this account is denominated in */
   commodity_guid: string;
+  /** GUID of the parent account, or null for the root account */
   parent_guid: string | null;
   code: string;
   description: string;
+  /** 1 = hidden in GNUCash UI */
   hidden: number;
+  /** 1 = placeholder account (cannot hold transactions directly) */
   placeholder: number;
 }
 
+/** Raw transaction record from the GNUCash `transactions` table. */
 export interface GnuCashTransaction {
   guid: string;
+  /** GUID of the currency this transaction is denominated in */
   currency_guid: string;
+  /** Check number or reference string */
   num: string;
+  /** Date the transaction was posted, in GNUCash format (YYYYMMDDHHMMSS or YYYY-MM-DD HH:MM:SS) */
   post_date: string;
+  /** Date the transaction was entered into the system */
   enter_date: string;
   description: string;
 }
 
+/** Raw split record from the GNUCash `splits` table. Every transaction has 2+ splits (double-entry). */
 export interface GnuCashSplit {
   guid: string;
+  /** GUID of the parent transaction */
   tx_guid: string;
+  /** GUID of the account this split belongs to */
   account_guid: string;
   memo: string;
+  /** e.g. "Buy", "Sell", "Deposit" — often empty */
   action: string;
+  /** "y" = reconciled, "c" = cleared, "n" = unreconciled */
   reconcile_state: string;
+  /** Numerator of the value in the transaction's currency. Amount = value_num / value_denom. */
   value_num: number;
+  /** Denominator of the value. Typically 100 for currencies with 2 decimal places. */
   value_denom: number;
+  /** Numerator of the quantity in the account's native commodity. For same-currency accounts, equals value_num. For stocks, this is the number of shares. */
   quantity_num: number;
+  /** Denominator of the quantity */
   quantity_denom: number;
+  /** GUID of the lot (used for capital gains tracking), or null */
   lot_guid: string | null;
 }
 
+/** Raw commodity/currency record from the GNUCash `commodities` table. */
 export interface GnuCashCommodity {
   guid: string;
+  /** "CURRENCY" for fiat currencies, or an exchange name (e.g. "NASDAQ") for securities */
   namespace: string;
+  /** Ticker symbol or ISO 4217 code (e.g. "GBP", "AAPL") */
   mnemonic: string;
+  /** Human-readable name (e.g. "British Pound Sterling") */
   fullname: string;
+  /** ISIN or CUSIP identifier for securities, empty for currencies */
   cusip: string;
+  /** Smallest fractional unit (e.g. 100 for GBP = 2 decimal places, 10000 for stocks = 4 decimal places) */
   fraction: number;
 }
 
+/** Raw price record from the GNUCash `prices` table. Stores historical prices for commodities. */
 export interface GnuCashPrice {
   guid: string;
+  /** GUID of the commodity being priced (e.g. AAPL stock) */
   commodity_guid: string;
+  /** GUID of the currency the price is expressed in (e.g. USD) */
   currency_guid: string;
+  /** Date of the price quote, in GNUCash format */
   date: string;
+  /** Source of the price (e.g. "user:price-editor", "Finance::Quote") */
   source: string;
+  /** Type of price (e.g. "last", "nav") */
   type: string;
+  /** Numerator of the price. Price = value_num / value_denom. */
   value_num: number;
   value_denom: number;
 }
 
+/** Raw scheduled transaction record from the GNUCash `schedxactions` table. */
 export interface GnuCashScheduledTransaction {
   guid: string;
   name: string;
+  /** 1 = enabled, 0 = disabled */
   enabled: number;
+  /** First occurrence date in GNUCash format */
   start_date: string;
+  /** Last possible occurrence date, or null for no end date */
   end_date: string | null;
+  /** Date of the last created instance, or null if none yet */
   last_occur: string | null;
+  /** Total number of occurrences (0 = unlimited) */
   num_occur: number;
+  /** Remaining occurrences */
   rem_occur: number;
+  /** 1 = auto-create transactions, 0 = prompt user */
   auto_create: number;
 }
 
+/** Raw budget record from the GNUCash `budgets` table. */
 export interface GnuCashBudget {
   guid: string;
   name: string;
   description: string;
+  /** Number of budget periods, typically 12 (one per month) */
   num_periods: number;
 }
 
+/** Raw budget amount record from the GNUCash `budget_amounts` table. One row per account per period. */
 export interface GnuCashBudgetAmount {
+  /** GUID of the budget this amount belongs to */
   budget_guid: string;
+  /** GUID of the account being budgeted */
   account_guid: string;
+  /** 0-indexed period number (0 = January, 11 = December) */
   period_num: number;
+  /** Numerator of the budgeted amount. Amount = amount_num / amount_denom. */
   amount_num: number;
+  /** Denominator of the budgeted amount, typically 100 */
   amount_denom: number;
 }
 
-// Derived types for the dashboard
+// ----- Derived types for the dashboard -----
 
+/** Hierarchical account node used in the accounts tree view. Balances are converted to base currency. */
 export interface AccountNode {
   guid: string;
   name: string;
+  /** Colon-separated account path excluding the root, e.g. "Assets:Bank:Checking" */
   fullPath: string;
+  /** GNUCash account type (BANK, CASH, EXPENSE, etc.) */
   type: string;
+  /** GUID of the commodity this account is denominated in */
   commodityGuid: string;
+  /** Ticker/currency code of the commodity (e.g. "GBP", "AAPL") */
   commodityMnemonic: string;
   parentGuid: string | null;
   hidden: boolean;
   placeholder: boolean;
+  /** Account balance in base currency, including all descendant accounts */
   balance: number;
   children: AccountNode[];
 }
 
+/** Subset of commodity fields exposed to the UI. */
 export interface CommodityInfo {
   guid: string;
   namespace: string;
@@ -107,138 +164,208 @@ export interface CommodityInfo {
   fraction: number;
 }
 
+/** One data point in the net worth time series. All values are in base currency. */
 export interface MonthlyNetWorth {
   month: string; // YYYY-MM
   netWorth: number;
+  /** Total assets including investments at market value */
   assets: number;
+  /** Total liabilities as a positive number */
   liabilities: number;
 }
 
+/** One data point in the income/expense cash flow series. All values are positive. */
 export interface MonthlyCashFlow {
   month: string; // YYYY-MM
+  /** Total income for this month (positive) */
   income: number;
+  /** Total expenses for this month (positive) */
   expenses: number;
+  /** income - expenses */
   net: number;
 }
 
+/** Hierarchical expense category with nested children. Used for tree-structured breakdowns. */
 export interface ExpenseCategory {
+  /** Leaf account name (e.g. "Groceries") */
   name: string;
+  /** Colon-separated path from expense root (e.g. "Food:Groceries") */
   fullPath: string;
+  /** Total amount spent in this category (positive) */
   amount: number;
+  /** Assigned color for charts */
   color?: string;
   children?: ExpenseCategory[];
 }
 
+/** Flat row of expense/income data per category per month. Used for pie/bar charts with drill-down. */
 export interface MonthlyExpenseByCategory {
   month: string; // YYYY-MM
-  category: string; // leaf account name
-  fullPath: string; // e.g. "Food:Groceries:Supermarket"
-  pathParts: string[]; // ["Food", "Groceries", "Supermarket"]
+  /** Leaf account name (e.g. "Supermarket") */
+  category: string;
+  /** Colon-separated path from top-level category (e.g. "Food:Groceries:Supermarket") */
+  fullPath: string;
+  /** Path split into segments for hierarchical drill-down (e.g. ["Food", "Groceries", "Supermarket"]) */
+  pathParts: string[];
+  /** Amount spent (positive) in base currency */
   amount: number;
 }
 
+/** Current holdings for a single investment account (STOCK or MUTUAL). */
 export interface InvestmentHolding {
   accountName: string;
+  /** Commodity ticker/mnemonic (e.g. "AAPL") */
   ticker: string;
   sharesHeld: number;
+  /** Total cost of shares purchased (sum of all buy transactions) */
   costBasis: number;
+  /** Current market value (sharesHeld × latest price) */
   marketValue: number;
+  /** marketValue - costBasis */
   gainLoss: number;
+  /** Gain/loss as a percentage of cost basis */
   gainLossPct: number;
+  /** Change in market value over the past 12 months, or null if insufficient price history */
   change12m: number | null;
+  /** 12-month change as a percentage, or null */
   change12mPct: number | null;
 }
 
+/** Monthly snapshot of an investment's value. Used for the portfolio value-over-time chart. */
 export interface MonthlyInvestmentValue {
   month: string; // YYYY-MM
   ticker: string;
-  value: number; // market value = shares held at month end × price at month end
-  costBasis: number; // cumulative cost basis at month end
+  /** Market value at month end = shares held × price at month end */
+  value: number;
+  /** Cumulative cost basis at month end */
+  costBasis: number;
 }
 
+/** A recent transaction from a BANK/CASH/ASSET/CREDIT/LIABILITY account. */
 export interface RecentTransaction {
   date: string;
   description: string;
+  /** Transaction amount in the account's currency (positive = debit, negative = credit) */
   amount: number;
+  /** Name of the account the split belongs to */
   accountName: string;
+  /** Name of the counter-account (other side of the split), or "Split" for multi-split transactions */
   categoryName: string;
   reconciled: boolean;
 }
 
+/** An upcoming scheduled transaction (bill). */
 export interface UpcomingBill {
   name: string;
+  /** ISO date string of the next occurrence */
   nextDate: string;
+  /** Estimated amount from the template splits, or null if unavailable */
   amount: number | null;
   enabled: boolean;
 }
 
+/** Balance of a single non-placeholder account, converted to base currency. */
 export interface TopBalance {
   accountName: string;
+  /** Colon-separated path (e.g. "Assets:Bank:Checking") */
   fullPath: string;
-  type: string; // BANK, CASH, STOCK, MUTUAL, ASSET, etc.
-  value: number; // market value for investments, balance for others
+  /** GNUCash account type: BANK, CASH, STOCK, MUTUAL, ASSET, LIABILITY, CREDIT, etc. */
+  type: string;
+  /** Balance in base currency. For investments: shares × latest price. For others: sum of quantity splits × FX rate. */
+  value: number;
+  /** Ticker or currency code of the account's commodity */
   commodityMnemonic: string;
 }
 
+/** A single expense or income transaction row for the transactions table. */
 export interface ExpenseTransaction {
   date: string; // YYYY-MM-DD
   description: string;
-  accountName: string; // leaf expense account name
-  fullPath: string; // e.g. "Food:Groceries"
+  /** Leaf account name (e.g. "Groceries") */
+  accountName: string;
+  /** Colon-separated category path (e.g. "Food:Groceries") */
+  fullPath: string;
+  /** Path split into segments for filtering */
   pathParts: string[];
+  /** Amount in base currency (positive for expenses, negative for income — then abs'd in income view) */
   amount: number;
 }
 
+/** A single split within a ledger transaction. */
 export interface LedgerSplit {
   accountGuid: string;
   accountName: string;
+  /** Full colon-separated account path (e.g. "Assets:Bank:Checking") */
   accountFullPath: string;
   accountType: string;
   memo: string;
-  reconcileState: string; // "y" = reconciled, "c" = cleared, "n" = unreconciled
-  amount: number; // value_num / value_denom (in transaction currency)
-  quantity: number; // quantity_num / quantity_denom (in account commodity)
+  /** "y" = reconciled, "c" = cleared, "n" = unreconciled */
+  reconcileState: string;
+  /** Split amount in the transaction's currency (value_num / value_denom) */
+  amount: number;
+  /** Split amount in the account's native commodity (quantity_num / quantity_denom). Differs from amount for FX or stock transactions. */
+  quantity: number;
   commodityMnemonic: string;
 }
 
+/** A full ledger transaction with all its splits. */
 export interface LedgerTransaction {
   guid: string;
   date: string; // YYYY-MM-DD
   description: string;
-  num: string; // check number / reference
+  /** Check number or reference */
+  num: string;
   splits: LedgerSplit[];
 }
 
+/** Metadata about a GNUCash budget. */
 export interface BudgetInfo {
   guid: string;
   name: string;
   description: string;
+  /** Number of budget periods (typically 12 for monthly budgets) */
   numPeriods: number;
 }
 
+/** A single row in the budget view, representing one account's budgeted vs actual amounts. */
 export interface BudgetCategoryRow {
   accountGuid: string;
   accountName: string;
+  /** Colon-separated path within the budget hierarchy */
   fullPath: string;
-  budgeted: number; // total budgeted for the selected period
-  actual: number; // actual spending for the selected period
-  variance: number; // budgeted - actual (positive = under budget)
-  variancePct: number; // variance / budgeted * 100
-  periods: { period: number; budgeted: number; actual: Record<string, number> }[]; // actual keyed by year
-  parentAccountGuid: string | null; // nearest ancestor in the budget hierarchy (null = top-level)
-  depth: number; // 0 = top-level budget category
-  hasChildren: boolean; // true if child accounts also appear in the budget hierarchy
-  hasExplicitBudget: boolean; // true if this account has its own budget_amounts entry
-  childBudgetTotal: number; // sum of direct children's budgeted amounts
-  imbalance: number; // this.budgeted - childBudgetTotal (only non-zero for explicit budgets with children)
-  isUnbudgeted?: boolean; // true for synthetic "Unbudgeted" rows
+  /** Total budgeted amount for the selected period (always positive) */
+  budgeted: number;
+  /** Total actual amount for the selected period (always positive) */
+  actual: number;
+  /** budgeted - actual (positive = under budget, negative = over budget) */
+  variance: number;
+  /** (variance / budgeted) × 100 */
+  variancePct: number;
+  /** Per-period data. `actual` is keyed by year string (e.g. "2025") to support year-over-year comparison. */
+  periods: { period: number; budgeted: number; actual: Record<string, number> }[];
+  /** Nearest ancestor in the budget hierarchy, or null for top-level categories */
+  parentAccountGuid: string | null;
+  /** 0 = top-level budget category, 1 = first sub-level, etc. */
+  depth: number;
+  /** True if child accounts also appear as rows in the budget hierarchy */
+  hasChildren: boolean;
+  /** True if this account has an explicit entry in the budget_amounts table (vs. synthesised from children) */
+  hasExplicitBudget: boolean;
+  /** Sum of direct children's budgeted amounts */
+  childBudgetTotal: number;
+  /** budgeted - childBudgetTotal. Only non-zero for accounts with both an explicit budget AND budgeted children. */
+  imbalance: number;
+  /** True for synthetic "Unbudgeted" rows that show the gap between a parent's budget and its children's budgets */
+  isUnbudgeted?: boolean;
 }
 
+/** Budget data for a single GNUCash budget, split into expense and income categories. */
 export interface BudgetDataForBudget {
   expenseCategories: BudgetCategoryRow[];
   incomeCategories: BudgetCategoryRow[];
 }
 
+/** All budget data across all GNUCash budgets in the file. */
 export interface BudgetData {
   budgets: BudgetInfo[];
   /** Categories keyed by budget guid */
@@ -246,35 +373,67 @@ export interface BudgetData {
   /** @deprecated Use categoriesByBudget instead — kept for convenience as alias to first budget */
   expenseCategories: BudgetCategoryRow[];
   incomeCategories: BudgetCategoryRow[];
+  /** Years that have actual transaction data, sorted descending (most recent first) */
   availableYears: number[];
 }
 
+/**
+ * The complete data model passed from the worker to the UI.
+ * Computed once when a GNUCash file is loaded and cached in React context.
+ * All monetary values are converted to the base currency unless otherwise noted.
+ */
 export interface DashboardData {
-  currency: string; // ISO 4217 code detected from GNUCash (e.g. "GBP", "USD")
-  currencyGuid: string; // GUID of the base currency commodity
-  currencyFraction: number; // Smallest unit for the base currency (e.g., 100 for USD/GBP)
+  /** ISO 4217 currency code detected from the GNUCash root account (e.g. "GBP", "USD") */
+  currency: string;
+  /** GUID of the base currency commodity in the commodities table */
+  currencyGuid: string;
+  /** Smallest fractional unit for the base currency (e.g. 100 for USD/GBP = 2 decimal places) */
+  currencyFraction: number;
+  /** Hierarchical account tree rooted at the GNUCash root account's children */
   accounts: AccountNode[];
+  /** Monthly net worth time series (assets, liabilities, net worth) */
   netWorthSeries: MonthlyNetWorth[];
+  /** Monthly income vs expense series (used by the Income/Expense Flow chart) */
   cashFlowSeries: MonthlyCashFlow[];
+  /** Hierarchical expense breakdown for the expense category tree */
   expenseBreakdown: ExpenseCategory[];
+  /** Flat monthly expense rows for pie/bar charts with drill-down */
   monthlyExpensesByCategory: MonthlyExpenseByCategory[];
+  /** Stable colour assignments for top-level expense categories (keyed by category name) */
   expenseCategoryColors: Record<string, string>;
+  /** Individual expense transactions for the expense table */
   expenseTransactions: ExpenseTransaction[];
+  /** Flat monthly income rows for pie/bar charts with drill-down */
   monthlyIncomeByCategory: MonthlyExpenseByCategory[];
+  /** Stable colour assignments for top-level income categories */
   incomeCategoryColors: Record<string, string>;
+  /** Individual income transactions for the income table */
   incomeTransactions: ExpenseTransaction[];
+  /** Current investment holdings with cost basis and market value */
   investments: InvestmentHolding[];
+  /** Monthly portfolio value time series per ticker */
   investmentValueSeries: MonthlyInvestmentValue[];
+  /** All non-placeholder account balances, sorted by value */
   topBalances: TopBalance[];
+  /** 50 most recent transactions from BANK/CASH/ASSET/CREDIT/LIABILITY accounts */
   recentTransactions: RecentTransaction[];
+  /** Upcoming scheduled transactions (bills) */
   upcomingBills: UpcomingBill[];
+  /** Current total net worth in base currency */
   currentNetWorth: number;
+  /** Income for the current calendar month */
   currentMonthIncome: number;
+  /** Expenses for the current calendar month */
   currentMonthExpenses: number;
+  /** (income - expenses) / income × 100 for the current month */
   savingsRate: number;
+  /** Budget data (null if no budgets exist in the GNUCash file) */
   budgetData: BudgetData | null;
+  /** All transactions with full split details for the ledger view */
   ledgerTransactions: LedgerTransaction[];
+  /** All commodities/currencies in the file */
   commodities: CommodityInfo[];
+  /** True if the file contains book-closing transactions (year-end entries that zero out income/expense) */
   hasClosingTransactions: boolean;
   /** Cash flow series with closing transactions excluded (only present when hasClosingTransactions is true). */
   cashFlowSeriesExcludingClosing?: MonthlyCashFlow[];

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,146 @@
+# Architecture
+
+GnuDash is a client-side web application that reads GNUCash files and renders financial dashboards. All data processing happens in the browser — no server-side computation or storage.
+
+## Data Flow
+
+```
+GNUCash file (.gnucash SQLite or .gnucash XML)
+        │
+        ▼
+┌─────────────────────────┐
+│   Web Worker            │
+│   (SQLite WASM)         │
+│                         │
+│   1. Load file into     │
+│      in-memory SQLite   │
+│   2. Build ParseContext │
+│   3. Run domain fns     │
+│   4. Return DashboardData│
+└────────────┬────────────┘
+             │ postMessage
+             ▼
+┌─────────────────────────┐
+│   Main Thread           │
+│                         │
+│   DashboardContext       │
+│   (React Context)       │
+│   - Stores DashboardData│
+│   - Provides useDashboard()│
+│   - Handles file upload │
+│   - Manages write ops   │
+└────────────┬────────────┘
+             │
+             ▼
+┌─────────────────────────┐
+│   Page Components       │
+│                         │
+│   Each page reads from  │
+│   useDashboard() and    │
+│   renders charts/tables │
+└─────────────────────────┘
+```
+
+## Key Layers
+
+### 1. File Loading (`lib/gnucash/`)
+
+**Entry points:**
+- `worker/db-worker.ts` — Web Worker that loads a file buffer into SQLite WASM and exposes domain functions via `postMessage`
+- `index.ts` — Node.js entry point for server-side parsing (uses native SQLite)
+- `xml/parser.ts` — Parser for XML-format GNUCash files (converted to in-memory SQLite)
+
+**Context:** `context.ts` defines `ParseContext`, a bag of pre-computed lookups passed to every domain function:
+- `db` — SQLite database adapter
+- `accountMap` — GUID → account lookup
+- `commodityMap` — GUID → commodity lookup
+- `fxRates` — Foreign exchange rate converter
+- `latestPrices` — Most recent price per commodity
+- `topExpenseGuids` / `topIncomeGuids` — Top-level category account GUIDs
+
+### 2. Domain Layer (`lib/gnucash/domain/`)
+
+Pure functions that query SQLite and return typed data. Each file owns one area of financial computation:
+
+| File | Functions | What it computes |
+|------|-----------|-----------------|
+| `accounts.ts` | `buildAccountTree` | Hierarchical account tree with balances in base currency |
+| `balances.ts` | `computeTopBalances` | Current balance of every non-placeholder account |
+| `bills.ts` | `getUpcomingBills` | Next occurrence of scheduled transactions |
+| `budgets.ts` | `computeBudgetData` | Budget vs actual with hierarchy, imbalance detection |
+| `cash-flow.ts` | `computeCashFlowSeries` | Monthly income vs expense totals (not true cash flow) |
+| `closing.ts` | `hasClosingTransactions` | Detects year-end book-closing entries |
+| `expenses.ts` | `computeExpenseBreakdown`, `getExpenseTransactions` | Expense categories, monthly breakdowns, transaction list |
+| `fx.ts` | `buildFxRateMap` | Foreign exchange rate lookup from price history |
+| `income.ts` | `computeIncomeBreakdown`, `getIncomeTransactions` | Income categories and transactions |
+| `investments.ts` | `computeInvestments`, `computeInvestmentValueSeries` | Holdings, cost basis, market value, portfolio time series |
+| `ledger.ts` | `getLedgerTransactions`, `getRecentTransactions` | Full transaction ledger and recent transactions |
+| `net-worth.ts` | `computeNetWorthSeries`, `computeCurrentNetWorth` | Monthly net worth (assets + investments - liabilities) |
+
+**Important conventions:**
+- All domain functions take `ParseContext` as their first argument
+- Monetary values are converted to base currency unless noted otherwise
+- Income amounts are negated (GNUCash stores income splits as negative values)
+- Balance queries use `quantity_num/quantity_denom` (native commodity) with FX conversion, not `value_num/value_denom`, for accurate multi-currency support
+
+### 3. Data Model (`lib/types/gnucash.ts`)
+
+Two categories of types:
+- **Schema types** (`GnuCashAccount`, `GnuCashSplit`, etc.) — mirror the SQLite tables
+- **Derived types** (`DashboardData`, `MonthlyNetWorth`, etc.) — computed by domain functions
+
+`DashboardData` is the central type — it contains everything the UI needs, computed once when a file is loaded. See the type file for detailed field documentation.
+
+### 4. React Layer
+
+**Context providers** (wrap the app in `(dashboard)/layout.tsx`):
+- `DashboardContext` — provides `useDashboard()` hook with all data + mutation functions
+- `PrivacyContext` — `usePrivacy()` for the hide/show values toggle (applied via CSS blur)
+- `ClosingContext` — `useClosing()` for the global exclude-closing-transactions toggle
+
+**Page structure** (`app/(dashboard)/`):
+- `/` — Dashboard overview (net worth, income/spending overview, cash flow, balances)
+- `/accounts` — Chart of accounts tree
+- `/transactions` — Full ledger with search/filter
+- `/income` — Income breakdown (pie, bar, table) with drill-down
+- `/spending` — Spending breakdown (pie, bar, table) with drill-down
+- `/investment` — Portfolio summary, allocation, holdings, value over time
+- `/budget` — Budget vs actual (expense/income basis)
+- `/cash-flow` — Cash flow budget (cash-basis tracking)
+- `/sankey` — Sankey flow diagram
+
+**Shared filter state:** The spending and income pages share a `SpendingFilterContext` that synchronises:
+- Period selection (time range)
+- Category drill-down (selectedCategory)
+- Leaf account selection (selectedAccount) — filters bar chart and transaction table
+- Month selection (from clicking a bar)
+- Excluded categories (hidden from pie chart)
+
+### 5. Worker Communication
+
+The worker uses a typed message protocol defined in `worker/messages.ts`. The main thread sends commands (`openFile`, `query`, `mutate`) and receives responses (`result`, `error`). `GnuCashWorkerClient` (`worker/client.ts`) wraps this in a promise-based API.
+
+For mutations (create/edit/delete transactions, accounts, commodities), the worker:
+1. Validates the operation
+2. Writes to the in-memory SQLite database
+3. Recomputes `DashboardData`
+4. Returns the fresh data to the main thread
+
+### 6. File Persistence
+
+Files are persisted client-side using two mechanisms:
+- **OPFS** (Origin Private File System) — primary storage, survives page refreshes
+- **sessionStorage** — fallback cache for browsers without OPFS support
+
+The original `.gnucash` file can be exported back via the sidebar.
+
+## Closing Transactions
+
+GNUCash year-end closing transactions zero out income/expense accounts. These are detected via the `slots` table (`name = 'book-closing'`). A global toggle in the header bar excludes them from all income/expense charts. Pre-computed "excluding closing" variants of the data are stored in `DashboardData` alongside the full data.
+
+## Multi-Currency Support
+
+- Base currency is detected from the GNUCash root account
+- Foreign currency accounts use `quantity` (native amount) × FX rate, not `value` (which may be stale)
+- FX rates come from the GNUCash `prices` table (most recent price per currency pair)
+- Investment accounts use `quantity` (shares) × latest price for market value


### PR DESCRIPTION
## Summary
- **Bug fix:** Monthly spending/income bar chart now filters by selected leaf account, matching the transactions table. Previously clicking a child account in the pie chart only filtered the table, not the bar chart.
- **Type documentation:** Added field-level JSDoc comments to all interfaces in `gnucash.ts` (schema types and derived types)
- **Domain documentation:** Added JSDoc headers to all 18 exported domain functions explaining what they compute, key assumptions, and non-obvious behaviour (e.g. income negation, quantity vs value for multi-currency)
- **Architecture doc:** New `docs/architecture.md` covering the full data flow, layer responsibilities, multi-currency handling, closing transactions, and file persistence

## Test plan
- [ ] On spending page: click a category in the pie to drill down, then click a leaf account — verify the bar chart now filters to show only that account's monthly spend
- [ ] Same test on income page
- [ ] Verify build passes
- [ ] Review JSDoc comments on domain functions for accuracy
- [ ] Review docs/architecture.md for completeness