### PR TITLE
Add bulk edit transactions workflow (#56)

### DIFF
--- a/app/src/app/(dashboard)/special-functions/bulk-edit/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/bulk-edit/page.tsx
@@ -1,0 +1,580 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { useDashboard } from "@/lib/dashboard-context";
+import { formatCurrency } from "@/lib/format";
+import type { AccountNode, LedgerTransaction } from "@/lib/types/gnucash";
+import { ArrowLeft, ArrowRight, Layers, Search, X } from "lucide-react";
+
+/**
+ * Bulk-edit workflow for cleaning up imported transactions.
+ *
+ * Groups simple (single-split, 2-posting) transactions by exact description
+ * match and lets the user apply a rename and/or account reassignment across
+ * every member of the group in one atomic DB write. Multi-split transactions
+ * are excluded from grouping because "from"/"to" is ambiguous for them.
+ */
+
+interface TransactionGroup {
+  key: string; // description (exact)
+  description: string;
+  transactions: LedgerTransaction[];
+  totalValue: number; // absolute value sum in the tx currency
+  currencyMnemonic: string;
+  /** Most common "from" account in the group, or null if fully mixed. */
+  dominantFromName: string | null;
+  /** Most common "to" account in the group, or null if fully mixed. */
+  dominantToName: string | null;
+  fromIsMixed: boolean;
+  toIsMixed: boolean;
+  firstDate: string;
+  lastDate: string;
+  /**
+   * Currency-GUID proxy: the commodity mnemonic of the tx splits. Used to
+   * verify a target account is compatible before sending the mutation.
+   */
+  commodityMnemonic: string;
+}
+
+/** Flatten an account tree into a list of real (non-placeholder) accounts. */
+function flattenAccounts(nodes: AccountNode[]): AccountNode[] {
+  const out: AccountNode[] = [];
+  const walk = (n: AccountNode) => {
+    if (!n.placeholder && n.type !== "ROOT") out.push(n);
+    for (const c of n.children) walk(c);
+  };
+  for (const n of nodes) walk(n);
+  return out.sort((a, b) => a.fullPath.localeCompare(b.fullPath));
+}
+
+/**
+ * Build groups of single-split (exactly 2-posting) transactions keyed by
+ * exact description. Only returns groups with 2 or more members.
+ */
+function buildGroups(txs: LedgerTransaction[]): TransactionGroup[] {
+  const byDescription = new Map<string, LedgerTransaction[]>();
+  for (const tx of txs) {
+    if (tx.splits.length !== 2) continue;
+    // All splits must share one commodity for the "mixed" heuristic and
+    // currency check to be meaningful.
+    if (tx.splits[0].commodityMnemonic !== tx.splits[1].commodityMnemonic) continue;
+    const list = byDescription.get(tx.description) ?? [];
+    list.push(tx);
+    byDescription.set(tx.description, list);
+  }
+
+  const groups: TransactionGroup[] = [];
+  for (const [desc, list] of byDescription) {
+    if (list.length < 2) continue;
+
+    const fromCounts = new Map<string, number>();
+    const toCounts = new Map<string, number>();
+    let totalValue = 0;
+    let firstDate = list[0].date;
+    let lastDate = list[0].date;
+
+    for (const tx of list) {
+      if (tx.date < firstDate) firstDate = tx.date;
+      if (tx.date > lastDate) lastDate = tx.date;
+      for (const s of tx.splits) {
+        if (s.amount < 0) {
+          fromCounts.set(s.accountFullPath, (fromCounts.get(s.accountFullPath) ?? 0) + 1);
+        } else if (s.amount > 0) {
+          toCounts.set(s.accountFullPath, (toCounts.get(s.accountFullPath) ?? 0) + 1);
+          totalValue += s.amount;
+        }
+      }
+    }
+
+    const fromEntries = Array.from(fromCounts.entries()).sort((a, b) => b[1] - a[1]);
+    const toEntries = Array.from(toCounts.entries()).sort((a, b) => b[1] - a[1]);
+    const fromIsMixed = fromEntries.length > 1;
+    const toIsMixed = toEntries.length > 1;
+
+    groups.push({
+      key: desc,
+      description: desc,
+      transactions: list,
+      totalValue,
+      currencyMnemonic: list[0].splits[0].commodityMnemonic,
+      dominantFromName: fromEntries.length > 0 ? fromEntries[0][0] : null,
+      dominantToName: toEntries.length > 0 ? toEntries[0][0] : null,
+      fromIsMixed,
+      toIsMixed,
+      firstDate,
+      lastDate,
+      commodityMnemonic: list[0].splits[0].commodityMnemonic,
+    });
+  }
+
+  return groups.sort((a, b) => b.transactions.length - a.transactions.length);
+}
+
+export default function BulkEditPage() {
+  const { data, isWritable, bulkEditTransactions } = useDashboard();
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [newDescription, setNewDescription] = useState("");
+  const [newFromGuid, setNewFromGuid] = useState("");
+  const [newToGuid, setNewToGuid] = useState("");
+  const [showPreview, setShowPreview] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const groups = useMemo(
+    () => (data ? buildGroups(data.ledgerTransactions) : []),
+    [data],
+  );
+
+  const accounts = useMemo(
+    () => (data ? flattenAccounts(data.accounts) : []),
+    [data],
+  );
+
+  const filteredGroups = useMemo(() => {
+    const q = searchQuery.trim().toLowerCase();
+    if (!q) return groups;
+    return groups.filter((g) => g.description.toLowerCase().includes(q));
+  }, [groups, searchQuery]);
+
+  const selected = useMemo(
+    () => groups.find((g) => g.key === selectedKey) ?? null,
+    [groups, selectedKey],
+  );
+
+  /**
+   * Accounts compatible with the selected group for account reassignment.
+   * Must share the same commodity as the group's transactions.
+   */
+  const compatibleAccounts = useMemo(() => {
+    if (!selected) return [];
+    return accounts.filter((a) => a.commodityMnemonic === selected.commodityMnemonic);
+  }, [accounts, selected]);
+
+  function handleSelectGroup(key: string) {
+    setSelectedKey(key);
+    const g = groups.find((x) => x.key === key);
+    setNewDescription(g?.description ?? "");
+    setNewFromGuid("");
+    setNewToGuid("");
+    setError(null);
+  }
+
+  function clearSelection() {
+    setSelectedKey(null);
+    setNewDescription("");
+    setNewFromGuid("");
+    setNewToGuid("");
+    setError(null);
+  }
+
+  const hasChanges = !!selected && (
+    (newDescription.trim() !== "" && newDescription !== selected.description) ||
+    newFromGuid !== "" ||
+    newToGuid !== ""
+  );
+
+  async function handleApply() {
+    if (!selected || !hasChanges) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await bulkEditTransactions({
+        transactionGuids: selected.transactions.map((t) => t.guid),
+        newDescription: newDescription !== selected.description ? newDescription : undefined,
+        newFromAccountGuid: newFromGuid || undefined,
+        newToAccountGuid: newToGuid || undefined,
+      });
+      setShowPreview(false);
+      clearSelection();
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!data) return null;
+
+  if (!isWritable) {
+    return (
+      <div className="mx-auto max-w-4xl space-y-4">
+        <BreadcrumbBar />
+        <Card>
+          <CardContent className="p-6 text-sm text-[#6F767E]">
+            Bulk edit requires the database to be open in editing mode. Click the
+            <span className="mx-1 font-medium text-[#3B6B8A]">Read-only</span>
+            button in the top bar to enable editing.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-4">
+      <BreadcrumbBar />
+
+      <header className="flex items-start gap-3">
+        <div className="mt-1 rounded-lg bg-[#3B6B8A]/10 p-2 text-[#3B6B8A]">
+          <Layers className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-[#1A1D1F]">Bulk edit transactions</h1>
+          <p className="mt-1 text-sm text-[#6F767E]">
+            Groups simple 2-posting transactions by exact description.
+            Multi-split transactions are not shown. Changes commit atomically.
+          </p>
+        </div>
+      </header>
+
+      <div className="grid gap-4 lg:grid-cols-[1fr_380px]">
+        {/* ── Groups list ────────────────────────────────────────── */}
+        <Card>
+          <CardContent className="p-4">
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <div className="relative flex-1">
+                <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-[#9A9FA5]" />
+                <input
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  placeholder="Search descriptions..."
+                  className="w-full rounded-lg border border-[#EFEFEF] bg-white py-1.5 pl-8 pr-3 text-sm outline-none focus:border-[#3B6B8A]"
+                />
+              </div>
+              <span className="text-xs text-[#9A9FA5]">
+                {filteredGroups.length} group{filteredGroups.length === 1 ? "" : "s"}
+              </span>
+            </div>
+
+            {filteredGroups.length === 0 ? (
+              <p className="px-2 py-8 text-center text-sm text-[#9A9FA5]">
+                No matching groups found.
+              </p>
+            ) : (
+              <div className="max-h-[70vh] overflow-y-auto">
+                <table className="w-full text-sm">
+                  <thead className="sticky top-0 bg-white text-xs text-[#9A9FA5]">
+                    <tr>
+                      <th className="py-2 pr-2 text-left font-normal">Description</th>
+                      <th className="py-2 pr-2 text-right font-normal">Count</th>
+                      <th className="py-2 pr-2 text-right font-normal">Total</th>
+                      <th className="py-2 pr-2 text-left font-normal">Transfer</th>
+                      <th className="py-2 text-left font-normal">Dates</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {filteredGroups.map((g) => {
+                      const isActive = g.key === selectedKey;
+                      return (
+                        <tr
+                          key={g.key}
+                          onClick={() => handleSelectGroup(g.key)}
+                          className={`cursor-pointer border-t border-[#EFEFEF] transition-colors ${
+                            isActive ? "bg-[#3B6B8A]/5" : "hover:bg-[#F4F5F7]"
+                          }`}
+                        >
+                          <td className="py-2 pr-2 font-medium text-[#1A1D1F]">
+                            {g.description}
+                          </td>
+                          <td className="py-2 pr-2 text-right text-[#6F767E]">
+                            {g.transactions.length}
+                          </td>
+                          <td className="py-2 pr-2 text-right font-mono text-xs text-[#6F767E]">
+                            {formatCurrency(g.totalValue, g.currencyMnemonic)}
+                          </td>
+                          <td className="py-2 pr-2 text-xs text-[#6F767E]">
+                            {g.fromIsMixed ? <em className="text-[#9A9FA5]">(mixed)</em> : g.dominantFromName}
+                            <ArrowRight className="mx-1 inline h-3 w-3 text-[#9A9FA5]" />
+                            {g.toIsMixed ? <em className="text-[#9A9FA5]">(mixed)</em> : g.dominantToName}
+                          </td>
+                          <td className="py-2 text-xs text-[#9A9FA5]">
+                            {g.firstDate === g.lastDate ? g.firstDate : `${g.firstDate} → ${g.lastDate}`}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* ── Edit panel ─────────────────────────────────────────── */}
+        <Card>
+          <CardContent className="p-4">
+            {selected ? (
+              <>
+                <div className="mb-3 flex items-start justify-between gap-2">
+                  <div>
+                    <p className="text-xs uppercase tracking-wide text-[#9A9FA5]">
+                      Editing {selected.transactions.length} transaction
+                      {selected.transactions.length === 1 ? "" : "s"}
+                    </p>
+                    <p className="mt-0.5 text-sm font-medium text-[#1A1D1F]">
+                      {selected.description}
+                    </p>
+                  </div>
+                  <button
+                    onClick={clearSelection}
+                    title="Clear selection"
+                    className="rounded p-1 text-[#9A9FA5] hover:bg-[#F4F5F7] hover:text-[#6F767E]"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+
+                <div className="space-y-3">
+                  <FieldLabel>New description</FieldLabel>
+                  <input
+                    value={newDescription}
+                    onChange={(e) => setNewDescription(e.target.value)}
+                    className="w-full rounded-lg border border-[#EFEFEF] bg-white px-3 py-1.5 text-sm outline-none focus:border-[#3B6B8A]"
+                  />
+
+                  <FieldLabel>Reassign &ldquo;from&rdquo; account (optional)</FieldLabel>
+                  <AccountSelect
+                    accounts={compatibleAccounts}
+                    value={newFromGuid}
+                    onChange={setNewFromGuid}
+                    placeholder="Leave as-is"
+                  />
+
+                  <FieldLabel>Reassign &ldquo;to&rdquo; account (optional)</FieldLabel>
+                  <AccountSelect
+                    accounts={compatibleAccounts}
+                    value={newToGuid}
+                    onChange={setNewToGuid}
+                    placeholder="Leave as-is"
+                  />
+
+                  {error && (
+                    <p className="rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+                      {error}
+                    </p>
+                  )}
+
+                  <button
+                    onClick={() => setShowPreview(true)}
+                    disabled={!hasChanges}
+                    className="w-full rounded-lg bg-[#3B6B8A] px-3 py-2 text-sm font-medium text-white transition-colors hover:bg-[#2F5770] disabled:cursor-not-allowed disabled:bg-[#9A9FA5]"
+                  >
+                    Preview changes
+                  </button>
+                </div>
+              </>
+            ) : (
+              <p className="px-2 py-8 text-center text-sm text-[#9A9FA5]">
+                Select a group from the list to start editing.
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {showPreview && selected && (
+        <BulkEditPreview
+          group={selected}
+          accounts={accounts}
+          newDescription={newDescription !== selected.description ? newDescription : undefined}
+          newFromGuid={newFromGuid || undefined}
+          newToGuid={newToGuid || undefined}
+          submitting={submitting}
+          onCancel={() => setShowPreview(false)}
+          onConfirm={handleApply}
+        />
+      )}
+    </div>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────
+
+function BreadcrumbBar() {
+  return (
+    <nav className="flex items-center gap-2 text-xs text-[#9A9FA5]">
+      <Link
+        href="/special-functions"
+        className="inline-flex items-center gap-1 hover:text-[#6F767E]"
+      >
+        <ArrowLeft className="h-3 w-3" />
+        Special functions
+      </Link>
+    </nav>
+  );
+}
+
+function FieldLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <label className="mt-2 block text-xs font-medium uppercase tracking-wide text-[#9A9FA5]">
+      {children}
+    </label>
+  );
+}
+
+function AccountSelect({
+  accounts,
+  value,
+  onChange,
+  placeholder,
+}: {
+  accounts: AccountNode[];
+  value: string;
+  onChange: (v: string) => void;
+  placeholder: string;
+}) {
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded-lg border border-[#EFEFEF] bg-white px-3 py-1.5 text-sm outline-none focus:border-[#3B6B8A]"
+    >
+      <option value="">{placeholder}</option>
+      {accounts.map((a) => (
+        <option key={a.guid} value={a.guid}>
+          {a.fullPath}
+        </option>
+      ))}
+    </select>
+  );
+}
+
+/**
+ * Read-only preview modal. Lists every transaction that would be affected,
+ * showing the old → new value for each field the user chose to change.
+ */
+function BulkEditPreview({
+  group,
+  accounts,
+  newDescription,
+  newFromGuid,
+  newToGuid,
+  submitting,
+  onCancel,
+  onConfirm,
+}: {
+  group: TransactionGroup;
+  accounts: AccountNode[];
+  newDescription?: string;
+  newFromGuid?: string;
+  newToGuid?: string;
+  submitting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  const fromName = newFromGuid ? accounts.find((a) => a.guid === newFromGuid)?.fullPath ?? "?" : undefined;
+  const toName = newToGuid ? accounts.find((a) => a.guid === newToGuid)?.fullPath ?? "?" : undefined;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/20 p-4">
+      <div className="flex max-h-[85vh] w-full max-w-3xl flex-col overflow-hidden rounded-xl bg-white shadow-xl">
+        <header className="flex items-center justify-between border-b border-[#EFEFEF] px-5 py-3">
+          <div>
+            <h2 className="text-base font-semibold text-[#1A1D1F]">
+              Preview bulk edit
+            </h2>
+            <p className="mt-0.5 text-xs text-[#9A9FA5]">
+              {group.transactions.length} transaction{group.transactions.length === 1 ? "" : "s"} will be updated atomically.
+            </p>
+          </div>
+          <button
+            onClick={onCancel}
+            className="rounded p-1 text-[#9A9FA5] hover:bg-[#F4F5F7] hover:text-[#6F767E]"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </header>
+
+        <div className="overflow-y-auto px-5 py-4">
+          <dl className="mb-4 space-y-1 text-sm">
+            {newDescription !== undefined && (
+              <ChangeRow label="Description">
+                <span className="text-[#9A9FA5] line-through">{group.description}</span>
+                <ArrowRight className="mx-2 inline h-3 w-3 text-[#9A9FA5]" />
+                <span className="font-medium text-[#1A1D1F]">{newDescription}</span>
+              </ChangeRow>
+            )}
+            {fromName && (
+              <ChangeRow label='"From" account'>
+                <span className="font-medium text-[#1A1D1F]">{fromName}</span>
+                <span className="ml-2 text-xs text-[#9A9FA5]">
+                  (applied to the negative-value split on each transaction)
+                </span>
+              </ChangeRow>
+            )}
+            {toName && (
+              <ChangeRow label='"To" account'>
+                <span className="font-medium text-[#1A1D1F]">{toName}</span>
+                <span className="ml-2 text-xs text-[#9A9FA5]">
+                  (applied to the positive-value split on each transaction)
+                </span>
+              </ChangeRow>
+            )}
+          </dl>
+
+          <div className="rounded-lg border border-[#EFEFEF]">
+            <table className="w-full text-xs">
+              <thead className="bg-[#F4F5F7] text-[#9A9FA5]">
+                <tr>
+                  <th className="px-3 py-2 text-left font-normal">Date</th>
+                  <th className="px-3 py-2 text-left font-normal">Description</th>
+                  <th className="px-3 py-2 text-right font-normal">Amount</th>
+                  <th className="px-3 py-2 text-left font-normal">Transfer</th>
+                </tr>
+              </thead>
+              <tbody>
+                {group.transactions.map((tx) => {
+                  const to = tx.splits.find((s) => s.amount > 0);
+                  const from = tx.splits.find((s) => s.amount < 0);
+                  return (
+                    <tr key={tx.guid} className="border-t border-[#EFEFEF]">
+                      <td className="px-3 py-1.5 text-[#6F767E]">{tx.date}</td>
+                      <td className="px-3 py-1.5 text-[#6F767E]">{tx.description}</td>
+                      <td className="px-3 py-1.5 text-right font-mono text-[#6F767E]">
+                        {to ? formatCurrency(to.amount, to.commodityMnemonic) : "—"}
+                      </td>
+                      <td className="px-3 py-1.5 text-[#6F767E]">
+                        {from?.accountFullPath ?? "—"}
+                        <ArrowRight className="mx-1 inline h-3 w-3 text-[#9A9FA5]" />
+                        {to?.accountFullPath ?? "—"}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <footer className="flex items-center justify-end gap-2 border-t border-[#EFEFEF] px-5 py-3">
+          <button
+            onClick={onCancel}
+            disabled={submitting}
+            className="rounded-lg px-3 py-1.5 text-sm text-[#6F767E] hover:bg-[#F4F5F7]"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={submitting}
+            className="rounded-lg bg-[#3B6B8A] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#2F5770] disabled:bg-[#9A9FA5]"
+          >
+            {submitting ? "Applying..." : "Apply bulk edit"}
+          </button>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function ChangeRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <dt className="w-32 shrink-0 text-xs uppercase tracking-wide text-[#9A9FA5]">{label}</dt>
+      <dd className="text-sm">{children}</dd>
+    </div>
+  );
+}

--- a/app/src/app/(dashboard)/special-functions/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/page.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Wand2, Layers } from "lucide-react";
+
+/**
+ * Index for the "Special functions" area: a home for experimental or
+ * narrowly-scoped power tools that don't yet have a natural place in the
+ * main app shell. Bulk edit lives here until a better home emerges.
+ */
+export default function SpecialFunctionsPage() {
+  return (
+    <div className="mx-auto max-w-4xl space-y-6">
+      <header className="flex items-start gap-3">
+        <div className="mt-1 rounded-lg bg-[#6C9B8B]/10 p-2 text-[#6C9B8B]">
+          <Wand2 className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-[#1A1D1F]">Special functions</h1>
+          <p className="mt-1 text-sm text-[#6F767E]">
+            Power tools for cleaning up imported books and performing operations that
+            don&apos;t fit into the normal ledger flow.
+          </p>
+        </div>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Link href="/special-functions/bulk-edit" className="group">
+          <Card className="h-full transition-shadow hover:shadow-md">
+            <CardContent className="p-5">
+              <div className="flex items-start gap-3">
+                <div className="rounded-lg bg-[#3B6B8A]/10 p-2 text-[#3B6B8A]">
+                  <Layers className="h-5 w-5" />
+                </div>
+                <div>
+                  <h2 className="text-base font-semibold text-[#1A1D1F] group-hover:text-[#3B6B8A]">
+                    Bulk edit transactions
+                  </h2>
+                  <p className="mt-1 text-sm text-[#6F767E]">
+                    Group simple (2-posting) transactions by description and rename or
+                    reassign accounts across the whole group in one step. Useful for
+                    cleaning up auto-imported data.
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/dashboard/sidebar.tsx
+++ b/app/src/components/dashboard/sidebar.tsx
@@ -10,6 +10,7 @@ import {
   Banknote,
   LogOut,
   Download,
+  Wand2,
 } from "lucide-react";
 import { useDashboard } from "@/lib/dashboard-context";
 
@@ -19,6 +20,7 @@ const mainNav = [
   { icon: Receipt, label: "Income / Expenses", href: "/income-expenses" },
   { icon: Banknote, label: "Cash Flow", href: "/cash-flow" },
   { icon: TrendingUp, label: "Investment", href: "/investment" },
+  { icon: Wand2, label: "Special functions", href: "/special-functions" },
 ];
 
 

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { DashboardData } from "@/lib/types/gnucash";
 import { GnuCashWorkerClient } from "@/lib/gnucash/worker/client";
-import type { CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "@/lib/gnucash/worker/messages";
+import type { CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "@/lib/gnucash/worker/messages";
 import { generateDemoData } from "@/lib/demo-data";
 
 const STORAGE_KEY = "gnucash-dashboard-data";
@@ -33,6 +33,7 @@ interface DashboardContextType {
   createTransaction: (payload: CreateTransactionPayload) => Promise<void>;
   deleteTransaction: (payload: DeleteTransactionPayload) => Promise<void>;
   editTransaction: (payload: EditTransactionPayload) => Promise<void>;
+  bulkEditTransactions: (payload: BulkEditTransactionsPayload) => Promise<void>;
   createAccount: (payload: CreateAccountPayload) => Promise<void>;
   updateAccount: (payload: UpdateAccountPayload) => Promise<void>;
   deleteAccountWithReallocation: (payload: DeleteAccountPayload) => Promise<void>;
@@ -220,6 +221,14 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setData(dashboardData);
   }
 
+  async function bulkEditTransactionsFn(payload: BulkEditTransactionsPayload) {
+    if (!isWritable) throw new Error("Database is not open in read-write mode");
+
+    const client = getClient();
+    const dashboardData = await client.bulkEditTransactions(payload);
+    setData(dashboardData);
+  }
+
   async function createAccountFn(payload: CreateAccountPayload) {
     if (!isWritable) throw new Error("Database is not open in read-write mode");
     const client = getClient();
@@ -282,7 +291,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
   return (
     <DashboardContext.Provider
-      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, toggleWritable, uploadFile, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, exportFile, setCurrency: setCurrencyFn }}
+      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, toggleWritable, uploadFile, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, exportFile, setCurrency: setCurrencyFn }}
     >
       {children}
     </DashboardContext.Provider>

--- a/app/src/lib/gnucash/__tests__/engine/operations.test.ts
+++ b/app/src/lib/gnucash/__tests__/engine/operations.test.ts
@@ -14,6 +14,7 @@ import {
   deleteAccount,
 } from "../../engine/operations/account-ops";
 import { addPrice, deletePrice } from "../../engine/operations/price-ops";
+import { bulkEditTransactions } from "../../engine/operations/bulk-ops";
 import {
   createLot,
   assignSplitToLot,
@@ -407,5 +408,188 @@ describe("lot-ops", () => {
 
     const lotRow = db.prepare(`SELECT is_closed FROM lots WHERE guid = ?`).get(lot.lotGuid) as { is_closed: number };
     expect(lotRow.is_closed).toBe(1);
+  });
+});
+
+// ── Bulk transaction operations ─────────────────────────────────
+
+describe("bulk-ops", () => {
+  const GBP = "gbp00000000000000000000000000001";
+  const BANK = "bank0000000000000000000000000001";
+  const GROCERIES = "exp00000000000000000000000000001";
+  const ENTERTAINMENT = "exp00000000000000000000000000002";
+  const SAVINGS = "bank0000000000000000000000000002";
+  const AAPL_ACCOUNT = "stck0000000000000000000000000001";
+
+  function seedExtraAccounts() {
+    db.run(
+      `INSERT INTO accounts (guid, name, account_type, commodity_guid, parent_guid, placeholder) VALUES (?, ?, ?, ?, ?, ?)`,
+      ENTERTAINMENT, "Entertainment", "EXPENSE", GBP, "root0000000000000000000000000001", 0,
+    );
+    db.run(
+      `INSERT INTO accounts (guid, name, account_type, commodity_guid, parent_guid, placeholder) VALUES (?, ?, ?, ?, ?, ?)`,
+      SAVINGS, "Savings Account", "BANK", GBP, "root0000000000000000000000000001", 0,
+    );
+  }
+
+  function createGbpTx(desc: string, expenseGuid = GROCERIES, bankGuid = BANK): string {
+    const result = new TransactionBuilder(db, ctx)
+      .currency(GBP)
+      .postDate(new Date(2025, 0, 15))
+      .description(desc)
+      .addSimpleSplit(expenseGuid, new GncNumeric(4550, 100))
+      .addSimpleSplit(bankGuid, new GncNumeric(-4550, 100))
+      .commit();
+    return result.transactionGuid;
+  }
+
+  it("renames description across all transactions in a group", () => {
+    const a = createGbpTx("TESCO STORES 4412");
+    const b = createGbpTx("TESCO STORES 4412");
+    const c = createGbpTx("TESCO STORES 4412");
+
+    const result = bulkEditTransactions(db, {
+      transactionGuids: [a, b, c],
+      newDescription: "Tesco",
+    });
+
+    expect(result.descriptionsUpdated).toBe(3);
+    const rows = db.prepare(
+      `SELECT description FROM transactions WHERE guid IN (?, ?, ?)`,
+    ).all(a, b, c) as { description: string }[];
+    expect(rows.every((r) => r.description === "Tesco")).toBe(true);
+  });
+
+  it("reassigns the 'from' (source) account on all transactions", () => {
+    seedExtraAccounts();
+    const a = createGbpTx("Lunch");
+    const b = createGbpTx("Lunch");
+
+    bulkEditTransactions(db, {
+      transactionGuids: [a, b],
+      newFromAccountGuid: SAVINGS,
+    });
+
+    // The negative-value split on each tx should now point at SAVINGS
+    const fromSplits = db.prepare(
+      `SELECT account_guid FROM splits WHERE tx_guid IN (?, ?) AND value_num < 0`,
+    ).all(a, b) as { account_guid: string }[];
+    expect(fromSplits).toHaveLength(2);
+    expect(fromSplits.every((s) => s.account_guid === SAVINGS)).toBe(true);
+
+    // The positive-value (destination) split should still point at GROCERIES
+    const toSplits = db.prepare(
+      `SELECT account_guid FROM splits WHERE tx_guid IN (?, ?) AND value_num > 0`,
+    ).all(a, b) as { account_guid: string }[];
+    expect(toSplits.every((s) => s.account_guid === GROCERIES)).toBe(true);
+  });
+
+  it("reassigns the 'to' (destination) account on all transactions", () => {
+    seedExtraAccounts();
+    const a = createGbpTx("Cinema");
+    const b = createGbpTx("Cinema");
+
+    bulkEditTransactions(db, {
+      transactionGuids: [a, b],
+      newToAccountGuid: ENTERTAINMENT,
+    });
+
+    const toSplits = db.prepare(
+      `SELECT account_guid FROM splits WHERE tx_guid IN (?, ?) AND value_num > 0`,
+    ).all(a, b) as { account_guid: string }[];
+    expect(toSplits.every((s) => s.account_guid === ENTERTAINMENT)).toBe(true);
+
+    // The source split should still point at BANK
+    const fromSplits = db.prepare(
+      `SELECT account_guid FROM splits WHERE tx_guid IN (?, ?) AND value_num < 0`,
+    ).all(a, b) as { account_guid: string }[];
+    expect(fromSplits.every((s) => s.account_guid === BANK)).toBe(true);
+  });
+
+  it("rolls back and throws when a target account has mismatched commodity", () => {
+    const a = createGbpTx("Coffee");
+    const b = createGbpTx("Coffee");
+    const originalDescription = "Coffee";
+
+    // AAPL_ACCOUNT has commodity AAPL, not GBP — should refuse the batch
+    expect(() =>
+      bulkEditTransactions(db, {
+        transactionGuids: [a, b],
+        newDescription: "Starbucks",
+        newToAccountGuid: AAPL_ACCOUNT,
+      }),
+    ).toThrow(/commodity does not match/i);
+
+    // Nothing should have changed because the whole batch rolls back
+    const rows = db.prepare(
+      `SELECT description FROM transactions WHERE guid IN (?, ?)`,
+    ).all(a, b) as { description: string }[];
+    expect(rows.every((r) => r.description === originalDescription)).toBe(true);
+  });
+
+  it("rolls back and throws when any transaction has more than 2 splits", () => {
+    // Create a simple 2-split transaction
+    const simple = createGbpTx("Snack");
+
+    // Create a 3-split transaction (one bank, two expense categories)
+    const multi = new TransactionBuilder(db, ctx)
+      .currency(GBP)
+      .postDate(new Date(2025, 1, 3))
+      .description("Big shop")
+      .addSimpleSplit(GROCERIES, new GncNumeric(3000, 100))
+      .addSimpleSplit(GROCERIES, new GncNumeric(2000, 100))
+      .addSimpleSplit(BANK, new GncNumeric(-5000, 100))
+      .commit()
+      .transactionGuid;
+
+    expect(() =>
+      bulkEditTransactions(db, {
+        transactionGuids: [simple, multi],
+        newDescription: "Anything",
+      }),
+    ).toThrow(/requires exactly 2/);
+
+    // Nothing changed — both descriptions are as originally created
+    const rows = db.prepare(
+      `SELECT description FROM transactions WHERE guid IN (?, ?) ORDER BY description`,
+    ).all(simple, multi) as { description: string }[];
+    expect(rows.map((r) => r.description).sort()).toEqual(["Big shop", "Snack"]);
+  });
+
+  it("rejects empty input and no-op input", () => {
+    expect(() => bulkEditTransactions(db, { transactionGuids: [] })).toThrow(/empty/);
+    const a = createGbpTx("x");
+    expect(() => bulkEditTransactions(db, { transactionGuids: [a] })).toThrow(/no changes/);
+  });
+
+  it("applies rename and both account reassignments in one call", () => {
+    seedExtraAccounts();
+    const a = createGbpTx("AMZN PURCHASE");
+    const b = createGbpTx("AMZN PURCHASE");
+
+    const result = bulkEditTransactions(db, {
+      transactionGuids: [a, b],
+      newDescription: "Amazon",
+      newFromAccountGuid: SAVINGS,
+      newToAccountGuid: ENTERTAINMENT,
+    });
+
+    expect(result.descriptionsUpdated).toBe(2);
+    expect(result.fromSplitsUpdated).toBe(2);
+    expect(result.toSplitsUpdated).toBe(2);
+
+    const descRows = db.prepare(
+      `SELECT description FROM transactions WHERE guid IN (?, ?)`,
+    ).all(a, b) as { description: string }[];
+    expect(descRows.every((r) => r.description === "Amazon")).toBe(true);
+
+    const splits = db.prepare(
+      `SELECT tx_guid, account_guid, value_num FROM splits WHERE tx_guid IN (?, ?)`,
+    ).all(a, b) as { tx_guid: string; account_guid: string; value_num: number }[];
+
+    for (const s of splits) {
+      if (s.value_num < 0) expect(s.account_guid).toBe(SAVINGS);
+      else expect(s.account_guid).toBe(ENTERTAINMENT);
+    }
   });
 });

--- a/app/src/lib/gnucash/engine/operations/bulk-ops.ts
+++ b/app/src/lib/gnucash/engine/operations/bulk-ops.ts
@@ -1,0 +1,185 @@
+/**
+ * Bulk transaction operations.
+ *
+ * Apply the same description rename and/or account reassignment across many
+ * simple (single-split, i.e. 2-posting) transactions in one atomic DB write.
+ * Restricted to 2-posting transactions so the "from" and "to" legs are
+ * unambiguous: the negative-value split is the source, the positive-value
+ * split is the destination.
+ */
+
+import type { WritableDbAdapter } from "../db/writable-adapter";
+
+export interface BulkEditTransactionsInput {
+  /** GUIDs of the transactions to edit. */
+  transactionGuids: string[];
+  /** If set, every transaction's description is replaced with this value. */
+  newDescription?: string;
+  /** If set, the negative-value (source) split moves to this account. */
+  newFromAccountGuid?: string;
+  /** If set, the positive-value (destination) split moves to this account. */
+  newToAccountGuid?: string;
+}
+
+export interface BulkEditTransactionsResult {
+  /** Number of transactions whose description was updated. */
+  descriptionsUpdated: number;
+  /** Number of source (from) splits reassigned. */
+  fromSplitsUpdated: number;
+  /** Number of destination (to) splits reassigned. */
+  toSplitsUpdated: number;
+}
+
+/**
+ * Apply a bulk edit to a set of single-split transactions.
+ *
+ * Validation is strict: if any transaction fails a precondition the whole
+ * batch rolls back. Preconditions:
+ *   - transactionGuids is non-empty
+ *   - at least one of newDescription / newFromAccountGuid / newToAccountGuid is set
+ *   - every referenced transaction exists and has exactly 2 splits
+ *   - no split in any referenced transaction is reconciled
+ *   - any target account exists and its commodity matches the transaction's currency
+ */
+export function bulkEditTransactions(
+  db: WritableDbAdapter,
+  input: BulkEditTransactionsInput,
+): BulkEditTransactionsResult {
+  const { transactionGuids, newDescription, newFromAccountGuid, newToAccountGuid } = input;
+
+  if (transactionGuids.length === 0) {
+    throw new Error("bulkEditTransactions: transactionGuids is empty");
+  }
+  if (
+    newDescription === undefined &&
+    newFromAccountGuid === undefined &&
+    newToAccountGuid === undefined
+  ) {
+    throw new Error("bulkEditTransactions: no changes requested");
+  }
+
+  return db.transaction(() => {
+    // 1. Validate every referenced transaction is a simple 2-split transaction
+    //    with no reconciled splits, and gather its currency for commodity checks.
+    const txRows = db
+      .prepare(
+        `SELECT t.guid AS tx_guid,
+                t.currency_guid AS currency_guid,
+                (SELECT COUNT(*) FROM splits s WHERE s.tx_guid = t.guid) AS split_count,
+                (SELECT COUNT(*) FROM splits s WHERE s.tx_guid = t.guid AND s.reconcile_state = 'y') AS reconciled_count
+         FROM transactions t
+         WHERE t.guid IN (${placeholders(transactionGuids.length)})`,
+      )
+      .all(...transactionGuids) as {
+        tx_guid: string;
+        currency_guid: string;
+        split_count: number;
+        reconciled_count: number;
+      }[];
+
+    if (txRows.length !== transactionGuids.length) {
+      const found = new Set(txRows.map((r) => r.tx_guid));
+      const missing = transactionGuids.filter((g) => !found.has(g));
+      throw new Error(
+        `bulkEditTransactions: ${missing.length} transaction(s) not found: ${missing.slice(0, 3).join(", ")}`,
+      );
+    }
+
+    for (const row of txRows) {
+      if (row.split_count !== 2) {
+        throw new Error(
+          `bulkEditTransactions: transaction ${row.tx_guid} has ${row.split_count} splits; bulk edit requires exactly 2`,
+        );
+      }
+      if (row.reconciled_count > 0) {
+        throw new Error(
+          `bulkEditTransactions: transaction ${row.tx_guid} has a reconciled split and cannot be edited`,
+        );
+      }
+    }
+
+    // 2. For any account reassignment, verify the target account exists and
+    //    that its commodity matches every affected transaction's currency.
+    if (newFromAccountGuid !== undefined) {
+      assertAccountMatchesCurrencies(db, newFromAccountGuid, txRows, "newFromAccountGuid");
+    }
+    if (newToAccountGuid !== undefined) {
+      assertAccountMatchesCurrencies(db, newToAccountGuid, txRows, "newToAccountGuid");
+    }
+
+    // 3. Apply the updates. All of these are pure SQL and safe to do in bulk
+    //    because we've already validated every precondition above.
+    let descriptionsUpdated = 0;
+    let fromSplitsUpdated = 0;
+    let toSplitsUpdated = 0;
+
+    if (newDescription !== undefined) {
+      const res = db.run(
+        `UPDATE transactions SET description = ? WHERE guid IN (${placeholders(transactionGuids.length)})`,
+        newDescription,
+        ...transactionGuids,
+      );
+      descriptionsUpdated = res.changes;
+    }
+
+    if (newFromAccountGuid !== undefined) {
+      // "From" = the split with negative value (money leaving the source account).
+      const res = db.run(
+        `UPDATE splits SET account_guid = ?
+         WHERE tx_guid IN (${placeholders(transactionGuids.length)})
+           AND value_num < 0`,
+        newFromAccountGuid,
+        ...transactionGuids,
+      );
+      fromSplitsUpdated = res.changes;
+    }
+
+    if (newToAccountGuid !== undefined) {
+      // "To" = the split with positive value (money arriving at the destination).
+      const res = db.run(
+        `UPDATE splits SET account_guid = ?
+         WHERE tx_guid IN (${placeholders(transactionGuids.length)})
+           AND value_num > 0`,
+        newToAccountGuid,
+        ...transactionGuids,
+      );
+      toSplitsUpdated = res.changes;
+    }
+
+    return { descriptionsUpdated, fromSplitsUpdated, toSplitsUpdated };
+  });
+}
+
+/**
+ * Build a comma-separated list of `?` placeholders of the given length for
+ * use with SQL IN clauses.
+ */
+function placeholders(n: number): string {
+  return new Array(n).fill("?").join(",");
+}
+
+/**
+ * Verify that `accountGuid` exists and its commodity matches the currency
+ * of every affected transaction. Throws with a descriptive message if not.
+ */
+function assertAccountMatchesCurrencies(
+  db: WritableDbAdapter,
+  accountGuid: string,
+  txRows: { tx_guid: string; currency_guid: string }[],
+  fieldName: string,
+): void {
+  const account = db
+    .prepare(`SELECT commodity_guid FROM accounts WHERE guid = ?`)
+    .get(accountGuid) as { commodity_guid: string } | undefined;
+
+  if (!account) {
+    throw new Error(`bulkEditTransactions: ${fieldName} account ${accountGuid} not found`);
+  }
+
+  const mismatches = txRows.filter((r) => r.currency_guid !== account.commodity_guid);
+  if (mismatches.length > 0) {
+    throw new Error(
+      `bulkEditTransactions: ${fieldName} commodity does not match ${mismatches.length} transaction(s); cross-currency reassignment is not supported`,
+    );
+  }
+}

--- a/app/src/lib/gnucash/worker/client.ts
+++ b/app/src/lib/gnucash/worker/client.ts
@@ -17,7 +17,7 @@ import type {
   BudgetData,
   DashboardData,
 } from "@/lib/types/gnucash";
-import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "./messages";
 import { parseGnuCashXml } from "../xml/parser";
 
 type PendingRequest = {
@@ -271,6 +271,14 @@ export class GnuCashWorkerClient {
    */
   async editTransaction(payload: EditTransactionPayload): Promise<DashboardData> {
     return this.mutate("editTransaction", payload);
+  }
+
+  /**
+   * Bulk edit: apply a rename and/or account reassignment across many
+   * single-split transactions atomically. Returns refreshed dashboard data.
+   */
+  async bulkEditTransactions(payload: BulkEditTransactionsPayload): Promise<DashboardData> {
+    return this.mutate("bulkEditTransactions", payload);
   }
 
   async createAccount(payload: CreateAccountPayload): Promise<DashboardData> {

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -26,12 +26,13 @@ import { GncNumeric } from "../engine/gnc-numeric";
 import type { WritableDbAdapter } from "../engine/db/writable-adapter";
 import type { DashboardData } from "@/lib/types/gnucash";
 import { deleteTransaction } from "../engine/operations/transaction-ops";
+import { bulkEditTransactions } from "../engine/operations/bulk-ops";
 import { AccountBuilder } from "../engine/builders/account-builder";
 import { updateAccount, deleteAccountWithReallocation } from "../engine/operations/account-ops";
 import { createCommodity } from "../engine/operations/commodity-ops";
 import { addPrice, deletePrice } from "../engine/operations/price-ops";
 import type { AccountType } from "../engine/types";
-import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "./messages";
 import type { GnuCashXmlData } from "../xml/types";
 import { GNUCASH_SCHEMA_DDL } from "../xml/schema";
 
@@ -491,6 +492,25 @@ function handleEditTransaction(payload: EditTransactionPayload): DashboardData {
   return getFullDashboardData();
 }
 
+/**
+ * Handle a bulkEditTransactions mutation. Applies rename and/or account
+ * reassignment across multiple single-split transactions atomically.
+ */
+function handleBulkEditTransactions(payload: BulkEditTransactionsPayload): DashboardData {
+  if (!ctx) throw new Error("No database loaded");
+  if (!writableAdapter) throw new Error("Database is not open in read-write mode");
+
+  bulkEditTransactions(writableAdapter, {
+    transactionGuids: payload.transactionGuids,
+    newDescription: payload.newDescription,
+    newFromAccountGuid: payload.newFromAccountGuid,
+    newToAccountGuid: payload.newToAccountGuid,
+  });
+
+  ctx = buildParseContext(writableAdapter);
+  return getFullDashboardData();
+}
+
 function handleCreateAccount(payload: CreateAccountPayload): DashboardData {
   if (!ctx) throw new Error("No database loaded");
   if (!writableAdapter) throw new Error("Database is not open in read-write mode");
@@ -693,6 +713,9 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
             break;
           case "editTransaction":
             data = handleEditTransaction(msg.payload as EditTransactionPayload);
+            break;
+          case "bulkEditTransactions":
+            data = handleBulkEditTransactions(msg.payload as BulkEditTransactionsPayload);
             break;
           case "createAccount":
             data = handleCreateAccount(msg.payload as CreateAccountPayload);

--- a/app/src/lib/gnucash/worker/messages.ts
+++ b/app/src/lib/gnucash/worker/messages.ts
@@ -35,6 +35,7 @@ export type DomainFunction =
 
 export type MutationAction =
   | "createTransaction" | "deleteTransaction" | "editTransaction"
+  | "bulkEditTransactions"
   | "createAccount" | "updateAccount" | "deleteAccount"
   | "createCommodity"
   | "addPrice" | "editPrice" | "deletePrice";
@@ -81,6 +82,22 @@ export interface EditTransactionPayload {
     quantityDenom: number;
     memo?: string;
   }[];
+}
+
+/**
+ * Payload for a grouped bulk edit across multiple single-split transactions.
+ * Applies any combination of: description rename, from-account reassign,
+ * to-account reassign. All changes commit atomically in one DB transaction.
+ */
+export interface BulkEditTransactionsPayload {
+  /** GUIDs of the transactions to edit. Must all be 2-split transactions. */
+  transactionGuids: string[];
+  /** If set, every transaction's description is replaced with this value. */
+  newDescription?: string;
+  /** If set, the negative-value (source) split is moved to this account. */
+  newFromAccountGuid?: string;
+  /** If set, the positive-value (destination) split is moved to this account. */
+  newToAccountGuid?: string;
 }
 
 export interface CreateAccountPayload {


### PR DESCRIPTION
## Summary

- New **Special functions** area in the sidebar, hosting a **Bulk edit transactions** tool for cleaning up imported books.
- Groups simple (single-split, 2-posting) transactions by exact description match. Multi-split transactions are intentionally excluded to keep "from"/"to" semantics unambiguous.
- Supports rename and/or source/destination account reassignment in any combination, applied atomically to every transaction in the group via one `WritableDbAdapter.transaction()`. Preview dialog before commit.

Closes #56.

## Implementation notes

- Direct-SQL engine operation (`bulk-ops.ts`) updates `description` on `transactions` and `account_guid` on the sign-split-identified legs, rather than going through delete-and-recreate. Pre-validation refuses any batch with: missing transactions, split count ≠ 2, reconciled splits, or target-account commodity mismatch.
- Grouping is client-side (JS `Map` keyed on exact `description`). Fine at realistic book sizes.
- Preview dialog follows the `delete-account-dialog` modal styling pattern — modals for read-only previews are permitted; the "no modals for entry" rule is respected because all edit inputs live in the side panel.
- Account selects for reassignment are filtered to accounts whose `commodityMnemonic` matches the group's currency, making cross-currency mistakes impossible in the UI.

## Test plan

- [x] `vitest run src/lib/gnucash/__tests__/engine/operations.test.ts` — 25/25 passing including 7 new bulk-ops cases:
  - rename across group
  - reassign "from" (source)
  - reassign "to" (destination)
  - rollback on currency mismatch
  - rollback on multi-split member
  - empty/no-op input rejection
  - combined rename + both reassignments
- [x] `tsc --noEmit` clean
- [x] Dev server compiles `/special-functions` and `/special-functions/bulk-edit` with 200 responses
- [x] Manual verification against real uploaded `.gnucash` data — rename, reassign-from, reassign-to, and combined edits all apply correctly; atomic rollback verified on a forced currency mismatch.

## Follow-ups

- Bigger than realistic books may want a SQL-side grouping query; holding off until there's a reason.
- No compaction/pagination on the group list yet (currently shows all groups ≥ 2 members).
- A "Special functions" area is intentionally a holding pen; bulk edit will migrate to a more natural home once one emerges.

## Dependencies

- Branch is based on main pre-#58. After #58 merges, rebase this branch onto the new main to pick up the `commodity_scu` account-creation fix.