### PR TITLE
Fix CSP headers: allow unsafe-eval for SQLite WASM

### DIFF
--- a/app/public/_headers
+++ b/app/public/_headers
@@ -4,5 +4,5 @@
   X-Content-Type-Options: nosniff
   X-Frame-Options: DENY
   Referrer-Policy: strict-origin-when-cross-origin
-  Content-Security-Policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; worker-src 'self' blob:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; worker-src 'self' blob:; connect-src 'self' ws:; object-src 'none'; base-uri 'self'; form-action 'self'
   Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()


### PR DESCRIPTION
## Summary
- The `_headers` file served by Cloudflare Pages was missing `'unsafe-eval'` and `'unsafe-inline'` on `script-src`
- SQLite WASM requires `'unsafe-eval'` for WebAssembly compilation
- This caused the entire app to silently fail on the production deployment — file upload, demo data, everything broken
- Also added `ws:` to `connect-src` to match the dev config

## Test plan
- [ ] Deploy to Cloudflare Pages and verify file upload works
- [ ] Verify SQLite WASM initialises and dashboard loads