### PR TITLE
Mitigate "Too many open files" crash on Linux (issue #37)

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -6,6 +6,18 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   turbopack: {},
+  // Exclude test directories from webpack's file watcher to reduce open file
+  // descriptors during development (helps avoid EMFILE on Linux with low ulimits).
+  // Note: Turbopack does not currently support watch exclusions — if you hit
+  // "Too many open files" with Turbopack, increase your OS file descriptor
+  // limit instead (see docs/deployment.md).
+  webpack: (config) => {
+    config.watchOptions = {
+      ...config.watchOptions,
+      ignored: ["**/__tests__/**", "**/__snapshots__/**", "**/fixtures/**"],
+    };
+    return config;
+  },
   // Active during `npm run dev`; ignored during static export
   headers: async () => [
     {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -6197,6 +6197,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -28,6 +28,35 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000). The dev server sets the required headers automatically via `next.config.ts`.
 
+### Linux: "Too many open files" error
+
+On Linux (e.g. Ubuntu), you may see this crash when running `npm run dev`:
+
+```
+FATAL: An unexpected Turbopack error occurred.
+Error [TurbopackInternalError]: Too many open files (os error 24)
+```
+
+This happens because the Next.js dev server (Turbopack) opens file watchers across the project tree, and Linux distributions often ship with a low default limit on open file descriptors (typically 1024). Between the source files, `node_modules`, and Turbopack's internal bookkeeping, the dev server can exceed that limit.
+
+**Quick fix** — raise the limit for your current shell session:
+
+```bash
+ulimit -n 65536
+npm run dev
+```
+
+**Permanent fix** — add these lines to `/etc/security/limits.conf` (requires sudo) so the change persists across reboots:
+
+```
+* soft nofile 65536
+* hard nofile 65536
+```
+
+Then log out and back in (or reboot) for the new limits to take effect. You can verify with `ulimit -n`.
+
+> **Why this isn't needed on macOS or Docker:** macOS sets a much higher default limit (tens of thousands), and the Docker images used for production builds don't run a file watcher at all — they just serve the static build output via nginx.
+
 ---
 
 ## Static Build


### PR DESCRIPTION
Exclude test directories (__tests__, __snapshots__, fixtures) from
webpack's file watcher to reduce file descriptor usage during
development. Document the root cause and ulimit fix in the deployment
guide for Linux users hitting Turbopack's EMFILE error.

https://claude.ai/code/session_01LDtSu7ebhW2xEiJzz2m3t4