### PR TITLE
Fix investment price calculator (#66) + flag orphaned prices

### DIFF
--- a/app/src/components/inline-transaction-entry.tsx
+++ b/app/src/components/inline-transaction-entry.tsx
@@ -247,23 +247,68 @@ export function InlineTransactionEntry({ account, transactions, colSpan, editing
     return { shares: s, price: p, value: v };
   }
 
-  function handleInvestmentFieldChange(field: "shares" | "price" | "value", val: string) {
-    const newS = field === "shares" ? val : shares;
-    const newP = field === "price" ? val : price;
-    const newV = field === "value" ? val : value;
+  /** Raw setter used by onChange — never triggers auto-compute or the recalc picker
+   *  while the user is still typing. See {@link commitInvestmentField}. */
+  function setInvestmentFieldRaw(field: "shares" | "price" | "value", val: string) {
+    if (field === "shares") setShares(val);
+    else if (field === "price") setPrice(val);
+    else setValue(val);
+    markDirty();
+  }
 
-    // If all three are already filled, ask which to recalculate
-    if (parseNum(shares) != null && parseNum(price) != null && parseNum(value) != null && parseNum(val) != null) {
-      pendingInvChange.current = { field, val };
-      setShowRecalcPicker(true);
-      return;
+  /** Commits an edit to an investment field (shares/price/value).
+   *
+   *  Called on blur, Tab, or Enter — never mid-typing. Behaviour mirrors GnuCash:
+   *   - If fewer than 2 fields are filled, do nothing special.
+   *   - If exactly 2 are filled, silently compute the missing third.
+   *   - If all 3 are filled and they reconcile (shares × price ≈ value), no-op.
+   *   - If all 3 are filled but don't reconcile, show the GnuCash-style recalc
+   *     picker asking which of the other two fields to recompute.
+   *
+   *  Returns true when the recalc picker was opened so the caller can skip
+   *  advancing focus or submitting the row.
+   */
+  function commitInvestmentField(field: "shares" | "price" | "value", rawVal: string): boolean {
+    const val = evalExpr(rawVal);
+    const s = field === "shares" ? val : shares;
+    const p = field === "price" ? val : price;
+    const v = field === "value" ? val : value;
+
+    // Canonicalise the edited field (e.g. "10+5" → "15") before any further work.
+    if (field === "shares" && val !== shares) setShares(val);
+    else if (field === "price" && val !== price) setPrice(val);
+    else if (field === "value" && val !== value) setValue(val);
+
+    const sN = parseNum(s);
+    const pN = parseNum(p);
+    const vN = parseNum(v);
+    const filled = (sN != null ? 1 : 0) + (pN != null ? 1 : 0) + (vN != null ? 1 : 0);
+
+    if (filled < 2) {
+      markDirty();
+      return false;
     }
 
-    const result = investmentAutoCompute(field, newS, newP, newV);
-    setShares(result.shares);
-    setPrice(result.price);
-    setValue(result.value);
-    markDirty();
+    if (filled === 2) {
+      const result = investmentAutoCompute(field, s, p, v);
+      setShares(result.shares);
+      setPrice(result.price);
+      setValue(result.value);
+      markDirty();
+      return false;
+    }
+
+    // All three filled — check reconciliation within a 1-cent tolerance.
+    if (sN != null && pN != null && vN != null) {
+      if (Math.abs(sN * pN - vN) < 0.01) {
+        markDirty();
+        return false;
+      }
+      pendingInvChange.current = { field, val };
+      setShowRecalcPicker(true);
+      return true;
+    }
+    return false;
   }
 
   function handleRecalcPick(recalcField: "shares" | "price" | "value") {
@@ -321,6 +366,24 @@ export function InlineTransactionEntry({ account, transactions, colSpan, editing
     }
     if (e.key === "Enter") {
       e.preventDefault();
+      // Investment fields defer auto-compute to commit time. Flush the edit
+      // (which may fill the missing third field or open the recalc picker)
+      // before attempting to submit.
+      if (
+        isInvestment &&
+        !isMultiSplit &&
+        (field === "shares" || field === "price" || field === "value")
+      ) {
+        const pickerShown = commitInvestmentField(
+          field,
+          (e.currentTarget as HTMLInputElement).value,
+        );
+        if (pickerShown) return;
+        // Defer so the setState queued by commitInvestmentField flushes before
+        // handleSubmit closes over the (stale) previous state.
+        setTimeout(() => submitRef.current(), 0);
+        return;
+      }
       submitRef.current();
       return;
     }
@@ -671,8 +734,8 @@ export function InlineTransactionEntry({ account, transactions, colSpan, editing
                 type="text"
                 inputMode="decimal"
                 value={shares}
-                onChange={(e) => handleInvestmentFieldChange("shares", e.target.value)}
-                onBlur={(e) => { const v = evalExpr(e.target.value); if (v !== shares) handleInvestmentFieldChange("shares", v); }}
+                onChange={(e) => setInvestmentFieldRaw("shares", e.target.value)}
+                onBlur={(e) => commitInvestmentField("shares", e.target.value)}
                 onFocus={(e) => e.target.select()}
                 onKeyDown={(e) => handleFieldKeyDown("shares", e)}
                 placeholder="Shares"
@@ -688,8 +751,8 @@ export function InlineTransactionEntry({ account, transactions, colSpan, editing
                 type="text"
                 inputMode="decimal"
                 value={price}
-                onChange={(e) => handleInvestmentFieldChange("price", e.target.value)}
-                onBlur={(e) => { const v = evalExpr(e.target.value); if (v !== price) handleInvestmentFieldChange("price", v); }}
+                onChange={(e) => setInvestmentFieldRaw("price", e.target.value)}
+                onBlur={(e) => commitInvestmentField("price", e.target.value)}
                 onFocus={(e) => e.target.select()}
                 onKeyDown={(e) => handleFieldKeyDown("price", e)}
                 placeholder="Price"
@@ -705,8 +768,8 @@ export function InlineTransactionEntry({ account, transactions, colSpan, editing
                 type="text"
                 inputMode="decimal"
                 value={value}
-                onChange={(e) => handleInvestmentFieldChange("value", e.target.value)}
-                onBlur={(e) => { const v = evalExpr(e.target.value); if (v !== value) handleInvestmentFieldChange("value", v); }}
+                onChange={(e) => setInvestmentFieldRaw("value", e.target.value)}
+                onBlur={(e) => commitInvestmentField("value", e.target.value)}
                 onFocus={(e) => e.target.select()}
                 onKeyDown={(e) => handleFieldKeyDown("value", e)}
                 placeholder="Value"

--- a/app/src/components/investment/prices-table.tsx
+++ b/app/src/components/investment/prices-table.tsx
@@ -7,21 +7,42 @@ import { useDashboard } from "@/lib/dashboard-context";
 import type { GnuCashPrice, CommodityInfo } from "@/lib/types/gnucash";
 import { Plus, Pencil, Trash2, AlertTriangle } from "lucide-react";
 
-/** Human-readable labels for price source fields */
+/** Human-readable labels for price source fields (non-transaction sources only). */
 const SOURCE_LABELS: Record<string, { label: string; color: string }> = {
   "user:price-editor": { label: "User", color: "bg-blue-50 text-blue-700" },
   "user:price": { label: "User", color: "bg-blue-50 text-blue-700" },
-  "user:xfer-dialog": { label: "Transaction", color: "bg-emerald-50 text-emerald-700" },
-  "transaction": { label: "Transaction", color: "bg-emerald-50 text-emerald-700" },
   "Finance::Quote": { label: "API", color: "bg-purple-50 text-purple-700" },
 };
 
-function getSourceBadge(source: string, type: string): { label: string; color: string } {
-  // Check source first, then type
-  if (SOURCE_LABELS[source]) return SOURCE_LABELS[source];
-  if (type === "transaction") return { label: "Transaction", color: "bg-emerald-50 text-emerald-700" };
-  if (source.startsWith("user:")) return { label: "User", color: "bg-blue-50 text-blue-700" };
-  return { label: source || type || "Unknown", color: "bg-gray-50 text-gray-600" };
+/** Badge describing a price's provenance. Transaction-linked prices are split
+ *  into "Linked" (originating tx still exists) and "Orphaned" (the tx has been
+ *  edited away or deleted), driven by the {@link orphaned} flag. */
+function getSourceBadge(
+  price: GnuCashPrice,
+  orphaned: boolean,
+): { label: string; color: string; title: string } {
+  if (isTransactionLinked(price)) {
+    return orphaned
+      ? {
+          label: "Orphaned",
+          color: "bg-amber-50 text-amber-700",
+          title:
+            "The transaction that created this price no longer exists or was changed. Safe to delete.",
+        }
+      : {
+          label: "Linked",
+          color: "bg-emerald-50 text-emerald-700",
+          title: "Auto-generated from a transaction. Editing here may drift from the source transaction.",
+        };
+  }
+  if (SOURCE_LABELS[price.source]) return { ...SOURCE_LABELS[price.source], title: price.source };
+  if (price.source.startsWith("user:"))
+    return { label: "User", color: "bg-blue-50 text-blue-700", title: price.source };
+  return {
+    label: price.source || price.type || "Unknown",
+    color: "bg-gray-50 text-gray-600",
+    title: price.source || price.type || "Unknown",
+  };
 }
 
 function formatPriceDate(dateStr: string): string {
@@ -47,6 +68,13 @@ export function PricesTable({ currency, selectedTicker }: Props) {
   const [editingPrice, setEditingPrice] = useState<GnuCashPrice | null>(null);
   const [deletingPrice, setDeletingPrice] = useState<GnuCashPrice | null>(null);
   const [error, setError] = useState<string | null>(null);
+
+  // Set of price guids flagged by the worker as orphaned (transaction-linked
+  // but with no matching transaction). Used to render the "Orphaned" badge.
+  const orphanSet = useMemo(
+    () => new Set(data?.orphanedPriceGuids ?? []),
+    [data?.orphanedPriceGuids],
+  );
 
   // Build commodity lookup
   const commodityMap = useMemo(() => {
@@ -147,7 +175,7 @@ export function PricesTable({ currency, selectedTicker }: Props) {
                   const commodity = commodityMap.get(p.commodity_guid);
                   const priceCurrency = commodityMap.get(p.currency_guid);
                   const priceValue = p.value_num / p.value_denom;
-                  const source = getSourceBadge(p.source, p.type);
+                  const source = getSourceBadge(p, orphanSet.has(p.guid));
 
                   return (
                     <tr key={p.guid} className="group border-b border-[#EFEFEF] hover:bg-[#F9FAFB] transition-colors">
@@ -163,7 +191,10 @@ export function PricesTable({ currency, selectedTicker }: Props) {
                         {formatAmount(priceValue, priceCurrency?.mnemonic ?? currency, 6)}
                       </td>
                       <td className="py-2 text-center">
-                        <span className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${source.color}`}>
+                        <span
+                          title={source.title}
+                          className={`inline-block rounded px-1.5 py-0.5 text-[10px] font-medium ${source.color}`}
+                        >
                           {source.label}
                         </span>
                       </td>
@@ -246,11 +277,19 @@ export function PricesTable({ currency, selectedTicker }: Props) {
             <p className="mt-2 text-xs text-[#6F767E]">
               Are you sure you want to delete this price entry? This cannot be undone.
             </p>
-            {isTransactionLinked(deletingPrice) && (
+            {isTransactionLinked(deletingPrice) && !orphanSet.has(deletingPrice.guid) && (
               <div className="mt-2 flex items-start gap-2 rounded-md bg-amber-50 border border-amber-200 px-3 py-2">
                 <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0 text-amber-600" />
                 <p className="text-[11px] text-amber-700">
-                  This price was generated from a transaction. Deleting it may affect portfolio valuations.
+                  This price is linked to a transaction. Deleting it may affect portfolio valuations.
+                </p>
+              </div>
+            )}
+            {orphanSet.has(deletingPrice.guid) && (
+              <div className="mt-2 flex items-start gap-2 rounded-md bg-emerald-50 border border-emerald-200 px-3 py-2">
+                <AlertTriangle className="h-3.5 w-3.5 mt-0.5 shrink-0 text-emerald-600" />
+                <p className="text-[11px] text-emerald-700">
+                  This price is orphaned — the originating transaction no longer exists. Safe to delete.
                 </p>
               </div>
             )}

--- a/app/src/lib/demo-data.ts
+++ b/app/src/lib/demo-data.ts
@@ -483,6 +483,7 @@ export function generateDemoData(): DashboardData {
     currencyFraction: 100,
     commodities: [],
     prices: [],
+    orphanedPriceGuids: [],
     availableCurrencies: [{ guid: "", mnemonic: "GBP", fullname: "British Pound Sterling" }],
     accounts,
     netWorthSeries,

--- a/app/src/lib/gnucash/domain/orphan-prices.ts
+++ b/app/src/lib/gnucash/domain/orphan-prices.ts
@@ -1,0 +1,108 @@
+/**
+ * Orphaned transaction-linked price detection.
+ *
+ * GnuCash optionally records an "implied price" when a stock buy/sell or
+ * FX transfer is entered (source = "user:xfer-dialog", type = "transaction").
+ * Those rows have no FK back to the transaction that created them, so if the
+ * originating transaction is later edited or deleted, the price is left behind
+ * as an orphan with no way to tell it apart from still-live ones.
+ *
+ * This module performs a best-effort heuristic match: for each transaction-
+ * linked price we look for any existing split whose (commodity, currency,
+ * post-date) line up and whose value/quantity ratio is within a small
+ * tolerance of the stored price. If no such split exists the price is flagged
+ * as orphaned.
+ *
+ * The result is only used to surface a badge and an opt-in cleanup button in
+ * the prices table — nothing is deleted automatically.
+ */
+
+import type { ParseContext } from "../context";
+import type { GnuCashPrice } from "@/lib/types/gnucash";
+
+/** Relative tolerance when matching a price against a split's value/quantity ratio. */
+const PRICE_MATCH_TOLERANCE = 0.005; // 0.5%
+
+/** A price row is considered transaction-linked if GnuCash tagged it as such. */
+export function isTransactionLinkedPrice(price: GnuCashPrice): boolean {
+  return price.source === "user:xfer-dialog" || price.type === "transaction";
+}
+
+/** Normalise a GnuCash timestamp ("YYYY-MM-DD HH:MM:SS") or ISO date to "YYYY-MM-DD". */
+function toDayKey(date: string): string {
+  return date.slice(0, 10);
+}
+
+interface SplitRatioRow {
+  post_date: string;
+  currency_guid: string;
+  account_guid: string;
+  value_num: number;
+  value_denom: number;
+  quantity_num: number;
+  quantity_denom: number;
+}
+
+/**
+ * Build the set of orphaned transaction-linked price GUIDs.
+ *
+ * An orphan is a price flagged as transaction-linked (per
+ * {@link isTransactionLinkedPrice}) for which no current split on the same
+ * day, commodity and currency has a value/quantity ratio within
+ * {@link PRICE_MATCH_TOLERANCE} of the stored price.
+ */
+export function computeOrphanedPriceGuids(ctx: ParseContext): Set<string> {
+  const linkedPrices = ctx.prices.filter(isTransactionLinkedPrice);
+  if (linkedPrices.length === 0) return new Set();
+
+  // Pull every split that could plausibly have produced an implied price —
+  // i.e. ones with a non-zero quantity. Joining transactions gives us the
+  // tx-level currency and post-date needed for the lookup key.
+  const rows = ctx.db
+    .prepare(
+      `SELECT t.post_date, t.currency_guid, s.account_guid,
+              s.value_num, s.value_denom, s.quantity_num, s.quantity_denom
+       FROM splits s
+       JOIN transactions t ON s.tx_guid = t.guid
+       WHERE s.quantity_num != 0`,
+    )
+    .all() as SplitRatioRow[];
+
+  // Bucket the split ratios by (commodity, currency, day) for O(1) matching.
+  const bucket = new Map<string, number[]>();
+  for (const row of rows) {
+    const account = ctx.accountMap.get(row.account_guid);
+    if (!account) continue;
+    // A split only implies a price when its account commodity differs from
+    // the transaction currency — otherwise value == quantity and there's no
+    // conversion to record.
+    if (account.commodity_guid === row.currency_guid) continue;
+    if (row.quantity_denom === 0 || row.value_denom === 0) continue;
+
+    const value = Math.abs(row.value_num / row.value_denom);
+    const quantity = Math.abs(row.quantity_num / row.quantity_denom);
+    if (quantity === 0 || value === 0) continue;
+
+    const ratio = value / quantity;
+    const key = `${account.commodity_guid}|${row.currency_guid}|${toDayKey(row.post_date)}`;
+    const list = bucket.get(key);
+    if (list) list.push(ratio);
+    else bucket.set(key, [ratio]);
+  }
+
+  const orphans = new Set<string>();
+  for (const price of linkedPrices) {
+    if (price.value_denom === 0) continue;
+    const priceValue = price.value_num / price.value_denom;
+    if (priceValue === 0) continue;
+
+    const key = `${price.commodity_guid}|${price.currency_guid}|${toDayKey(price.date)}`;
+    const ratios = bucket.get(key);
+    const matched = ratios?.some(
+      (r) => Math.abs(r - priceValue) / priceValue < PRICE_MATCH_TOLERANCE,
+    );
+    if (!matched) orphans.add(price.guid);
+  }
+
+  return orphans;
+}

--- a/app/src/lib/gnucash/index.ts
+++ b/app/src/lib/gnucash/index.ts
@@ -14,6 +14,7 @@ import { computeCashFlowBudgetData } from "./domain/cash-flow-budget";
 import { computeCashFlowByCategory } from "./domain/cash-flow-by-category";
 import { getUpcomingBills } from "./domain/bills";
 import { hasClosingTransactions } from "./domain/closing";
+import { computeOrphanedPriceGuids } from "./domain/orphan-prices";
 import { formatMonth } from "./shared/dates";
 
 export function parseGnuCashFile(filePath: string, overrideBaseCurrencyGuid?: string): DashboardData {
@@ -116,6 +117,7 @@ export function parseGnuCashFile(filePath: string, overrideBaseCurrencyGuid?: st
         fraction: c.fraction,
       })),
       prices: ctx.prices,
+      orphanedPriceGuids: Array.from(computeOrphanedPriceGuids(ctx)),
       availableCurrencies: ctx.availableCurrencies,
       hasClosingTransactions: hasClosing,
       cashFlowSeriesExcludingClosing,

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -25,6 +25,7 @@ import { TransactionBuilder } from "../engine/builders/transaction-builder";
 import { GncNumeric } from "../engine/gnc-numeric";
 import type { WritableDbAdapter } from "../engine/db/writable-adapter";
 import type { DashboardData } from "@/lib/types/gnucash";
+import { computeOrphanedPriceGuids } from "@/lib/gnucash/domain/orphan-prices";
 import { deleteTransaction } from "../engine/operations/transaction-ops";
 import { bulkEditTransactions } from "../engine/operations/bulk-ops";
 import { AccountBuilder } from "../engine/builders/account-builder";
@@ -339,6 +340,7 @@ function getFullDashboardData(): DashboardData {
       fraction: c.fraction,
     })),
     prices: ctx.prices,
+    orphanedPriceGuids: Array.from(computeOrphanedPriceGuids(ctx)),
     availableCurrencies: ctx.availableCurrencies,
     hasClosingTransactions: hasClosing,
     cashFlowSeriesExcludingClosing,

--- a/app/src/lib/types/gnucash.ts
+++ b/app/src/lib/types/gnucash.ts
@@ -451,6 +451,10 @@ export interface DashboardData {
   commodities: CommodityInfo[];
   /** All price entries from the prices table, ordered by date descending */
   prices: GnuCashPrice[];
+  /** GUIDs of transaction-linked prices whose originating transaction can no
+   *  longer be found (i.e. the tx was edited away or deleted). Used by the
+   *  prices table to render an "Orphaned" badge and offer bulk cleanup. */
+  orphanedPriceGuids: string[];
   /** Currencies available for the display currency selector (CURRENCY namespace only) */
   availableCurrencies: { guid: string; mnemonic: string; fullname: string }[];
   /** True if the file contains book-closing transactions (year-end entries that zero out income/expense) */


### PR DESCRIPTION
## Summary
- **Fixes #66** — investment row's price calculator no longer recomputes on every keystroke. Auto-compute now fires only on Tab/Enter/blur: fill any two of shares/price/value, commit the second field, and the third is silently filled. Editing a field in an already-reconciled row reopens the existing GnuCash-style "recalculate which?" picker.
- **Orphan price badges** — transaction-linked prices (`source=user:xfer-dialog` / `type=transaction`) whose originating transaction can no longer be found are now flagged as "Orphaned" in the Price Database. A new heuristic detector (`computeOrphanedPriceGuids`) matches each linked price against existing splits by commodity, currency, day, and value/quantity ratio. Delete dialog shows a green "safe to delete" note for orphans. No automatic cascade on tx edit/delete — this matches GnuCash desktop behaviour, just makes the resulting orphans visible.

Closes #66

## Test plan
- [ ] Buy an asset; type into the Shares field — the Price/Value fields no longer flicker mid-typing.
- [ ] Fill Shares and Price, Tab out — Value silently fills.
- [ ] Fill Shares and Value, Tab out — Price silently fills.
- [ ] With all three reconciling, change one field and Tab — the recalculate picker appears.
- [ ] Create a stock buy that generates an implied price, then delete the transaction — the price now shows an amber "Orphaned" badge in the Price Database.
- [ ] Deleting an orphaned price shows the green "safe to delete" note instead of the amber "may affect valuations" warning.