### PR TITLE
Switch default build to standalone and add Postgres compose foundation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@ WORKDIR /app
 COPY app/package*.json ./
 RUN npm ci
 COPY app/ ./
+# Force static export: this image serves the build output through nginx and
+# has no Node runtime. The default build target (standalone) is used by the
+# Postgres-backend deployment path instead — see docs/deployment.md.
+ENV NEXT_OUTPUT=export
 RUN npm run build
 
 FROM nginx:alpine@sha256:582c496ccf79d8aa6f8203a79d32aaf7ffd8b13362c60a701a2f9ac64886c93d

--- a/README.md
+++ b/README.md
@@ -107,7 +107,12 @@ Open [http://localhost:3000](http://localhost:3000) and drag-and-drop your `.gnu
 
 ## Deployment
 
-GnuDash is a fully static site — no backend server required. See the **[Deployment Guide](docs/deployment.md)** for full instructions covering Docker, Cloudflare Pages, Vercel, Netlify, Coolify, and more.
+GnuDash ships two deployment modes:
+
+- **Static** (the default public [gnudash.pages.dev](https://gnudash.pages.dev/) deployment): build with `NEXT_OUTPUT=export npm run build` and host the `out/` folder on any static CDN (Cloudflare Pages, Netlify, the included nginx Dockerfile, a plain web server). The Local (OPFS) storage backend is the only option in this mode; nothing leaves your browser.
+- **Standalone Node.js** (default `npm run build`): run the built app on a Node.js server. This unlocks the optional Server (Postgres) backend ([issue #48](https://github.com/QuirkyTurtle94/GnuDash/issues/48)) for sharing a book across devices, while keeping the Local backend fully functional.
+
+See the **[Deployment Guide](docs/deployment.md)** for step-by-step instructions for both modes covering Docker, Cloudflare Pages, Vercel, Netlify, Coolify, Synology, and more.
 
 ## Tech Stack
 

--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,7 +1,15 @@
 import type { NextConfig } from "next";
 
+// Default build target is the standalone Node.js server, which the Postgres
+// backend (issue #48) needs for its API routes. Set `NEXT_OUTPUT=export` at
+// build time to produce the legacy static `out/` bundle for nginx / Cloudflare
+// Pages / Netlify / any other host that serves pure static files. Static
+// export does NOT support the Postgres backend — see docs/deployment.md.
+const output: NextConfig["output"] =
+  process.env.NEXT_OUTPUT === "export" ? "export" : "standalone";
+
 const nextConfig: NextConfig = {
-  output: "export",
+  output,
   images: {
     unoptimized: true,
   },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+# Postgres for the optional Server backend (issue #48).
+#
+# Local-only users should IGNORE this file — the legacy static build served via
+# nginx (repo-root Dockerfile) does not need Postgres. This compose file exists
+# for users who want the self-hostable Server backend, which stores each book
+# in its own Postgres schema so a single database can cover multi-device usage.
+#
+# Usage:
+#   docker compose up -d postgres     # start the DB only
+#   docker compose down               # stop (keeps volume)
+#   ./scripts/db-reset.sh             # stop AND drop the data volume
+#
+# Connect from the upload screen's "Server" tab with:
+#   host=localhost port=5432 user=gnudash password=gnudash database=gnudash
+#
+# Production deployments MUST override the default password via env / secrets.
+
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: gnudash-postgres
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-gnudash}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-gnudash}
+      POSTGRES_DB: ${POSTGRES_DB:-gnudash}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - gnudash_pgdata:/var/lib/postgresql/data
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-gnudash} -d ${POSTGRES_DB:-gnudash}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # Uncomment to run the GnuDash app in standalone mode alongside Postgres.
+  # Requires a standalone Dockerfile (not yet added — MVP expects users to run
+  # `npm run dev` locally or self-host the Next.js output themselves).
+  #
+  # gnudash-app:
+  #   build:
+  #     context: ./app
+  #     dockerfile: Dockerfile.standalone
+  #   ports:
+  #     - "3000:3000"
+  #   depends_on:
+  #     postgres:
+  #       condition: service_healthy
+  #   environment:
+  #     NODE_ENV: production
+
+volumes:
+  gnudash_pgdata:
+    name: gnudash_pgdata

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,6 +1,15 @@
 # Deployment Guide
 
-GnuDash builds to a fully static site — just HTML, CSS, JS, and WASM files. No Node.js server, no API, no database. This means you can host it almost anywhere.
+GnuDash supports two deployment modes:
+
+| Mode | Output | Backends | When to use |
+|---|---|---|---|
+| **Static** (`NEXT_OUTPUT=export npm run build`) | `app/out/` — plain HTML/JS/WASM | Local (OPFS) only | Cloudflare Pages, Netlify, nginx, any static host |
+| **Standalone** (default `npm run build`) | `app/.next/standalone/` — Node.js server | Local (OPFS) **and** Server (Postgres) | Self-hosted behind Node, Docker, VPS — when you want a shared Postgres book across devices |
+
+The Server (Postgres) backend is tracked by [issue #48](https://github.com/QuirkyTurtle94/GnuDash/issues/48). Until that lands, both modes behave identically from the user's perspective — the default flip to `standalone` just enables the API routes the Postgres backend needs.
+
+If you have an existing static deployment (Cloudflare Pages, Netlify, the nginx Dockerfile in this repo), follow the commands in each section below — they already set `NEXT_OUTPUT=export` so nothing changes for you.
 
 ## Important: Required HTTP Headers
 
@@ -61,15 +70,17 @@ Then log out and back in (or reboot) for the new limits to take effect. You can 
 
 ## Static Build
 
-All production deployment methods start with the same build step:
+For any of the static hosts below (nginx, Cloudflare Pages, Netlify, a plain CDN), build with `NEXT_OUTPUT=export`:
 
 ```bash
 cd app
 npm install
-npm run build
+NEXT_OUTPUT=export npm run build
 ```
 
 This produces a static export in `app/out/` containing everything needed to serve the site.
+
+Without the env var, the build instead produces a standalone Node.js bundle in `app/.next/standalone/` which is what the Server (Postgres) backend needs — but the static hosts below cannot serve it.
 
 ---
 
@@ -123,7 +134,7 @@ The nginx configuration inside the container handles the COOP/COEP headers, MIME
 2. Select **Pages** > **Connect to Git**
 3. Pick your repository and branch
 4. Configure the build:
-   - **Build command**: `cd app && npm install && npm run build`
+   - **Build command**: `cd app && npm install && NEXT_OUTPUT=export npm run build`
    - **Build output directory**: `app/out`
 5. Deploy
 
@@ -143,7 +154,7 @@ No additional configuration needed.
 
 1. Import your repository on [Vercel](https://vercel.com)
 2. Set the **Root Directory** to `app`
-3. Vercel will auto-detect Next.js and build it
+3. Vercel will auto-detect Next.js and build it. If you want a pure-static deployment (no Postgres backend), set the **Build Command** to `NEXT_OUTPUT=export npm run build` and **Output Directory** to `out`. Otherwise Vercel will deploy the standalone Node.js output, which supports both backends.
 
 Add the required headers by creating `app/vercel.json`:
 
@@ -170,7 +181,7 @@ Add the required headers by creating `app/vercel.json`:
 1. Import your repository on [Netlify](https://netlify.com)
 2. Configure the build:
    - **Base directory**: `app`
-   - **Build command**: `npm run build`
+   - **Build command**: `NEXT_OUTPUT=export npm run build`
    - **Publish directory**: `app/out`
 
 Add the required headers by creating `app/public/_headers` (already included in the repo):
@@ -240,7 +251,7 @@ You can run GnuDash on a Synology NAS using Container Manager (Docker). No comma
    git clone https://github.com/QuirkyTurtle94/GnuDash.git
    cd GnuDash/app
    npm install
-   npm run build
+   NEXT_OUTPUT=export npm run build
    ```
 
 7. **Copy files to your NAS** using File Station or a network share:
@@ -272,7 +283,7 @@ When a new version of GnuDash is released, repeat steps 6-7 (rebuild and copy th
 If you'd prefer the NAS to build the Docker image itself (no need to copy files manually), your NAS needs enough RAM (2GB+ free) and you'll use SSH:
 
 1. SSH into your NAS: `ssh admin@YOUR-NAS-IP`
-2. Clone and build:
+2. Clone and build (the repo-root `Dockerfile` forces `NEXT_OUTPUT=export` so this keeps producing a static nginx image):
    ```bash
    cd /volume1/docker
    git clone https://github.com/QuirkyTurtle94/GnuDash.git
@@ -290,9 +301,24 @@ To update: `cd /volume1/docker/GnuDash && git pull && cd app && docker build -t 
 
 If your host isn't listed above, the process is the same:
 
-1. Build the site: `cd app && npm install && npm run build`
+1. Build the site: `cd app && npm install && NEXT_OUTPUT=export npm run build`
 2. Upload the contents of `app/out/` to your host
 3. Configure your server to set the two required headers (COOP and COEP)
 4. Ensure your server serves `index.html` for client-side routes (SPA fallback)
 
 If you can't set custom headers (e.g. GitHub Pages), the app will still load but file uploads will fail because `SharedArrayBuffer` won't be available.
+
+---
+
+## Self-hosted Postgres backend (in development)
+
+The repo-root `docker-compose.yml` starts a Postgres 16 container that the upcoming Server backend ([issue #48](https://github.com/QuirkyTurtle94/GnuDash/issues/48)) will connect to. For developers following along with that work:
+
+```bash
+docker compose up -d postgres     # start the DB
+./scripts/db-reset.sh             # stop AND drop the data volume
+```
+
+Defaults: `host=localhost port=5432 user=gnudash password=gnudash database=gnudash`. Override via environment variables (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT`) before `docker compose up`. **Any non-localhost deployment must terminate TLS in front of the app** — the Server backend sends Postgres credentials in request bodies from the browser.
+
+End-user walkthrough (Server tab on the upload screen, auto-reconnect, credentials-in-OPFS security note) will land with the final PR of issue #48.

--- a/scripts/db-reset.sh
+++ b/scripts/db-reset.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Drop the Postgres dev container and its named volume so the next
+# `docker compose up -d postgres` starts from an empty database.
+# Useful after a failed import or when switching between fixture books.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+docker compose down --volumes
+echo "Postgres data volume 'gnudash_pgdata' destroyed."


### PR DESCRIPTION
First PR of the Server (Postgres) backend series. Refs #48.

## Summary

- Make the Next.js build target switchable: default is now `output: "standalone"` (which the upcoming `/api/pg/*` routes need); pass `NEXT_OUTPUT=export` to fall back to the legacy static bundle.
- Pin `NEXT_OUTPUT=export` inside the repo-root `Dockerfile` so the existing nginx image behaves identically to before.
- Add `docker-compose.yml` with a Postgres 16-alpine service (named volume, healthcheck, env-overridable credentials) and a `scripts/db-reset.sh` helper to wipe it.
- Update the deployment guide so every static-host build command (Cloudflare Pages, Netlify, Synology, "Any Static Host") includes `NEXT_OUTPUT=export`. README mentions both modes.

No runtime behavior change. The Server backend UI, API routes, and client adapter land in follow-up PRs.

## Test plan

- [x] `NEXT_OUTPUT=export npm run build` still produces `app/out/*.html` (static export path used by gnudash.pages.dev)
- [x] `npm run build` (default) produces `app/.next/standalone/server.js` (the new default)
- [ ] `docker compose up -d postgres` starts the container and `pg_isready` passes (requires Docker — run locally before merging if you want to verify)
- [ ] `./scripts/db-reset.sh` drops container + volume cleanly
- [ ] Manual smoke: existing repo-root Docker image still builds and serves the app

## Out of scope

Per the plan in `memory/project_pg_backend_implementation.md`:
- PR 2: `postgres-schema.ts` + `sql-translate.ts` + unit tests
- PR 3: API routes + `pg` dep
- PR 4–8: adapter, OPFS settings, UI, reupload, auto-reconnect