### PR TITLE
Fix transaction entry UX and net-worth penny discrepancy

### DIFF
--- a/app/src/app/(dashboard)/accounts/page.tsx
+++ b/app/src/app/(dashboard)/accounts/page.tsx
@@ -363,11 +363,18 @@ function AccountRow({
     <>
       <tr
         className={`group border-b border-[#EFEFEF] transition-colors cursor-pointer hover:bg-[#F9FAFB] ${isTopLevel ? "bg-[#FAFBFC]" : ""}`}
-        onClick={hasChildren ? () => onToggle(account.guid) : undefined}
+        onClick={() => {
+          if (hasChildren) {
+            onToggle(account.guid);
+          } else if (account.type !== "ROOT") {
+            // Leaf accounts open their ledger on a single click
+            onOpenRegister(account);
+          }
+        }}
         onDoubleClick={(e) => {
           e.stopPropagation();
-          // Don't open ROOT type accounts
-          if (account.type !== "ROOT") {
+          // Double-click on parent accounts still opens the register
+          if (account.type !== "ROOT" && hasChildren) {
             onOpenRegister(account);
           }
         }}

--- a/app/src/components/inline-entry/account-autocomplete.tsx
+++ b/app/src/components/inline-entry/account-autocomplete.tsx
@@ -193,23 +193,12 @@ export function AccountAutocomplete({
       }
 
       if (e.key === "Tab") {
+        // Tab commits the highlighted suggestion as-is, advancing focus to the
+        // next cell. Hierarchy drill-down is handled by the ":" key instead, so
+        // typing "hob" + Down + Tab correctly commits Expenses:Fun:Hobbies
+        // rather than collapsing to the highest-order parent.
         if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
-          const selected = suggestions[highlightIndex];
-          const remaining = selected.fullPath.slice(hierarchyPrefix.length);
-          const nextSegment = remaining.split(":")[0];
-          const fullAtThisLevel = hierarchyPrefix + nextSegment;
-          const hasChildren = accounts.some((a) => a.fullPath.startsWith(fullAtThisLevel + ":"));
-
-          if (hasChildren && !e.shiftKey) {
-            e.preventDefault();
-            descendInto(selected);
-            return;
-          } else {
-            const exactAccount = accounts.find((a) => a.fullPath === fullAtThisLevel) ?? selected;
-            selectAccount(exactAccount);
-            onKeyDown(e);
-            return;
-          }
+          selectAccount(suggestions[highlightIndex]);
         }
         onKeyDown(e);
         return;

--- a/app/src/lib/gnucash/domain/net-worth.ts
+++ b/app/src/lib/gnucash/domain/net-worth.ts
@@ -151,53 +151,71 @@ export function computeNetWorthSeries(ctx: ParseContext): MonthlyNetWorth[] {
 }
 
 /**
+ * Round to the nearest cent using half-away-from-zero, matching GnuCash's
+ * GNC_HOW_RND_ROUND_HALF_UP. JavaScript's Math.round rounds half toward +∞
+ * (Math.round(-0.5) === 0), which disagrees with GnuCash on negative values.
+ */
+function roundHalfUpCents(n: number): number {
+  return (Math.sign(n) || 1) * Math.round(Math.abs(n) * 100) / 100;
+}
+
+/**
  * Compute the current total net worth as a single number.
  * Sums all non-investment account balances (with FX conversion) plus
  * investment market values (shares × latest price). Excludes ROOT,
  * INCOME, EXPENSE, EQUITY, and TRADING account types.
+ *
+ * Groups by account (not commodity) and rounds each per-account converted
+ * balance to the base currency's smallest unit using half-up rounding,
+ * mirroring GnuCash's gnc_pricedb_convert_balance_latest_price pipeline.
+ * Without this, float accumulation + a single late rounding can disagree
+ * with GnuCash by one minor unit on multi-currency books.
  */
 export function computeCurrentNetWorth(ctx: ParseContext): number {
-  const { db, commodityMap, baseCurrencyGuid, fxRates } = ctx;
+  const { db, commodityMap, fxRates } = ctx;
 
   const nonInvRows = db
     .prepare(
       `SELECT
+        a.guid AS account_guid,
         a.commodity_guid,
         SUM(CAST(s.quantity_num AS REAL) / s.quantity_denom) AS balance
       FROM splits s
       JOIN accounts a ON s.account_guid = a.guid
       WHERE a.account_type NOT IN ('STOCK', 'MUTUAL', 'ROOT', 'INCOME', 'EXPENSE', 'EQUITY', 'TRADING')
         AND a.placeholder = 0
-      GROUP BY a.commodity_guid`
+      GROUP BY a.guid, a.commodity_guid`
     )
-    .all() as { commodity_guid: string; balance: number }[];
+    .all() as { account_guid: string; commodity_guid: string; balance: number }[];
 
   let nonInvTotal = 0;
   for (const row of nonInvRows) {
     const commodity = commodityMap.get(row.commodity_guid);
-    if (commodity?.namespace === "CURRENCY") {
-      nonInvTotal += fxRates.toBase(row.commodity_guid, row.balance);
-    } else {
-      nonInvTotal += row.balance;
-    }
+    const converted =
+      commodity?.namespace === "CURRENCY"
+        ? fxRates.toBase(row.commodity_guid, row.balance)
+        : row.balance;
+    nonInvTotal += roundHalfUpCents(converted);
   }
 
-  // Investment market value from context's latestPrices (already normalized to base)
+  // Investment market value: one row per STOCK/MUTUAL account so each
+  // shares × price product can be rounded to cents independently.
   const invRows = db
     .prepare(
-      `SELECT a.commodity_guid,
+      `SELECT a.guid AS account_guid, a.commodity_guid,
               SUM(CAST(s.quantity_num AS REAL) / s.quantity_denom) AS shares
        FROM splits s
        JOIN accounts a ON s.account_guid = a.guid
        WHERE a.account_type IN ('STOCK', 'MUTUAL')
-       GROUP BY a.commodity_guid
+       GROUP BY a.guid, a.commodity_guid
        HAVING shares != 0`
     )
-    .all() as { commodity_guid: string; shares: number }[];
+    .all() as { account_guid: string; commodity_guid: string; shares: number }[];
 
   let investmentTotal = 0;
   for (const row of invRows) {
-    investmentTotal += row.shares * (ctx.latestPrices.get(row.commodity_guid) ?? 0);
+    const marketValue = row.shares * (ctx.latestPrices.get(row.commodity_guid) ?? 0);
+    investmentTotal += roundHalfUpCents(marketValue);
   }
 
   return nonInvTotal + investmentTotal;


### PR DESCRIPTION
Closes #61.

## Summary
- **Single-click leaf accounts**: clicking a leaf row in the accounts tree now opens its ledger tab immediately. Parents still toggle expansion on click and open the register on double-click.
- **Autocomplete Tab key**: typing a partial account name, pressing Down to highlight a suggestion, and then Tab now commits the highlighted suggestion. Previously Tab descended into the next hierarchy segment, collapsing the selection to the nearest ancestor (e.g. `hob` + Down + Tab became `Expenses:` instead of `Expenses:Fun:Hobbies`). Hierarchy drill-down remains on the `:` key.
- **Net-worth rounding**: `computeCurrentNetWorth` now groups by account rather than commodity and rounds each converted per-account balance to the base currency's smallest unit with half-away-from-zero, mirroring GnuCash's `gnc_pricedb_convert_balance_latest_price` pipeline. This closes a 1p discrepancy vs GnuCash desktop on multi-currency books. A note on JS `Math.round` vs GnuCash `ROUND_HALF_UP` for negative amounts is in the helper's docstring.

## On item 3 of #61 (rounding direction)
Verified against GnuCash source (`libgnucash/engine/gnc-numeric.h` + `Split.cpp`): GnuCash uses `GNC_HOW_RND_ROUND_HALF_UP` for all split persistence, not floor/truncate. Our existing write-path rounding already matches this, so no rounding-mode change is warranted. The penny the user was seeing turned out to be in the net-worth report path, not split storage — fixed by the per-account rounding change above. Broader work on exact-numeric reporting is tracked separately in #62.

## Test plan
- [x] Click a leaf account → ledger opens in a new tab on the first click.
- [x] Click a parent account → expands/collapses; double-click still opens the register.
- [x] In a new transaction row, type `hob`, press Down to highlight `Expenses:Fun:Hobbies`, press Tab → cell is filled with `Expenses:Fun:Hobbies`.
- [x] Typing `exp:`, drill-down via `:` still works as before.
- [x] Dashboard net-worth total matches GnuCash desktop on a multi-currency book.
- [x] Typecheck passes.