### PR TITLE
Fix period filters to use calendar month (fixes #42) + default to editing mode

### DIFF
--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -30,13 +30,29 @@ const PERIOD_LABELS: Record<string, string> = {
 };
 
 function getSlice(series: MonthlyCashFlow[], period: string, customRange?: CustomRange | null): MonthlyCashFlow[] {
+  // Anchor relative periods to the current calendar month, not the latest
+  // month in the dataset. Prevents future-dated transactions from shifting
+  // period selection. (Fixes #42)
+  const now = new Date();
+  const y = now.getFullYear();
+  const m = now.getMonth();
+  const monthStr = (offset: number) => {
+    const d = new Date(y, m + offset, 1);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  };
+  const monthSet = (count: number) => {
+    const s = new Set<string>();
+    for (let i = 0; i < count; i++) s.add(monthStr(i - count + 1));
+    return s;
+  };
+
   switch (period) {
-    case "this-month": return series.slice(-1);
-    case "last-month": return series.slice(-2, -1);
-    case "last-6m": return series.slice(-6);
-    case "last-12m": return series.slice(-12);
+    case "this-month": return series.filter((s) => s.month === monthStr(0));
+    case "last-month": return series.filter((s) => s.month === monthStr(-1));
+    case "last-6m": { const ms = monthSet(6); return series.filter((s) => ms.has(s.month)); }
+    case "last-12m": { const ms = monthSet(12); return series.filter((s) => ms.has(s.month)); }
     case "this-year": {
-      const year = String(new Date().getFullYear());
+      const year = String(y);
       return series.filter((s) => s.month.startsWith(year));
     }
     case "all-time": return series;

--- a/app/src/components/dashboard/charts/net-worth-chart.tsx
+++ b/app/src/components/dashboard/charts/net-worth-chart.tsx
@@ -72,17 +72,30 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
 
   const dataRange = useMemo(() => getDataRange(series) ?? { min: "2020-01", max: "2026-01" }, [series]);
   const filtered = useMemo(() => {
+    // Anchor relative periods to the current calendar month (fixes #42)
+    const now = new Date();
+    const y = now.getFullYear();
+    const m = now.getMonth();
+    const monthStr = (offset: number) => {
+      const d = new Date(y, m + offset, 1);
+      return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+    };
+    const monthSet = (count: number) => {
+      const s = new Set<string>();
+      for (let i = 0; i < count; i++) s.add(monthStr(i - count + 1));
+      return s;
+    };
+
     switch (period) {
-      case "last-6m": return series.slice(-6);
-      case "last-12m": return series.slice(-12);
+      case "last-6m": { const ms = monthSet(6); return series.filter((s) => ms.has(s.month)); }
+      case "last-12m": { const ms = monthSet(12); return series.filter((s) => ms.has(s.month)); }
       case "all-time": return series;
       case "custom":
         if (!customRange) return series;
         return series.filter((s) => s.month >= dateToMonth(customRange.start) && s.month <= dateToMonth(customRange.end));
       default: {
-        // Handle periods from the dashboard selector (this-month, last-month)
-        if (period === "this-month") return series.slice(-1);
-        if (period === "last-month") return series.slice(-2, -1);
+        if (period === "this-month") return series.filter((s) => s.month === monthStr(0));
+        if (period === "last-month") return series.filter((s) => s.month === monthStr(-1));
         return series;
       }
     }

--- a/app/src/components/upload/file-upload.tsx
+++ b/app/src/components/upload/file-upload.tsx
@@ -8,7 +8,7 @@ import { useDashboard } from "@/lib/dashboard-context";
 export function FileUpload() {
   const { uploadFile, loadDemo, isLoading, error } = useDashboard();
   const [isDragging, setIsDragging] = useState(false);
-  const [writable, setWritable] = useState(false);
+  const [readOnly, setReadOnly] = useState(false);
 
   const MAX_FILE_SIZE = 200 * 1024 * 1024; // 200 MB
   const [fileSizeError, setFileSizeError] = useState<string | null>(null);
@@ -25,9 +25,9 @@ export function FileUpload() {
         );
         return;
       }
-      uploadFile(file, writable);
+      uploadFile(file, !readOnly);
     },
-    [uploadFile, writable]
+    [uploadFile, readOnly]
   );
 
   const handleDrop = useCallback(
@@ -115,14 +115,14 @@ export function FileUpload() {
         <label className="mt-4 flex items-start gap-3 rounded-xl border border-[#D4DAE0] bg-white p-3 cursor-pointer transition-all hover:border-[#6C9B8B]/50">
           <input
             type="checkbox"
-            checked={writable}
-            onChange={(e) => setWritable(e.target.checked)}
+            checked={readOnly}
+            onChange={(e) => setReadOnly(e.target.checked)}
             className="mt-0.5 h-4 w-4 rounded border-[#D4DAE0] text-[#6C9B8B] accent-[#6C9B8B]"
           />
           <div>
-            <span className="text-sm font-medium text-[#1A1D1F]">Enable editing</span>
+            <span className="text-sm font-medium text-[#1A1D1F]">Read-only mode</span>
             <p className="mt-0.5 text-xs text-[#9A9FA5]">
-              Allows adding transactions. Changes are saved to the browser copy of your file.
+              Prevents any changes. Uncheck to allow adding transactions and editing.
             </p>
           </div>
         </label>

--- a/app/src/lib/sankey-utils.ts
+++ b/app/src/lib/sankey-utils.ts
@@ -49,35 +49,44 @@ export function getMonthsForPeriod(
 ): Set<string> {
   if (cashFlowSeries.length === 0) return new Set();
 
-  let slice: MonthlyCashFlow[];
+  // Anchor relative periods to the current calendar month, not the latest
+  // month in the dataset. This prevents future-dated transactions from
+  // shifting "This Month" to a future period. (Fixes #42)
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth(); // 0-based
+
+  /** Build a YYYY-MM string offset from the current month. */
+  const monthAtOffset = (offset: number): string => {
+    const d = new Date(currentYear, currentMonth + offset, 1);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+  };
+
+  /** Build a Set of YYYY-MM strings for a range of month offsets. */
+  const monthRange = (count: number): Set<string> =>
+    new Set(Array.from({ length: count }, (_, i) => monthAtOffset(i - count + 1)));
+
   switch (period) {
     case "this-month":
-      slice = cashFlowSeries.slice(-1);
-      break;
+      return new Set([monthAtOffset(0)]);
     case "last-month":
-      slice = cashFlowSeries.slice(-2, -1);
-      break;
+      return new Set([monthAtOffset(-1)]);
     case "last-3m":
-      slice = cashFlowSeries.slice(-3);
-      break;
+      return monthRange(3);
     case "last-6m":
-      slice = cashFlowSeries.slice(-6);
-      break;
+      return monthRange(6);
     case "last-12m":
-      slice = cashFlowSeries.slice(-12);
-      break;
+      return monthRange(12);
     case "all-time":
-      slice = cashFlowSeries;
-      break;
+      return new Set(cashFlowSeries.map((s) => s.month));
     case "custom":
       if (!customRange) return new Set();
-      slice = cashFlowSeries.filter(
-        (s) => s.month >= dateToMonth(customRange.start) && s.month <= dateToMonth(customRange.end),
+      return new Set(
+        cashFlowSeries
+          .filter((s) => s.month >= dateToMonth(customRange.start) && s.month <= dateToMonth(customRange.end))
+          .map((s) => s.month),
       );
-      break;
   }
-
-  return new Set(slice.map((s) => s.month));
 }
 
 // ── Colour constants ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- **Fixes #42**: All period filters ("This Month", "Last Month", etc.) now anchor to the current calendar month via `new Date()`, not the last entry in the dataset
- Applied consistently across **sankey-utils.ts**, **cash-flow-chart.tsx**, and **net-worth-chart.tsx** — the spending utils already used `new Date()` correctly
- **Files now open in editing mode by default** — upload checkbox changed from "Enable editing" (opt-in) to "Read-only mode" (opt-in)

## Test plan
- [ ] Add a future-dated transaction, verify "This Month" still shows the current month on Sankey, cash flow, and net worth charts
- [ ] Upload a file — verify it opens in writable/editing mode by default
- [ ] Tick "Read-only mode" on upload — verify editing is disabled