### PR TITLE
Fix account creation against real GnuCash schemas (#57)

### DIFF
--- a/app/src/lib/gnucash/__tests__/engine/operations.test.ts
+++ b/app/src/lib/gnucash/__tests__/engine/operations.test.ts
@@ -240,6 +240,36 @@ describe("account-ops", () => {
       const errors = builder.validate();
       expect(errors.some(e => e.code === "DUPLICATE_NAME")).toBe(true);
     });
+
+    // Regression for issue #57: real GnuCash schemas declare commodity_scu
+    // NOT NULL. The builder must populate it from the commodity's fraction
+    // rather than rely on a default.
+    it("sets commodity_scu to the commodity's fraction (issue #57)", () => {
+      const gbpAccount = new AccountBuilder(db, ctx)
+        .name("Hair cuts")
+        .type("EXPENSE")
+        .commodity("gbp00000000000000000000000000001") // fraction = 100
+        .parent("root0000000000000000000000000001")
+        .commit();
+
+      const gbpRow = db
+        .prepare(`SELECT commodity_scu, non_std_scu FROM accounts WHERE guid = ?`)
+        .get(gbpAccount.accountGuid) as { commodity_scu: number; non_std_scu: number };
+      expect(gbpRow.commodity_scu).toBe(100);
+      expect(gbpRow.non_std_scu).toBe(0);
+
+      const aaplAccount = new AccountBuilder(db, ctx)
+        .name("AAPL Holdings")
+        .type("STOCK")
+        .commodity("aapl0000000000000000000000000003") // fraction = 10000
+        .parent("root0000000000000000000000000001")
+        .commit();
+
+      const aaplRow = db
+        .prepare(`SELECT commodity_scu FROM accounts WHERE guid = ?`)
+        .get(aaplAccount.accountGuid) as { commodity_scu: number };
+      expect(aaplRow.commodity_scu).toBe(10000);
+    });
   });
 
   describe("renameAccount", () => {

--- a/app/src/lib/gnucash/engine/builders/account-builder.ts
+++ b/app/src/lib/gnucash/engine/builders/account-builder.ts
@@ -100,15 +100,26 @@ export class AccountBuilder {
 
     const accountGuid = generateGuid();
 
+    // Look up the commodity's fraction so we can populate commodity_scu,
+    // which is NOT NULL in real GnuCash schemas. Default to 100 if the
+    // commodity row is missing or has no fraction (should be rare — the
+    // validate() pass above already confirmed the commodity exists).
+    const commodityRow = this.db
+      .prepare(`SELECT fraction FROM commodities WHERE guid = ?`)
+      .get(this._commodityGuid) as { fraction: number } | undefined;
+    const commodityScu = commodityRow?.fraction ?? 100;
+
     this.db.transaction(() => {
       this.db.run(
-        `INSERT INTO accounts (guid, name, account_type, commodity_guid, parent_guid,
-                               code, description, hidden, placeholder)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO accounts (guid, name, account_type, commodity_guid, commodity_scu,
+                               non_std_scu, parent_guid, code, description, hidden, placeholder)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         accountGuid,
         this._name,
         this._accountType,
         this._commodityGuid,
+        commodityScu,
+        0,
         this._parentGuid,
         this._code,
         this._description,

--- a/app/src/lib/gnucash/engine/db/writable-connection.ts
+++ b/app/src/lib/gnucash/engine/db/writable-connection.ts
@@ -107,6 +107,8 @@ export function createWritableMemoryDb(): WritableDbAdapter {
       name TEXT NOT NULL,
       account_type TEXT NOT NULL,
       commodity_guid TEXT NOT NULL,
+      commodity_scu INTEGER NOT NULL DEFAULT 100,
+      non_std_scu INTEGER NOT NULL DEFAULT 0,
       parent_guid TEXT,
       code TEXT DEFAULT '',
       description TEXT DEFAULT '',

--- a/app/src/lib/gnucash/xml/schema.ts
+++ b/app/src/lib/gnucash/xml/schema.ts
@@ -25,6 +25,8 @@ export const GNUCASH_SCHEMA_DDL = `
     name TEXT NOT NULL,
     account_type TEXT NOT NULL,
     commodity_guid TEXT NOT NULL,
+    commodity_scu INTEGER NOT NULL DEFAULT 100,
+    non_std_scu INTEGER NOT NULL DEFAULT 0,
     parent_guid TEXT,
     code TEXT DEFAULT '',
     description TEXT DEFAULT '',


### PR DESCRIPTION
## Summary

- Creating a new account via the Add Account sheet failed against real `.gnucash` SQLite files with `NOT NULL constraint failed: accounts.commodity_scu`.
- `AccountBuilder.commit()` now looks up the commodity's `fraction` and populates `commodity_scu` + `non_std_scu` on insert.
- Both the XML-import DDL and the writable in-memory DDL gain `commodity_scu` / `non_std_scu` so they match the real GnuCash schema — this also unblocks tests that use the in-memory DB.

Closes #57.

## Test plan

- [x] `vitest run src/lib/gnucash/__tests__/engine/operations.test.ts` — 19/19 passing, including a new regression test that asserts `commodity_scu` is set to the commodity's fraction (100 for GBP, 10000 for AAPL).
- [x] Full suite: 124/125 (the 1 failure is a pre-existing stale snapshot unrelated to this branch).
- [x] Manual verification against a real uploaded `.gnucash` file — creating "Hair cuts" under `Expenses:General:Misc` no longer throws.