### PR TITLE
Add dark mode toggle to the dashboard

### DIFF
--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -8,6 +8,7 @@ import { PrivacyProvider, usePrivacy } from "@/lib/privacy-context";
 import { ClosingProvider, useClosing } from "@/lib/closing-context";
 import { FileUpload } from "@/components/upload/file-upload";
 import { Sidebar } from "@/components/dashboard/sidebar";
+import { ThemeToggle } from "@/components/dashboard/theme-toggle";
 
 function CurrencySelector() {
   const { data, setCurrency } = useDashboard();
@@ -28,14 +29,14 @@ function CurrencySelector() {
     <div className="relative" ref={ref}>
       <button
         onClick={() => setOpen((v) => !v)}
-        className="flex items-center gap-1 rounded-lg border border-[#EFEFEF] px-2.5 py-1.5 text-xs font-medium text-[#6F767E] transition-colors hover:bg-[#F4F5F7]"
+        className="flex items-center gap-1 rounded-lg border border-border px-2.5 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
         title="Change display currency"
       >
         {data.currency}
         <ChevronDown className="h-3 w-3" />
       </button>
       {open && (
-        <div className="absolute right-0 top-full z-50 mt-1 max-h-60 w-48 overflow-y-auto rounded-lg border border-[#EFEFEF] bg-white py-1 shadow-lg">
+        <div className="absolute right-0 top-full z-50 mt-1 max-h-60 w-48 overflow-y-auto rounded-lg border border-border bg-popover py-1 shadow-lg">
           {data.availableCurrencies.map((c) => (
             <button
               key={c.guid}
@@ -43,12 +44,12 @@ function CurrencySelector() {
                 setCurrency(c.guid);
                 setOpen(false);
               }}
-              className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-[#F4F5F7] ${
-                c.mnemonic === data.currency ? "font-semibold text-[#3B6B8A]" : "text-[#6F767E]"
+              className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors hover:bg-muted ${
+                c.mnemonic === data.currency ? "font-semibold text-[#3B6B8A] dark:text-[#6FA4C7]" : "text-muted-foreground"
               }`}
             >
               <span className="w-10 font-mono">{c.mnemonic}</span>
-              <span className="truncate text-[#9A9FA5]">{c.fullname}</span>
+              <span className="truncate text-muted-foreground/70">{c.fullname}</span>
             </button>
           ))}
         </div>
@@ -69,7 +70,7 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className={`flex h-screen bg-[#F4F5F7] ${hideValues ? "privacy-mode" : ""}`}>
+    <div className={`flex h-screen bg-muted ${hideValues ? "privacy-mode" : ""}`}>
       {/* Mobile overlay */}
       {sidebarOpen && (
         <div
@@ -94,11 +95,11 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
 
       <main className="flex flex-1 flex-col overflow-hidden">
         {/* Top bar */}
-        <header className="flex h-[68px] shrink-0 items-center justify-between border-b border-[#EFEFEF] bg-white px-4 sm:px-8">
+        <header className="flex h-[68px] shrink-0 items-center justify-between border-b border-border bg-card px-4 sm:px-8">
           <div className="flex items-center gap-3 -ml-6">
             <button
               onClick={() => setSidebarOpen(true)}
-              className="rounded-lg p-1.5 text-[#6F767E] transition-colors hover:bg-[#F4F5F7] md:hidden"
+              className="rounded-lg p-1.5 text-muted-foreground transition-colors hover:bg-muted md:hidden"
             >
               <Menu className="h-5 w-5" />
             </button>
@@ -114,7 +115,7 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
           <div className="flex items-center gap-2 sm:gap-3">
             {isXmlSource && data && (
               <span
-                className="flex items-center gap-1.5 rounded-lg border border-[#EFEFEF] px-3 py-1.5 text-xs font-medium text-[#9A9FA5]"
+                className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground"
                 title="XML files are read-only. Re-save as SQLite3 in GNUCash to enable editing."
               >
                 <Lock className="h-3 w-3" />
@@ -124,7 +125,7 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
             {!isXmlSource && isWritable && (
               <button
                 onClick={toggleWritable}
-                className="flex items-center gap-1.5 rounded-lg border border-[#3B6B8A] bg-[#3B6B8A]/10 px-3 py-1.5 text-xs font-medium text-[#3B6B8A] transition-colors hover:bg-[#3B6B8A]/20"
+                className="flex items-center gap-1.5 rounded-lg border border-[#3B6B8A] bg-[#3B6B8A]/10 px-3 py-1.5 text-xs font-medium text-[#3B6B8A] transition-colors hover:bg-[#3B6B8A]/20 dark:border-[#6FA4C7] dark:text-[#6FA4C7] dark:bg-[#6FA4C7]/10 dark:hover:bg-[#6FA4C7]/20"
                 title="Click to switch to read-only mode"
               >
                 <Pencil className="h-3.5 w-3.5" />
@@ -134,7 +135,7 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
             {!isXmlSource && !isWritable && data && (
               <button
                 onClick={toggleWritable}
-                className="flex items-center gap-1.5 rounded-lg border border-[#EFEFEF] px-3 py-1.5 text-xs font-medium text-[#9A9FA5] transition-colors hover:bg-[#F4F5F7] hover:text-[#6F767E]"
+                className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
                 title="Click to enable editing"
               >
                 <Lock className="h-3 w-3" />
@@ -146,8 +147,8 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
                 onClick={toggleExcludeClosing}
                 className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
                   excludeClosing
-                    ? "border-[#6C9B8B] bg-[#6C9B8B]/10 text-[#6C9B8B]"
-                    : "border-[#EFEFEF] text-[#6F767E] hover:bg-[#F4F5F7]"
+                    ? "border-[#6C9B8B] bg-[#6C9B8B]/10 text-[#6C9B8B] dark:border-[#8FBCA9] dark:text-[#8FBCA9] dark:bg-[#8FBCA9]/10"
+                    : "border-border text-muted-foreground hover:bg-muted"
                 }`}
                 title={excludeClosing ? "Show closing transactions" : "Exclude closing transactions"}
               >
@@ -160,14 +161,15 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
               onClick={toggleHideValues}
               className={`flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
                 hideValues
-                  ? "border-[#6C9B8B] bg-[#6C9B8B]/10 text-[#6C9B8B]"
-                  : "border-[#EFEFEF] text-[#6F767E] hover:bg-[#F4F5F7]"
+                  ? "border-[#6C9B8B] bg-[#6C9B8B]/10 text-[#6C9B8B] dark:border-[#8FBCA9] dark:text-[#8FBCA9] dark:bg-[#8FBCA9]/10"
+                  : "border-border text-muted-foreground hover:bg-muted"
               }`}
               title={hideValues ? "Show values" : "Hide values"}
             >
               {hideValues ? <EyeOff className="h-3.5 w-3.5" /> : <Eye className="h-3.5 w-3.5" />}
               <span className="hidden sm:inline">{hideValues ? "Show values" : "Hide values"}</span>
             </button>
+            <ThemeToggle />
           </div>
         </header>
 

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -51,6 +51,11 @@
 :root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
+  /* Chart axis/grid colors for SVG `stroke=`/`fill=` attributes that can't
+     go through Tailwind classes. Kept as rgb()/hex so they inline cleanly. */
+  --chart-grid: #EFEFEF;
+  --chart-axis-tick: #9A9FA5;
+  --chart-axis-line: rgba(26, 29, 31, 0.3);
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -86,6 +91,9 @@
 .dark {
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
+  --chart-grid: rgba(255, 255, 255, 0.08);
+  --chart-axis-tick: rgba(255, 255, 255, 0.55);
+  --chart-axis-line: rgba(255, 255, 255, 0.4);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
@@ -102,11 +110,14 @@
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
+  /* Charts: flipped from light mode (dark → light) so values stay legible
+     against the dark background. Light mode uses a descending gray scale
+     (0.87 → 0.269); dark mode uses an ascending scale (0.269 → 0.87). */
+  --chart-1: oklch(0.269 0 0);
+  --chart-2: oklch(0.439 0 0);
+  --chart-3: oklch(0.556 0 0);
+  --chart-4: oklch(0.708 0 0);
+  --chart-5: oklch(0.87 0 0);
   --sidebar: oklch(0.205 0 0);
   --sidebar-foreground: oklch(0.985 0 0);
   --sidebar-primary: oklch(0.488 0.243 264.376);
@@ -116,6 +127,62 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
 }
+
+/* -----------------------------------------------------------------------
+   Dark-mode overrides for hardcoded hex Tailwind classes.
+
+   The dashboard was built before dark mode existed, so many components use
+   arbitrary-value classes like `text-[#1A1D1F]` and `bg-white` directly.
+   Rewriting every file to use CSS-variable-backed classes would be a huge
+   sweep — these overrides remap the common hex values to dark-appropriate
+   ones when `.dark` is on `<html>`, so existing light-mode code stays
+   untouched but renders correctly in both themes.
+
+   As components are migrated to `bg-card` / `text-muted-foreground` etc.,
+   the matching rules below become dead code and can be removed.
+   ----------------------------------------------------------------------- */
+.dark .bg-white                                                      { background-color: var(--card); }
+.dark .bg-\[\#F4F5F7\]                                               { background-color: var(--muted); }
+.dark .hover\:bg-\[\#F4F5F7\]:hover                                  { background-color: var(--muted); }
+.dark .bg-\[\#F9FAFB\]                                               { background-color: var(--muted); }
+.dark .hover\:bg-\[\#F9FAFB\]:hover                                  { background-color: var(--muted); }
+.dark .bg-\[\#EFEFEF\]                                               { background-color: var(--muted); }
+.dark .hover\:bg-\[\#EFEFEF\]:hover                                  { background-color: color-mix(in oklch, var(--muted), white 10%); }
+.dark .bg-\[\#EBF5EC\]                                               { background-color: color-mix(in oklch, var(--muted), #6C9B8B 12%); }
+
+/* Neutral text */
+.dark .text-\[\#1A1D1F\]                                             { color: var(--foreground); }
+.dark .text-\[\#6F767E\]                                             { color: var(--muted-foreground); }
+.dark .text-\[\#9A9FA5\]                                             { color: color-mix(in oklch, var(--muted-foreground), transparent 20%); }
+.dark .text-\[\#D4DAE0\]                                             { color: color-mix(in oklch, var(--muted-foreground), transparent 40%); }
+.dark .hover\:text-\[\#1A1D1F\]:hover                                { color: var(--foreground); }
+.dark .hover\:text-\[\#6F767E\]:hover                                { color: var(--muted-foreground); }
+
+/* Neutral borders */
+.dark .border-\[\#EFEFEF\]                                           { border-color: var(--border); }
+.dark .border-\[\#D4DAE0\]                                           { border-color: var(--border); }
+.dark .border-\[\#D1D5DB\]                                           { border-color: var(--border); }
+
+/* Brand blue (#3B6B8A) — lighten slightly in dark for contrast */
+.dark .text-\[\#3B6B8A\]                                             { color: #6FA4C7; }
+.dark .border-\[\#3B6B8A\]                                           { border-color: #6FA4C7; }
+.dark .bg-\[\#3B6B8A\]                                               { background-color: #6FA4C7; }
+.dark .hover\:bg-\[\#3B6B8A\]:hover                                  { background-color: #6FA4C7; }
+.dark .hover\:text-\[\#3B6B8A\]:hover                                { color: #6FA4C7; }
+.dark .hover\:bg-\[\#2D5570\]:hover                                  { background-color: #5A93B6; }
+.dark .hover\:bg-\[\#2F5770\]:hover                                  { background-color: #5A93B6; }
+.dark .hover\:text-\[\#2D5570\]:hover                                { color: #5A93B6; }
+
+/* Brand green (#6C9B8B) — lighten slightly in dark for contrast */
+.dark .text-\[\#6C9B8B\]                                             { color: #8FBCA9; }
+.dark .border-\[\#6C9B8B\]                                           { border-color: #8FBCA9; }
+.dark .bg-\[\#6C9B8B\]                                               { background-color: #8FBCA9; }
+.dark .hover\:bg-\[\#6C9B8B\]:hover                                  { background-color: #8FBCA9; }
+.dark .hover\:text-\[\#6C9B8B\]:hover                                { color: #8FBCA9; }
+.dark .hover\:border-\[\#6C9B8B\]:hover                              { border-color: #8FBCA9; }
+
+/* Destructive red accents — keep the light-mode red, which reads fine on dark */
+/* (#E87C6B, #F87171 unchanged) */
 
 @layer base {
   * {

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -2,6 +2,22 @@ import type { Metadata } from "next";
 import { DM_Sans, Inter } from "next/font/google";
 import "./globals.css";
 import { DashboardProvider } from "@/lib/dashboard-context";
+import { ThemeProvider } from "@/lib/theme-context";
+
+// Runs before hydration to set the `.dark` class on <html> based on the
+// persisted preference (or OS setting when no preference is stored), avoiding
+// a flash of the wrong theme on first paint.
+const themeInitScript = `
+(function() {
+  try {
+    var stored = localStorage.getItem('gnudash-theme');
+    var dark = stored === 'dark' ||
+      ((!stored || stored === 'system') &&
+       window.matchMedia('(prefers-color-scheme: dark)').matches);
+    if (dark) document.documentElement.classList.add('dark');
+  } catch (e) {}
+})();
+`;
 
 const dmSans = DM_Sans({
   variable: "--font-dm-sans",
@@ -26,9 +42,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${dmSans.variable} ${inter.variable} h-full antialiased`}>
+    <html
+      lang="en"
+      className={`${dmSans.variable} ${inter.variable} h-full antialiased`}
+      suppressHydrationWarning
+    >
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body className="min-h-full" style={{ fontFamily: "var(--font-dm-sans), var(--font-inter), system-ui, sans-serif" }}>
-        <DashboardProvider>{children}</DashboardProvider>
+        <ThemeProvider>
+          <DashboardProvider>{children}</DashboardProvider>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -155,17 +155,17 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
           <div className="h-[220px]">
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={filtered} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
                 <XAxis
                   dataKey="month"
                   tickFormatter={formatMonthLabel}
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <YAxis
                   tickFormatter={(v) => formatCurrencyShort(v, currency)}
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   axisLine={false}
                   tickLine={false}
                   width={50}
@@ -182,8 +182,9 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
                     return `${months[parseInt(m) - 1]} ${y}`;
                   }}
                   contentStyle={{
-                    backgroundColor: "white",
-                    border: "1px solid #EFEFEF",
+                    backgroundColor: "var(--popover)",
+                    color: "var(--popover-foreground)",
+                    border: "1px solid var(--border)",
                     borderRadius: "10px",
                     fontSize: "13px",
                   }}
@@ -193,7 +194,7 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
                 <Line
                   type="monotone"
                   dataKey="net"
-                  stroke="#1A1D1F"
+                  stroke="currentColor"
                   strokeWidth={2}
                   strokeDasharray="6 4"
                   dot={false}

--- a/app/src/components/dashboard/charts/investment-performance.tsx
+++ b/app/src/components/dashboard/charts/investment-performance.tsx
@@ -110,16 +110,16 @@ export function InvestmentPerformance({ investments, currency }: InvestmentPerfo
         <div className="h-[280px]">
           <ResponsiveContainer width="100%" height="100%">
             <BarChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
               <XAxis
                 dataKey="name"
-                tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                 axisLine={false}
                 tickLine={false}
               />
               <YAxis
                 tickFormatter={(v) => formatCurrencyShort(v, currency)}
-                tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                 axisLine={false}
                 tickLine={false}
                 width={55}
@@ -130,8 +130,9 @@ export function InvestmentPerformance({ investments, currency }: InvestmentPerfo
                   name === "costBasis" ? "Cost Basis" : "Market Value",
                 ]}
                 contentStyle={{
-                  backgroundColor: "white",
-                  border: "1px solid #EFEFEF",
+                  backgroundColor: "var(--popover)",
+                  color: "var(--popover-foreground)",
+                  border: "1px solid var(--border)",
                   borderRadius: "10px",
                   fontSize: "13px",
                 }}

--- a/app/src/components/dashboard/charts/net-worth-chart.tsx
+++ b/app/src/components/dashboard/charts/net-worth-chart.tsx
@@ -217,12 +217,12 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
                   <stop offset="100%" stopColor="#3B6B8A" stopOpacity={0} />
                 </linearGradient>
               </defs>
-              <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
+              <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
               <XAxis
                 dataKey="month"
                 tickFormatter={formatAxisMonth}
                 ticks={getVisibleTicks(filtered)}
-                tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                 axisLine={false}
                 tickLine={false}
               />
@@ -231,12 +231,12 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
                 ticks={yTicks}
                 interval={0}
                 tickFormatter={(v) => formatCurrencyShort(v, currency)}
-                tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                 axisLine={false}
                 tickLine={false}
                 width={55}
               />
-              <ReferenceLine y={0} stroke="#1A1D1F" strokeWidth={1} strokeOpacity={0.3} />
+              <ReferenceLine y={0} stroke="var(--chart-axis-line)" strokeWidth={1} />
               <Tooltip
                 content={({ active, payload, label }) => {
                   if (!active || !payload?.length) return null;
@@ -245,7 +245,7 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
                   const [y, m] = (label as string).split("-");
                   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
                   return (
-                    <div className="rounded-[10px] border border-[#EFEFEF] bg-white px-3 py-2 text-[13px] shadow-md">
+                    <div className="rounded-[10px] border border-border bg-popover px-3 py-2 text-[13px] shadow-md">
                       <p className="mb-1.5 text-xs font-medium text-[#6F767E]">{months[parseInt(m) - 1]} {y}</p>
                       <div className="flex flex-col gap-1">
                         <div className="flex items-center justify-between gap-4">

--- a/app/src/components/dashboard/sidebar.tsx
+++ b/app/src/components/dashboard/sidebar.tsx
@@ -35,7 +35,7 @@ export function Sidebar({ onNavigate, expanded }: SidebarProps) {
 
   return (
     <aside
-      className={`flex h-full flex-col border-r border-[#EFEFEF] bg-white transition-[width] duration-200 overflow-hidden ${
+      className={`flex h-full flex-col border-r border-border bg-card transition-[width] duration-200 overflow-hidden ${
         expanded ? "w-[260px]" : "w-[60px]"
       }`}
     >
@@ -43,7 +43,7 @@ export function Sidebar({ onNavigate, expanded }: SidebarProps) {
         {/* Main Menu */}
         <div>
           {expanded && (
-            <p className="mb-2 px-3 text-xs text-[#9A9FA5]">Main menu</p>
+            <p className="mb-2 px-3 text-xs text-muted-foreground/70">Main menu</p>
           )}
           <nav className="flex flex-col gap-0.5">
             {mainNav.map((item) => {
@@ -63,12 +63,12 @@ export function Sidebar({ onNavigate, expanded }: SidebarProps) {
                       : "h-[42px] w-[42px] mx-auto justify-center"
                   } ${
                     isActive
-                      ? "bg-[#6C9B8B]/10 text-[#1A1D1F]"
-                      : "text-[#6F767E] hover:bg-[#F4F5F7]"
+                      ? "bg-[#6C9B8B]/10 text-foreground dark:bg-[#8FBCA9]/10"
+                      : "text-muted-foreground hover:bg-muted"
                   }`}
                 >
                   <item.icon
-                    className={`h-[18px] w-[18px] shrink-0 ${isActive ? "text-[#6C9B8B]" : "text-[#9A9FA5]"}`}
+                    className={`h-[18px] w-[18px] shrink-0 ${isActive ? "text-[#6C9B8B] dark:text-[#8FBCA9]" : "text-muted-foreground/70"}`}
                   />
                   {expanded && (
                     <span className={`text-sm ${isActive ? "font-medium" : ""}`}>
@@ -83,33 +83,33 @@ export function Sidebar({ onNavigate, expanded }: SidebarProps) {
       </div>
 
       {/* Bottom: Export + Upload new file */}
-      <div className={`mt-auto border-t border-[#EFEFEF] ${expanded ? "p-5" : "p-2"}`}>
+      <div className={`mt-auto border-t border-border ${expanded ? "p-5" : "p-2"}`}>
         <button
           onClick={exportFile}
           title="Export .gnucash file"
-          className={`flex items-center rounded-[10px] text-sm text-[#6F767E] transition-colors hover:bg-[#F4F5F7] whitespace-nowrap ${
+          className={`flex items-center rounded-[10px] text-sm text-muted-foreground transition-colors hover:bg-muted whitespace-nowrap ${
             expanded
               ? "w-full gap-2.5 px-3 py-2"
               : "h-[42px] w-[42px] mx-auto justify-center"
           }`}
         >
-          <Download className="h-[18px] w-[18px] shrink-0 text-[#9A9FA5]" />
+          <Download className="h-[18px] w-[18px] shrink-0 text-muted-foreground/70" />
           {expanded && "Export .gnucash file"}
         </button>
         <button
           onClick={clearData}
           title="Upload new file"
-          className={`flex items-center rounded-[10px] text-sm text-[#6F767E] transition-colors hover:bg-[#F4F5F7] whitespace-nowrap ${
+          className={`flex items-center rounded-[10px] text-sm text-muted-foreground transition-colors hover:bg-muted whitespace-nowrap ${
             expanded
               ? "w-full gap-2.5 px-3 py-2"
               : "h-[42px] w-[42px] mx-auto justify-center"
           }`}
         >
-          <LogOut className="h-[18px] w-[18px] shrink-0 text-[#9A9FA5]" />
+          <LogOut className="h-[18px] w-[18px] shrink-0 text-muted-foreground/70" />
           {expanded && "Upload new file"}
         </button>
         {expanded && uploadedAt && (
-          <p className="mt-1.5 px-3 text-xs text-[#9A9FA5]">
+          <p className="mt-1.5 px-3 text-xs text-muted-foreground/70">
             Loaded {uploadedAt.toLocaleDateString(undefined, { day: "numeric", month: "short", year: "numeric" })}{" "}
             {uploadedAt.toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" })}
           </p>

--- a/app/src/components/dashboard/theme-toggle.tsx
+++ b/app/src/components/dashboard/theme-toggle.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useTheme } from "@/lib/theme-context";
+
+export function ThemeToggle() {
+  const { resolvedTheme, toggleTheme, mounted } = useTheme();
+
+  // Render an inert placeholder on the server and during the first client
+  // render. The actual icon depends on the client-only resolved theme, so
+  // rendering it before hydration would cause a hydration mismatch. The
+  // overall page theme is already correct thanks to the inline head script.
+  if (!mounted) {
+    return (
+      <button
+        type="button"
+        aria-hidden="true"
+        tabIndex={-1}
+        className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground"
+      >
+        <span className="block h-3.5 w-3.5" />
+      </button>
+    );
+  }
+
+  const isDark = resolvedTheme === "dark";
+  return (
+    <button
+      onClick={toggleTheme}
+      className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted"
+      title={isDark ? "Switch to light mode" : "Switch to dark mode"}
+      aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+    >
+      {isDark ? <Sun className="h-3.5 w-3.5" /> : <Moon className="h-3.5 w-3.5" />}
+    </button>
+  );
+}

--- a/app/src/lib/theme-context.tsx
+++ b/app/src/lib/theme-context.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from "react";
+
+export type Theme = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+  toggleTheme: () => void;
+  mounted: boolean;
+}
+
+const STORAGE_KEY = "gnudash-theme";
+
+const ThemeContext = createContext<ThemeContextType>({
+  theme: "system",
+  resolvedTheme: "light",
+  setTheme: () => {},
+  toggleTheme: () => {},
+  mounted: false,
+});
+
+// useSyncExternalStore with a no-op subscription gives us a clean "is this
+// the client after hydration?" signal: returns false during SSR and the
+// first client render, true on every render after hydration. Using this in
+// place of useEffect+setState avoids the react-hooks/set-state-in-effect
+// lint error while serving the same purpose.
+const subscribeNoop = () => () => {};
+function useMounted(): boolean {
+  return useSyncExternalStore(
+    subscribeNoop,
+    () => true,
+    () => false,
+  );
+}
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  // Lazy initializers read from localStorage / the pre-hydration .dark class
+  // so the provider starts with the correct theme on the client without a
+  // setState-in-effect round trip. On the server these return safe defaults
+  // ("system" / "light"); the inline <head> script (in the root layout) has
+  // already applied the correct class to <html> before React hydrates, so
+  // no flash occurs even though React's state starts defaulted.
+  const [theme, setThemeState] = useState<Theme>(() => {
+    if (typeof window === "undefined") return "system";
+    return (localStorage.getItem(STORAGE_KEY) as Theme | null) ?? "system";
+  });
+  const [resolvedTheme, setResolvedTheme] = useState<ResolvedTheme>(() => {
+    if (typeof window === "undefined") return "light";
+    return document.documentElement.classList.contains("dark") ? "dark" : "light";
+  });
+  const mounted = useMounted();
+
+  // Apply the .dark class whenever the effective theme changes, and follow
+  // the OS preference when theme === "system".
+  useEffect(() => {
+    const media = window.matchMedia("(prefers-color-scheme: dark)");
+    const resolve = () => {
+      const next: ResolvedTheme =
+        theme === "system" ? (media.matches ? "dark" : "light") : theme;
+      setResolvedTheme(next);
+      document.documentElement.classList.toggle("dark", next === "dark");
+    };
+    resolve();
+    if (theme === "system") {
+      media.addEventListener("change", resolve);
+      return () => media.removeEventListener("change", resolve);
+    }
+  }, [theme]);
+
+  const setTheme = (next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+  };
+
+  // Plain light ↔ dark flip. If currently following "system", this anchors
+  // to the opposite of whatever is resolved right now so a click always
+  // changes something visible.
+  const toggleTheme = () => setTheme(resolvedTheme === "dark" ? "light" : "dark");
+
+  return (
+    <ThemeContext.Provider
+      value={{ theme, resolvedTheme, setTheme, toggleTheme, mounted }}
+    >
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}


### PR DESCRIPTION
## Summary
- Adds a Sun/Moon toggle in the dashboard header that flips between light and dark. Choice is persisted to `localStorage` under `gnudash-theme` and defaults to the OS preference on first load. An inline `<head>` script applies the theme class before hydration so there's no flash on refresh.
- Dashboard chrome (header, sidebar, main background, currency selector) now uses the CSS variables already defined in `globals.css` (`--card`, `--muted`, `--border`, `--muted-foreground`) so it adapts natively to both themes.
- A dark-mode override layer in `globals.css` remaps the common hardcoded arbitrary Tailwind classes (`text-[#1A1D1F]`, `bg-white`, `border-[#EFEFEF]`, `bg-[#F4F5F7]`, brand blue/green) so the ~1,100 existing instances across 40+ components render correctly in dark mode without a per-file sweep. As components migrate to CSS-variable classes, the matching rules become dead code and can be removed.
- Chart CSS variables (`--chart-1`..`--chart-5`) were identical in light and dark previously; now flipped so grey-scale data series stay legible on the dark background.
- New `--chart-grid`, `--chart-axis-tick`, `--chart-axis-line` variables for SVG attribute colors (grid lines, axis ticks, reference lines) that can't be driven through Tailwind classes. The three main dashboard charts — net-worth, cash-flow, investment-performance — are updated to use them.

## Known follow-ups
These are deliberately out of scope for this PR to keep the diff reviewable:
- Other charts (sankey, allocation-pie, balance-pie, spending-pie, value-over-time, monthly-expense-bar) still have hardcoded `stroke="#EFEFEF"` / `fill: "#9A9FA5"` SVG attributes. They need the same treatment as the three main ones.
- Data-series colors (`#6C9B8B`, `#3B6B8A`, `#F87171`, `#E87C6B`) are unchanged — they read OK on both backgrounds but are worth eyeballing.
- Long-term, the override layer should be retired by migrating hardcoded hex classes in components to CSS-variable classes (`bg-card`, `text-muted-foreground`, etc.).

## Test plan
- [ ] Toggle appears in the dashboard header next to the hide-values button
- [ ] Clicking flips the whole app between light and dark
- [ ] Refreshing the page keeps the chosen theme (no flash of wrong theme)
- [ ] With no stored preference, theme follows OS setting (try switching OS theme while on "system")
- [ ] Top-bar filter chips (Editing / Read-only / Closing excluded / Hide values / currency) stay readable in dark mode
- [ ] Sidebar items and active state are legible in dark mode
- [ ] Monetary values on dashboard cards and tables are readable in dark mode (not dark-on-dark)
- [ ] Net-worth chart — grid lines, axis labels, tooltip background are legible in dark mode
- [ ] Cash-flow chart — same checks, plus the dashed net line (now `currentColor`)
- [ ] Investment-performance chart — same checks, plus cost-basis bar contrast
- [ ] Other charts (sankey, pies, spending) render — may still show light-themed axes; capture anything obviously broken for follow-up