### PR TITLE
Add client-side Postgres adapter, sync client, and worker wiring

### DIFF
--- a/app/src/lib/gnucash/db/__tests__/postgres-adapter.test.ts
+++ b/app/src/lib/gnucash/db/__tests__/postgres-adapter.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from "vitest";
+import { createWritablePostgresAdapter } from "../postgres-adapter";
+import { PostgresSyncClient } from "../postgres-sync-client";
+import type { PgConnection } from "@/lib/pg/connect";
+
+const connection: PgConnection = {
+  host: "localhost",
+  port: 5432,
+  user: "gnudash",
+  password: "gnudash",
+  database: "gnudash",
+};
+
+/**
+ * Minimal stand-in for the SQLite WASM oo1.Database used by the adapter.
+ * Records exec calls so tests can assert BEGIN/COMMIT/ROLLBACK ordering.
+ */
+function makeFakeDb() {
+  const execCalls: { sql: string; bind?: unknown[] }[] = [];
+  let changesValue = 0;
+  return {
+    execCalls,
+    setChanges(n: number) {
+      changesValue = n;
+    },
+    selectObjects: vi.fn(() => []),
+    selectObject: vi.fn(() => undefined),
+    exec: vi.fn((opts: { sql: string; bind?: unknown[] }) => {
+      execCalls.push(opts);
+      return 0;
+    }),
+    close: vi.fn(),
+    changes: () => changesValue,
+  };
+}
+
+function makeSyncClient() {
+  // Real client with a stub fetch — lets us verify enqueue/beginTx behaviour
+  // without mocking every method on the class.
+  return new PostgresSyncClient(connection, "default", vi.fn());
+}
+
+describe("createWritablePostgresAdapter", () => {
+  describe("run", () => {
+    it("applies the statement locally and enqueues it for sync", () => {
+      const db = makeFakeDb();
+      db.setChanges(1);
+      const sync = makeSyncClient();
+      const adapter = createWritablePostgresAdapter(db, sync);
+
+      const result = adapter.run(
+        "UPDATE accounts SET name = ? WHERE guid = ?",
+        "Alice",
+        "g-1",
+      );
+
+      expect(result.changes).toBe(1);
+      expect(db.exec).toHaveBeenCalledWith({
+        sql: "UPDATE accounts SET name = ? WHERE guid = ?",
+        bind: ["Alice", "g-1"],
+      });
+      expect(sync.pendingCount).toBe(1);
+    });
+
+    it("omits bind when no params are supplied", () => {
+      const db = makeFakeDb();
+      const sync = makeSyncClient();
+      const adapter = createWritablePostgresAdapter(db, sync);
+
+      adapter.run("DELETE FROM transactions");
+
+      expect(db.exec).toHaveBeenCalledWith({
+        sql: "DELETE FROM transactions",
+        bind: undefined,
+      });
+    });
+  });
+
+  describe("prepare", () => {
+    it("delegates .all to the local db", () => {
+      const db = makeFakeDb();
+      db.selectObjects = vi.fn(() => [{ guid: "g-1" }]);
+      const adapter = createWritablePostgresAdapter(db, makeSyncClient());
+
+      const rows = adapter.prepare("SELECT * FROM accounts WHERE id = ?").all(
+        "x",
+      );
+
+      expect(db.selectObjects).toHaveBeenCalledWith(
+        "SELECT * FROM accounts WHERE id = ?",
+        ["x"],
+      );
+      expect(rows).toEqual([{ guid: "g-1" }]);
+    });
+
+    it("delegates .get to the local db", () => {
+      const db = makeFakeDb();
+      db.selectObject = vi.fn(() => ({ guid: "g-1" }));
+      const adapter = createWritablePostgresAdapter(db, makeSyncClient());
+
+      const row = adapter
+        .prepare("SELECT * FROM accounts WHERE guid = ?")
+        .get("g-1");
+
+      expect(row).toEqual({ guid: "g-1" });
+    });
+  });
+
+  describe("transaction", () => {
+    it("issues BEGIN/COMMIT locally and stacks the sync tx on success", () => {
+      const db = makeFakeDb();
+      const sync = makeSyncClient();
+      const adapter = createWritablePostgresAdapter(db, sync);
+
+      const result = adapter.transaction(() => {
+        adapter.run("INSERT INTO accounts (guid) VALUES (?)", "g-1");
+        return "done";
+      });
+
+      expect(result).toBe("done");
+      expect(db.execCalls.map((c) => c.sql)).toEqual([
+        "BEGIN IMMEDIATE",
+        "INSERT INTO accounts (guid) VALUES (?)",
+        "COMMIT",
+      ]);
+      expect(sync.transactionDepth).toBe(0);
+      expect(sync.pendingCount).toBe(1);
+    });
+
+    it("issues ROLLBACK and drops enqueued statements on failure", () => {
+      const db = makeFakeDb();
+      const sync = makeSyncClient();
+      const adapter = createWritablePostgresAdapter(db, sync);
+
+      expect(() => {
+        adapter.transaction(() => {
+          adapter.run("INSERT INTO accounts (guid) VALUES (?)", "g-1");
+          throw new Error("engine rejection");
+        });
+      }).toThrow("engine rejection");
+
+      expect(db.execCalls.map((c) => c.sql)).toEqual([
+        "BEGIN IMMEDIATE",
+        "INSERT INTO accounts (guid) VALUES (?)",
+        "ROLLBACK",
+      ]);
+      expect(sync.transactionDepth).toBe(0);
+      expect(sync.pendingCount).toBe(0);
+    });
+
+    it("handles nested transactions via sync-client savepoint stacking", () => {
+      const db = makeFakeDb();
+      const sync = makeSyncClient();
+      const adapter = createWritablePostgresAdapter(db, sync);
+
+      adapter.transaction(() => {
+        adapter.run("a", []);
+        // Inner tx rolls back — outer statement stays.
+        expect(() => {
+          adapter.transaction(() => {
+            adapter.run("b", []);
+            throw new Error("inner fail");
+          });
+        }).toThrow("inner fail");
+        adapter.run("c", []);
+      });
+
+      expect(sync.pendingCount).toBe(2); // a and c, not b
+      expect(sync.transactionDepth).toBe(0);
+    });
+  });
+
+  describe("exec", () => {
+    it("runs locally only — no sync enqueue", () => {
+      const db = makeFakeDb();
+      const sync = makeSyncClient();
+      const adapter = createWritablePostgresAdapter(db, sync);
+
+      adapter.exec("CREATE TABLE IF NOT EXISTS foo (x)");
+
+      expect(db.exec).toHaveBeenCalledWith({
+        sql: "CREATE TABLE IF NOT EXISTS foo (x)",
+      });
+      expect(sync.pendingCount).toBe(0);
+    });
+  });
+
+  describe("close", () => {
+    it("closes the underlying local db", () => {
+      const db = makeFakeDb();
+      const adapter = createWritablePostgresAdapter(db, makeSyncClient());
+
+      adapter.close();
+
+      expect(db.close).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/app/src/lib/gnucash/db/__tests__/postgres-sync-client.test.ts
+++ b/app/src/lib/gnucash/db/__tests__/postgres-sync-client.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  PostgresSyncClient,
+  type FetchLike,
+} from "../postgres-sync-client";
+import type { PgConnection } from "@/lib/pg/connect";
+
+const connection: PgConnection = {
+  host: "localhost",
+  port: 5432,
+  user: "gnudash",
+  password: "gnudash",
+  database: "gnudash",
+};
+
+function fakeOkResponse(): Response {
+  return new Response(JSON.stringify({ results: [] }), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function fakeErrorResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("PostgresSyncClient", () => {
+  describe("enqueue + flush", () => {
+    it("flushes queued statements to /api/pg/book/exec and clears the queue", async () => {
+      const fetchMock = vi.fn<FetchLike>().mockResolvedValue(fakeOkResponse());
+      const client = new PostgresSyncClient(connection, "default", fetchMock);
+
+      client.enqueue("INSERT INTO accounts (guid) VALUES (?)", ["g-1"]);
+      client.enqueue("UPDATE accounts SET name = ? WHERE guid = ?", [
+        "Alice",
+        "g-1",
+      ]);
+      expect(client.pendingCount).toBe(2);
+
+      await client.flush();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [url, init] = fetchMock.mock.calls[0];
+      expect(url).toBe("/api/pg/book/exec");
+      expect(init.method).toBe("POST");
+      const body = JSON.parse(init.body) as {
+        connection: PgConnection;
+        bookId: string;
+        statements: { sql: string; params: unknown[] }[];
+      };
+      expect(body.connection).toEqual(connection);
+      expect(body.bookId).toBe("default");
+      expect(body.statements).toEqual([
+        { sql: "INSERT INTO accounts (guid) VALUES (?)", params: ["g-1"] },
+        {
+          sql: "UPDATE accounts SET name = ? WHERE guid = ?",
+          params: ["Alice", "g-1"],
+        },
+      ]);
+      expect(client.pendingCount).toBe(0);
+    });
+
+    it("is a no-op when the queue is empty", async () => {
+      const fetchMock = vi.fn<FetchLike>().mockResolvedValue(fakeOkResponse());
+      const client = new PostgresSyncClient(connection, "default", fetchMock);
+
+      await client.flush();
+
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it("surfaces the server's error message on non-2xx", async () => {
+      const fetchMock = vi
+        .fn<FetchLike>()
+        .mockResolvedValue(fakeErrorResponse(502, { error: "oops" }));
+      const client = new PostgresSyncClient(connection, "default", fetchMock);
+      client.enqueue("DELETE FROM accounts WHERE guid = ?", ["g-1"]);
+
+      await expect(client.flush()).rejects.toThrow(/oops/);
+    });
+
+    it("falls back to an HTTP status message when the body is not JSON", async () => {
+      const fetchMock = vi.fn<FetchLike>().mockResolvedValue(
+        new Response("not json", { status: 500 }),
+      );
+      const client = new PostgresSyncClient(connection, "default", fetchMock);
+      client.enqueue("DELETE FROM accounts WHERE guid = ?", ["g-1"]);
+
+      await expect(client.flush()).rejects.toThrow(/HTTP 500/);
+    });
+
+    it("drains the queue even when the flush fails so a retry does not double-send", async () => {
+      const fetchMock = vi
+        .fn<FetchLike>()
+        .mockResolvedValue(fakeErrorResponse(502, { error: "nope" }));
+      const client = new PostgresSyncClient(connection, "default", fetchMock);
+      client.enqueue("DELETE FROM accounts WHERE guid = ?", ["g-1"]);
+
+      await expect(client.flush()).rejects.toThrow();
+      expect(client.pendingCount).toBe(0);
+    });
+  });
+
+  describe("transaction stacking", () => {
+    it("tracks depth across nested begin/commit pairs", () => {
+      const client = new PostgresSyncClient(
+        connection,
+        "default",
+        vi.fn<FetchLike>(),
+      );
+
+      expect(client.transactionDepth).toBe(0);
+      client.beginTx();
+      expect(client.transactionDepth).toBe(1);
+      client.beginTx();
+      expect(client.transactionDepth).toBe(2);
+      client.commitTx();
+      expect(client.transactionDepth).toBe(1);
+      client.commitTx();
+      expect(client.transactionDepth).toBe(0);
+    });
+
+    it("keeps enqueued statements when committing a transaction", async () => {
+      const fetchMock = vi.fn<FetchLike>().mockResolvedValue(fakeOkResponse());
+      const client = new PostgresSyncClient(connection, "default", fetchMock);
+
+      client.beginTx();
+      client.enqueue("UPDATE x SET a = ? WHERE b = ?", [1, "y"]);
+      client.commitTx();
+
+      expect(client.pendingCount).toBe(1);
+      await client.flush();
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("drops statements enqueued since beginTx when rolled back", () => {
+      const client = new PostgresSyncClient(
+        connection,
+        "default",
+        vi.fn<FetchLike>(),
+      );
+
+      client.enqueue("INSERT INTO a (x) VALUES (?)", [1]); // before tx
+      client.beginTx();
+      client.enqueue("INSERT INTO a (x) VALUES (?)", [2]);
+      client.enqueue("INSERT INTO a (x) VALUES (?)", [3]);
+      expect(client.pendingCount).toBe(3);
+
+      client.rollbackTx();
+      expect(client.pendingCount).toBe(1);
+      expect(client.transactionDepth).toBe(0);
+    });
+
+    it("only rolls back to the innermost savepoint on nested rollback", () => {
+      const client = new PostgresSyncClient(
+        connection,
+        "default",
+        vi.fn<FetchLike>(),
+      );
+
+      client.beginTx();
+      client.enqueue("a", []);
+      client.beginTx();
+      client.enqueue("b", []);
+      client.enqueue("c", []);
+      expect(client.pendingCount).toBe(3);
+
+      client.rollbackTx(); // undo inner
+      expect(client.pendingCount).toBe(1);
+      expect(client.transactionDepth).toBe(1);
+
+      client.commitTx(); // commit outer
+      expect(client.pendingCount).toBe(1);
+      expect(client.transactionDepth).toBe(0);
+    });
+
+    it("rollbackTx without a matching begin is a safe no-op", () => {
+      const client = new PostgresSyncClient(
+        connection,
+        "default",
+        vi.fn<FetchLike>(),
+      );
+      client.enqueue("x", []);
+
+      expect(() => client.rollbackTx()).not.toThrow();
+      expect(client.pendingCount).toBe(1);
+      expect(client.transactionDepth).toBe(0);
+    });
+  });
+});

--- a/app/src/lib/gnucash/db/postgres-adapter.ts
+++ b/app/src/lib/gnucash/db/postgres-adapter.ts
@@ -1,0 +1,100 @@
+/**
+ * WritableDbAdapter backed by a local SQLite WASM cache and a PostgresSyncClient.
+ *
+ * Reads go straight to the local WASM DB — domain queries stay synchronous
+ * and cheap. Writes are applied locally first (so the engine's post-write
+ * `getFullDashboardData()` sees the change immediately) and enqueued on the
+ * sync client; the worker awaits `syncClient.flush()` once per UI mutation
+ * before responding so the round-trip to Postgres completes before the user
+ * sees the "saved" state.
+ *
+ * ## What this adapter does NOT do
+ *
+ * - No snapshot/restore on sync failure. If the server rejects a batch, the
+ *   local cache already contains the write. The caller surfaces the error
+ *   to the UI and a reload re-fetches the authoritative server state. A
+ *   richer recovery flow is out of scope for the MVP (see issue #48's
+ *   §10.6).
+ * - `exec(sql)` is local-only. The engine only uses `exec` for schema
+ *   bootstrap (BEGIN IMMEDIATE / CREATE TABLE IF NOT EXISTS), and the
+ *   server schema is already provisioned by the import route — we don't
+ *   want to ship BEGINs to the sync path.
+ */
+
+import type { PreparedQuery } from "./adapter";
+import type {
+  WritableDbAdapter,
+  RunResult,
+} from "../engine/db/writable-adapter";
+import type { PostgresSyncClient } from "./postgres-sync-client";
+
+/**
+ * Minimal interface for the SQLite WASM oo1.Database object; matches the
+ * subset `createWritableWasmAdapter` uses so we can reuse the same WASM
+ * instance behind either adapter.
+ */
+interface WasmDatabase {
+  selectObjects(sql: string, bind?: unknown[]): unknown[];
+  selectObject(sql: string, bind?: unknown[]): unknown | undefined;
+  exec(opts: { sql: string; bind?: unknown[]; returnValue?: string }): number;
+  close(): void;
+  changes(): number;
+}
+
+export function createWritablePostgresAdapter(
+  db: WasmDatabase,
+  syncClient: PostgresSyncClient,
+): WritableDbAdapter {
+  return {
+    prepare(sql: string): PreparedQuery {
+      return {
+        all(...params: unknown[]): unknown[] {
+          const bind = params.length > 0 ? (params as unknown[]) : undefined;
+          return db.selectObjects(sql, bind);
+        },
+        get(...params: unknown[]): unknown | undefined {
+          const bind = params.length > 0 ? (params as unknown[]) : undefined;
+          return db.selectObject(sql, bind);
+        },
+      };
+    },
+
+    run(sql: string, ...params: unknown[]): RunResult {
+      const bind = params.length > 0 ? (params as unknown[]) : undefined;
+      // Local write first — keeps the engine sync and means domain reads
+      // that follow this call immediately reflect the change.
+      db.exec({ sql, bind });
+      const changes = db.changes();
+      // Server sync: queue now, flush at the worker boundary.
+      syncClient.enqueue(sql, [...params]);
+      return { changes };
+    },
+
+    exec(sql: string): void {
+      // Local-only (see header note). The engine doesn't call this with
+      // parameterised SQL; it only uses it for BEGIN/COMMIT/ROLLBACK wrapping
+      // and the schema bootstrap DDL in writable-wasm-adapter, and neither of
+      // those should reach the server through this adapter.
+      db.exec({ sql });
+    },
+
+    transaction<T>(fn: () => T): T {
+      db.exec({ sql: "BEGIN IMMEDIATE" });
+      syncClient.beginTx();
+      try {
+        const result = fn();
+        db.exec({ sql: "COMMIT" });
+        syncClient.commitTx();
+        return result;
+      } catch (err) {
+        db.exec({ sql: "ROLLBACK" });
+        syncClient.rollbackTx();
+        throw err;
+      }
+    },
+
+    close(): void {
+      db.close();
+    },
+  };
+}

--- a/app/src/lib/gnucash/db/postgres-sync-client.ts
+++ b/app/src/lib/gnucash/db/postgres-sync-client.ts
@@ -1,0 +1,152 @@
+/**
+ * Browser-side sync client for the Postgres backend (#48).
+ *
+ * The engine's WritableDbAdapter interface is synchronous (`run` returns
+ * RunResult, not Promise), but sending writes to the server is inherently
+ * async. We bridge that by having the adapter apply each write locally first
+ * *and* enqueue it here; the worker then awaits `flush()` once at the end of
+ * every mutation handler, before posting the response back to the UI.
+ *
+ * Net effect: writes are "cache-and-sync" — the local WASM DB is updated
+ * immediately (engine stays sync), and the response to the UI only arrives
+ * after the server round-trip has succeeded.
+ *
+ * ## Transaction stacking
+ *
+ * The engine wraps most mutations in `adapter.transaction(fn)`. Those calls
+ * can nest (e.g. one domain op calls another). To keep the pending queue
+ * consistent with the local DB on rollback, `beginTx()` pushes the current
+ * queue length as a savepoint, `commitTx()` pops it (keeping the statements),
+ * and `rollbackTx()` pops AND truncates the queue back to that length so the
+ * aborted statements never reach the server.
+ */
+
+import type { PgConnection } from "@/lib/pg/connect";
+
+interface PendingStatement {
+  sql: string;
+  params: unknown[];
+}
+
+export interface SyncExecResponse {
+  results?: { changes: number }[];
+  error?: string;
+}
+
+/**
+ * Minimal fetch-compatible signature so tests can inject a stub without
+ * touching the global.
+ */
+export type FetchLike = (
+  input: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<Response>;
+
+export class PostgresSyncClient {
+  private readonly connection: PgConnection;
+  private readonly bookId: string;
+  private readonly fetchImpl: FetchLike;
+  private pending: PendingStatement[] = [];
+  /**
+   * Stack of pending-queue lengths captured at each `beginTx`. On rollback
+   * we truncate `pending` back to the top of this stack.
+   */
+  private txStack: number[] = [];
+
+  constructor(
+    connection: PgConnection,
+    bookId: string,
+    fetchImpl: FetchLike = globalThis.fetch.bind(globalThis) as FetchLike,
+  ) {
+    this.connection = connection;
+    this.bookId = bookId;
+    this.fetchImpl = fetchImpl;
+  }
+
+  /** Number of statements waiting to be flushed to the server. */
+  get pendingCount(): number {
+    return this.pending.length;
+  }
+
+  /** Depth of nested transactions currently open. Zero means no tx. */
+  get transactionDepth(): number {
+    return this.txStack.length;
+  }
+
+  /**
+   * Queue a mutation for the next flush. The adapter calls this after
+   * applying the same SQL locally. Never awaits — the worker awaits
+   * `flush()` once per UI mutation.
+   */
+  enqueue(sql: string, params: unknown[]): void {
+    this.pending.push({ sql, params });
+  }
+
+  /**
+   * Mark the start of an engine-level transaction. Records the current
+   * queue length so a subsequent rollback can truncate back to it.
+   */
+  beginTx(): void {
+    this.txStack.push(this.pending.length);
+  }
+
+  /**
+   * Mark the end of an engine-level transaction. Keeps the enqueued
+   * statements (they'll be flushed to the server as part of the next batch).
+   * No-op if we weren't in a transaction — the adapter guards against that
+   * but we stay defensive since the worker may surface misuse during wiring.
+   */
+  commitTx(): void {
+    this.txStack.pop();
+  }
+
+  /**
+   * Discard every statement enqueued since the matching `beginTx`. The
+   * caller is responsible for rolling back the local DB — this side just
+   * keeps the server queue consistent with what the local DB ended up with.
+   */
+  rollbackTx(): void {
+    const savepoint = this.txStack.pop();
+    if (savepoint !== undefined) {
+      this.pending.length = savepoint;
+    }
+  }
+
+  /**
+   * POST every pending statement to /api/pg/book/exec and clear the queue.
+   * The route wraps the batch in a single PG transaction, so the flush is
+   * all-or-nothing on the server side.
+   *
+   * On non-2xx response or network failure, the queue is drained anyway (the
+   * local DB already committed, so leaving stale statements in the queue
+   * would only make the next flush worse). The caller is expected to surface
+   * the error to the user — a reload will re-fetch the authoritative server
+   * state.
+   */
+  async flush(): Promise<void> {
+    if (this.pending.length === 0) return;
+    const batch = this.pending;
+    this.pending = [];
+
+    const res = await this.fetchImpl("/api/pg/book/exec", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        connection: this.connection,
+        bookId: this.bookId,
+        statements: batch,
+      }),
+    });
+
+    if (!res.ok) {
+      let message = `Sync failed: HTTP ${res.status}`;
+      try {
+        const body = (await res.json()) as SyncExecResponse;
+        if (body.error) message = `Sync failed: ${body.error}`;
+      } catch {
+        // Body wasn't JSON — keep the HTTP-status message.
+      }
+      throw new Error(message);
+    }
+  }
+}

--- a/app/src/lib/gnucash/worker/client.ts
+++ b/app/src/lib/gnucash/worker/client.ts
@@ -17,7 +17,7 @@ import type {
   BudgetData,
   DashboardData,
 } from "@/lib/types/gnucash";
-import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
 import { parseGnuCashXml } from "../xml/parser";
 
 type PendingRequest = {
@@ -190,6 +190,43 @@ export class GnuCashWorkerClient {
       };
 
       this.send({ type: "init", fileBuffer: buffer, writable }, [buffer]);
+    });
+  }
+
+  /**
+   * Open a book from a Postgres dump payload. The caller (typically the
+   * upload flow's server-connect panel) has already fetched the gzipped dump
+   * from `/api/pg/book/dump` and decompressed it to a `PostgresDumpPayload`.
+   * The worker rebuilds an in-memory SQLite WASM cache from the dump and
+   * wraps it with a writable adapter that cache-and-syncs every mutation to
+   * the same Postgres schema.
+   *
+   * Unlike `openFile`, there is no format detection and no OPFS write — the
+   * server is the source of truth, and reloading the page re-fetches from it.
+   */
+  async openFromPostgresDump(
+    dump: PostgresDumpPayload,
+    connection: PostgresConnectionInfo,
+    bookId: string,
+  ): Promise<void> {
+    await this.wasmReady;
+
+    return new Promise<void>((resolve, reject) => {
+      const prevHandler = this.worker.onmessage;
+      this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+        const msg = e.data;
+        if (msg.type === "ready") {
+          this.worker.onmessage = prevHandler;
+          resolve();
+        } else if (msg.type === "init-error") {
+          this.worker.onmessage = prevHandler;
+          reject(new Error(msg.message));
+        } else {
+          this.handleMessage(msg);
+        }
+      };
+
+      this.send({ type: "init-pg-dump", dump, connection, bookId });
     });
   }
 

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -33,9 +33,11 @@ import { updateAccount, deleteAccountWithReallocation } from "../engine/operatio
 import { createCommodity } from "../engine/operations/commodity-ops";
 import { addPrice, deletePrice } from "../engine/operations/price-ops";
 import type { AccountType } from "../engine/types";
-import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
 import type { GnuCashXmlData } from "../xml/types";
 import { GNUCASH_SCHEMA_DDL } from "../xml/schema";
+import { PostgresSyncClient } from "../db/postgres-sync-client";
+import { createWritablePostgresAdapter } from "../db/postgres-adapter";
 
 let sqlite3: Sqlite3Static;
 
@@ -66,8 +68,43 @@ let db: WasmDatabase | null = null;
 let ctx: ParseContext | null = null;
 let isWritable = false;
 let writableAdapter: WritableDbAdapter | null = null;
+/**
+ * Non-null when the currently open book is backed by the Server (Postgres)
+ * backend. Set by `initFromPostgresDump`; cleared by `closeDb`. When set,
+ * every mutation handler awaits `syncClient.flush()` before responding so
+ * the UI only sees the "saved" state after the Postgres round-trip.
+ */
+let syncClient: PostgresSyncClient | null = null;
 
 const OPFS_DB_NAME = "/gnucash-dashboard.db";
+
+/**
+ * DDL for ancillary engine tables (`lots`) that older .gnucash files may be
+ * missing. Duplicates the private ENSURE_TABLES_SQL in writable-wasm-adapter
+ * so the Postgres-backed local cache can bootstrap the same shape without
+ * depending on the writable adapter that we are intentionally NOT using here.
+ */
+const EXTRA_ENGINE_TABLES_SQL = `
+  CREATE TABLE IF NOT EXISTS lots (
+    guid TEXT PRIMARY KEY,
+    account_guid TEXT NOT NULL,
+    is_closed INTEGER DEFAULT 0
+  );
+  CREATE TABLE IF NOT EXISTS slots (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    obj_guid TEXT NOT NULL,
+    name TEXT NOT NULL,
+    slot_type INTEGER NOT NULL,
+    int64_val INTEGER,
+    string_val TEXT,
+    double_val REAL,
+    timespec_val TEXT,
+    guid_val TEXT,
+    numeric_val_num INTEGER,
+    numeric_val_denom INTEGER,
+    gdate_val TEXT
+  );
+`;
 
 function post(msg: WorkerResponse) {
   self.postMessage(msg);
@@ -268,6 +305,56 @@ function closeDb(): void {
     writableAdapter = null;
     isWritable = false;
   }
+  syncClient = null;
+}
+
+/**
+ * Build an in-memory SQLite WASM cache from a `/api/pg/book/dump` payload and
+ * wrap it with a Postgres-backed writable adapter. The local cache uses the
+ * engine's existing SQLite DDL (INTEGER / TEXT affinities) — SQLite's type
+ * system transparently coerces the BIGINT-as-string values that node-postgres
+ * returns into INTEGER for the numeric-pair columns, so no per-column
+ * normalisation is required here.
+ *
+ * Every mutation routed through the resulting adapter will be applied
+ * locally first and enqueued on `syncClient`; the mutation handler in the
+ * message loop awaits `syncClient.flush()` before posting the result.
+ */
+function initFromPostgresDump(
+  dump: PostgresDumpPayload,
+  connection: PostgresConnectionInfo,
+  bookId: string,
+): void {
+  closeDb();
+  isWritable = true;
+
+  db = new sqlite3.oo1.DB();
+  db.exec({ sql: GNUCASH_SCHEMA_DDL });
+  db.exec({ sql: EXTRA_ENGINE_TABLES_SQL });
+
+  for (const [table, rows] of Object.entries(dump.tables)) {
+    if (rows.length === 0) continue;
+    // `gnudash_meta` is a Postgres-only metadata table — the local cache has
+    // no schema for it and the engine never reads it.
+    if (table === "gnudash_meta") continue;
+    // Defensive: drop any columns the local SQLite schema does not declare.
+    // In practice the two match, but this keeps us forward-compatible if the
+    // Postgres schema ever gains a column the engine doesn't know about.
+    const columns = Object.keys(rows[0]);
+    const placeholders = columns.map(() => "?").join(", ");
+    const sql = `INSERT INTO ${table} (${columns.join(", ")}) VALUES (${placeholders})`;
+    for (const row of rows) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const values = columns.map((c) => row[c]) as any[];
+      db.exec({ sql, bind: values });
+    }
+  }
+
+  syncClient = new PostgresSyncClient(connection, bookId);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  writableAdapter = createWritablePostgresAdapter(db as any, syncClient);
+  validateSchema(writableAdapter);
+  ctx = buildParseContext(writableAdapter);
 }
 
 function getFullDashboardData(): DashboardData {
@@ -716,6 +803,21 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       break;
     }
 
+    case "init-pg-dump": {
+      try {
+        initFromPostgresDump(msg.dump, msg.connection, msg.bookId);
+        console.log(
+          "[db-worker] DB restored from Postgres dump",
+          `book=${msg.bookId}`,
+          "(read-write, syncing)",
+        );
+        post({ type: "ready" });
+      } catch (err) {
+        post({ type: "init-error", message: (err as Error).message });
+      }
+      break;
+    }
+
     case "query": {
       try {
         if (!ctx) throw new Error("No database loaded");
@@ -769,6 +871,14 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
             break;
           default:
             throw new Error(`Unknown mutation action: ${msg.action}`);
+        }
+        // On the Postgres backend, round-trip the pending write batch before
+        // telling the UI the mutation succeeded. Sync errors propagate to the
+        // catch block and surface as a standard `error` response — the UI is
+        // expected to show the message and prompt the user to reload so the
+        // local cache can reconcile with authoritative server state.
+        if (syncClient) {
+          await syncClient.flush();
         }
         post({ type: "result", id: msg.id, data });
       } catch (err) {

--- a/app/src/lib/gnucash/worker/messages.ts
+++ b/app/src/lib/gnucash/worker/messages.ts
@@ -5,10 +5,34 @@
 
 import type { GnuCashXmlData } from "../xml/types";
 
+/** Connection params for the Postgres backend (#48). Mirrors `PgConnection`
+ *  in `lib/pg/connect.ts` but lives here so worker modules never need to
+ *  import from the server-only `pg/connect` module. */
+export interface PostgresConnectionInfo {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+  ssl?: boolean;
+}
+
+/** Shape of the payload `/api/pg/book/dump` returns (after gunzip). */
+export interface PostgresDumpPayload {
+  version: 1;
+  tables: Record<string, Record<string, unknown>[]>;
+}
+
 export type WorkerRequest =
   | { type: "init"; fileBuffer: ArrayBuffer; writable?: boolean }
   | { type: "init-xml"; xmlData: GnuCashXmlData }
   | { type: "init-opfs"; fileName: string; writable?: boolean }
+  | {
+      type: "init-pg-dump";
+      dump: PostgresDumpPayload;
+      connection: PostgresConnectionInfo;
+      bookId: string;
+    }
   | { type: "query"; id: string; fn: DomainFunction }
   | { type: "mutation"; id: string; action: MutationAction; payload: unknown }
   | { type: "set-currency"; id: string; currencyGuid: string }


### PR DESCRIPTION
Fourth PR of the Server (Postgres) backend series. Refs #48.

## Summary

Connects the engine's \`WritableDbAdapter\` interface to the API routes from PR 3. Cache-and-sync architecture: reads hit a local SQLite WASM cache, writes apply locally first and round-trip to Postgres before the UI sees \"saved\".

- **\`db/postgres-sync-client.ts\`** — \`enqueue\` + \`flush\`, plus savepoint-style \`beginTx\`/\`commitTx\`/\`rollbackTx\` so nested engine transactions keep the server queue consistent with the local DB on rollback. Injectable fetch for tests. Drains the queue on failure so retries don't double-send.

- **\`db/postgres-adapter.ts\`** — \`createWritablePostgresAdapter(db, syncClient)\`. \`run()\` applies locally then enqueues; \`transaction(fn)\` wraps local \`BEGIN\`/\`COMMIT\` plus sync-client \`begin\`/\`commit\`; thrown errors trigger \`ROLLBACK\` on both. \`exec()\` is local-only — \`BEGIN\`/DDL never reach the sync path.

- **Worker wiring**
  - \`messages.ts\`: new \`init-pg-dump\` request carrying the dump payload + connection + bookId. \`PostgresConnectionInfo\` defined here so worker code never imports from the server-only \`lib/pg/connect\`.
  - \`db-worker.ts\`: module-level \`syncClient\`, \`initFromPostgresDump\` that creates a fresh SQLite WASM DB, applies \`GNUCASH_SCHEMA_DDL\` plus the \`lots\`/\`slots\` bootstrap, bulk-inserts the dump rows, and wraps with the PG adapter. The existing \`mutation\` case now \`await\`s \`syncClient.flush()\` when on the PG backend; sync errors surface via the existing \`error\` response channel.
  - \`client.ts\`: \`openFromPostgresDump(dump, connection, bookId)\` symmetric to \`openFile\` — no format detection, no OPFS write (the server is source of truth; reload re-fetches).

## Design calls

- **Why flush at the worker boundary, not inside the adapter?** The \`WritableDbAdapter\` interface is synchronous. Awaiting inside \`run()\` would require changing the interface (issue #74) and refactoring every callsite. Per-mutation flush at the message-handler boundary gives the same user-visible guarantee (server round-trip before the UI sees success) without that refactor.
- **Why BIGINT-as-string from \`pg\` survives?** SQLite's INTEGER column affinity coerces numeric-looking strings back to integers on insert. Dates stay as strings (TEXT affinity preserved) and numeric-pair columns end up as real integers, so the engine's math works unchanged.
- **Why no snapshot-restore on sync failure?** The plan's MVP-scope decision (§10.6 in the internal handoff). If the server rejects a batch, the local cache has the write but the server doesn't; the UI surfaces the error and a reload reconciles. Tracking richer recovery elsewhere.

## Test plan

- [x] 21 new unit tests (\`npm run test\`)
  - \`PostgresSyncClient\`: enqueue/flush, error-body handling, queue drained on failure, nested \`begin\`/\`commit\`/\`rollback\` stacking
  - \`createWritablePostgresAdapter\`: BEGIN/COMMIT/ROLLBACK ordering, sync-queue interactions, nested tx where inner rolls back and outer statements survive, \`exec\` stays local
- [x] Full suite: **217/217 passing** — existing 198 + 11 PR 3 integration (ran against the local Postgres I had up for manual testing of PR 3) + 19 new here (counts include setup/shared \`describe\` entries)
- [x] \`npm run build\` (standalone) — compiles cleanly, all 6 API routes intact
- [x] \`NEXT_OUTPUT=export npm run build\` (static export) — worker bundle compiles; \`api/\` still parked cleanly by \`next-build.mjs\`
- [x] \`npx tsc --noEmit\` clean; \`npm run lint\` clean for all new/modified files

## Still needed for a usable Server-backend flow

- **PR 5**: OPFS-persisted server settings so a page reload doesn't force the user to re-enter credentials.
- **PR 6**: upload UI restructure — the Server tab, connection form, and the client-side XML→SQLite conversion step that feeds \`/api/pg/book/import\`. Only after PR 6 will this adapter actually get wired into a user-visible flow.
- **PR 7**: reupload-from-dashboard (uses \`book/drop\` + \`book/import\`).
- **PR 8**: auto-reconnect on app boot + final docs, closes #48.