### PR TITLE
Add Inter as Cyrillic fallback font (issue #36)

### DIFF
--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -1,11 +1,17 @@
 import type { Metadata } from "next";
-import { DM_Sans } from "next/font/google";
+import { DM_Sans, Inter } from "next/font/google";
 import "./globals.css";
 import { DashboardProvider } from "@/lib/dashboard-context";
 
 const dmSans = DM_Sans({
   variable: "--font-dm-sans",
-  subsets: ["latin"],
+  subsets: ["latin", "latin-ext"],
+  weight: ["400", "500", "600", "700"],
+});
+
+const inter = Inter({
+  variable: "--font-inter",
+  subsets: ["cyrillic", "cyrillic-ext", "latin", "latin-ext"],
   weight: ["400", "500", "600", "700"],
 });
 
@@ -20,8 +26,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${dmSans.variable} h-full antialiased`}>
-      <body className="min-h-full" style={{ fontFamily: "var(--font-dm-sans), system-ui, sans-serif" }}>
+    <html lang="en" className={`${dmSans.variable} ${inter.variable} h-full antialiased`}>
+      <body className="min-h-full" style={{ fontFamily: "var(--font-dm-sans), var(--font-inter), system-ui, sans-serif" }}>
         <DashboardProvider>{children}</DashboardProvider>
       </body>
     </html>


### PR DESCRIPTION
DM Sans only supports Latin subsets, so Cyrillic text was falling back to system-ui which has different metrics and renders at a visibly different size. Load Inter (which has full Cyrillic coverage and similar geometry to DM Sans) as the second font in the stack so the browser uses it for Cyrillic characters while keeping DM Sans for Latin.

Fixes issue #36 