### PR TITLE
Ignore .wrangler/ build cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ node_modules/
 out/
 build/
 dist/
+.wrangler/
 
 # Environment
 .env


### PR DESCRIPTION
## Summary

Adds `.wrangler/` to the root `.gitignore`. Cloudflare's wrangler CLI writes a local cache directory there during `pages dev` / `pages deploy` runs, which was showing up as an untracked directory in `git status` for anyone who has run the dev tooling.

## Test plan

- [x] `git status` on a repo that has `.wrangler/` present no longer lists it as untracked.