### PR TITLE
Add OPFS-persisted server config helper for auto-reconnect

### DIFF
--- a/app/src/lib/gnucash/db/__tests__/postgres-adapter.test.ts
+++ b/app/src/lib/gnucash/db/__tests__/postgres-adapter.test.ts
@@ -23,8 +23,12 @@ function makeFakeDb() {
     setChanges(n: number) {
       changesValue = n;
     },
-    selectObjects: vi.fn(() => []),
-    selectObject: vi.fn(() => undefined),
+    selectObjects: vi.fn<(sql: string, bind?: unknown[]) => unknown[]>(
+      () => [],
+    ),
+    selectObject: vi.fn<
+      (sql: string, bind?: unknown[]) => unknown | undefined
+    >(() => undefined),
     exec: vi.fn((opts: { sql: string; bind?: unknown[] }) => {
       execCalls.push(opts);
       return 0;

--- a/app/src/lib/storage/__tests__/server-config.test.ts
+++ b/app/src/lib/storage/__tests__/server-config.test.ts
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearServerConfig,
+  hasServerConfig,
+  isServerConfigSupported,
+  loadServerConfig,
+  saveServerConfig,
+  type ServerConfig,
+} from "../server-config";
+
+/**
+ * Minimal in-memory OPFS stand-in. Holds files as string contents keyed by
+ * name and implements just the subset of the real API the helper uses.
+ */
+function installOpfsMock(): Map<string, string> {
+  const files = new Map<string, string>();
+
+  const storage = {
+    async getDirectory() {
+      return {
+        async getFileHandle(
+          name: string,
+          opts?: { create?: boolean },
+        ) {
+          if (!files.has(name) && !opts?.create) {
+            throw new DOMException("not found", "NotFoundError");
+          }
+          if (!files.has(name)) files.set(name, "");
+          return {
+            async getFile() {
+              if (!files.has(name)) {
+                throw new DOMException("not found", "NotFoundError");
+              }
+              const contents = files.get(name) ?? "";
+              return {
+                async text() {
+                  return contents;
+                },
+              };
+            },
+            async createWritable() {
+              let buffer = "";
+              return {
+                async write(data: string) {
+                  buffer += data;
+                },
+                async close() {
+                  files.set(name, buffer);
+                },
+              };
+            },
+          };
+        },
+        async removeEntry(name: string) {
+          if (!files.has(name)) {
+            throw new DOMException("not found", "NotFoundError");
+          }
+          files.delete(name);
+        },
+      };
+    },
+  };
+
+  vi.stubGlobal("navigator", { storage });
+  return files;
+}
+
+const validConfig: ServerConfig = {
+  host: "db.example",
+  port: 5432,
+  user: "gnudash",
+  password: "hunter2",
+  database: "gnudash",
+  bookId: "default",
+};
+
+describe("isServerConfigSupported", () => {
+  it("returns true when navigator.storage.getDirectory exists", () => {
+    installOpfsMock();
+    expect(isServerConfigSupported()).toBe(true);
+  });
+
+  it("returns false when navigator is undefined", () => {
+    vi.stubGlobal("navigator", undefined);
+    expect(isServerConfigSupported()).toBe(false);
+  });
+
+  it("returns false when storage.getDirectory is missing", () => {
+    vi.stubGlobal("navigator", { storage: {} });
+    expect(isServerConfigSupported()).toBe(false);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+});
+
+describe("OPFS round-trip", () => {
+  beforeEach(() => {
+    installOpfsMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("save then load returns an equivalent config", async () => {
+    await saveServerConfig(validConfig);
+    const loaded = await loadServerConfig();
+    expect(loaded).toEqual(validConfig);
+  });
+
+  it("preserves the optional ssl flag when true", async () => {
+    await saveServerConfig({ ...validConfig, ssl: true });
+    const loaded = await loadServerConfig();
+    expect(loaded?.ssl).toBe(true);
+  });
+
+  it("hasServerConfig flips true after save and false after clear", async () => {
+    expect(await hasServerConfig()).toBe(false);
+    await saveServerConfig(validConfig);
+    expect(await hasServerConfig()).toBe(true);
+    await clearServerConfig();
+    expect(await hasServerConfig()).toBe(false);
+  });
+
+  it("overwrites an existing file on save", async () => {
+    await saveServerConfig(validConfig);
+    await saveServerConfig({ ...validConfig, host: "new.example" });
+    const loaded = await loadServerConfig();
+    expect(loaded?.host).toBe("new.example");
+  });
+
+  it("clearServerConfig is idempotent when no file exists", async () => {
+    await expect(clearServerConfig()).resolves.toBeUndefined();
+  });
+});
+
+describe("loadServerConfig validation", () => {
+  beforeEach(() => {
+    installOpfsMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("returns null when nothing has been saved", async () => {
+    expect(await loadServerConfig()).toBeNull();
+  });
+
+  it("returns null when the file holds invalid JSON", async () => {
+    const files = installOpfsMock();
+    files.set("gnudash-server.json", "not {valid} json");
+    expect(await loadServerConfig()).toBeNull();
+  });
+
+  it("returns null when fields are missing", async () => {
+    const files = installOpfsMock();
+    files.set(
+      "gnudash-server.json",
+      JSON.stringify({ host: "x", port: 5432 }),
+    );
+    expect(await loadServerConfig()).toBeNull();
+  });
+
+  it("returns null when a field has the wrong type", async () => {
+    const files = installOpfsMock();
+    files.set(
+      "gnudash-server.json",
+      JSON.stringify({ ...validConfig, port: "5432" }),
+    );
+    expect(await loadServerConfig()).toBeNull();
+  });
+
+  it("drops an unknown ssl type instead of rejecting the whole file", async () => {
+    const files = installOpfsMock();
+    files.set(
+      "gnudash-server.json",
+      JSON.stringify({ ...validConfig, ssl: "yes" }),
+    );
+    const loaded = await loadServerConfig();
+    expect(loaded).not.toBeNull();
+    expect(loaded?.ssl).toBeUndefined();
+  });
+});
+
+describe("no-OPFS fallback behaviour", () => {
+  beforeEach(() => {
+    vi.stubGlobal("navigator", { storage: {} });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loadServerConfig returns null", async () => {
+    expect(await loadServerConfig()).toBeNull();
+  });
+
+  it("hasServerConfig returns false", async () => {
+    expect(await hasServerConfig()).toBe(false);
+  });
+
+  it("saveServerConfig throws a clear error", async () => {
+    await expect(saveServerConfig(validConfig)).rejects.toThrow(
+      /OPFS is not available/,
+    );
+  });
+
+  it("clearServerConfig is a no-op", async () => {
+    await expect(clearServerConfig()).resolves.toBeUndefined();
+  });
+});

--- a/app/src/lib/storage/server-config.ts
+++ b/app/src/lib/storage/server-config.ts
@@ -1,0 +1,169 @@
+/**
+ * OPFS-persisted Server-backend configuration (#48).
+ *
+ * Stores the Postgres connection parameters the user filled into the Server
+ * tab of the upload screen so subsequent visits to the app can auto-reconnect
+ * without prompting. Lives in the origin's private filesystem — never
+ * transmitted across the network, never readable by other origins.
+ *
+ * ## SECURITY
+ *
+ * **This file stores the Postgres password in plaintext.** OPFS is sandboxed
+ * per-origin and isolated from other websites, but it is still accessible to
+ * any JavaScript running on this origin (e.g. a malicious browser extension
+ * or a future XSS in this app). Deployments where that matters should:
+ *
+ *  - host this app behind an auth layer that users trust, and
+ *  - never reuse the Postgres password anywhere outside this app.
+ *
+ * Encryption at rest is tracked as out-of-scope in the PR #48 handoff;
+ * implementing it would require deriving a key from something that survives
+ * a page reload but isn't plaintext-persisted itself, which is non-trivial
+ * and not worth gating MVP on.
+ */
+
+/**
+ * Shape of the config we persist. Mirrors `PgConnection` (from
+ * `lib/pg/connect`) plus the active `bookId` so the auto-reconnect path can
+ * target the same schema without prompting.
+ */
+export interface ServerConfig {
+  host: string;
+  port: number;
+  user: string;
+  password: string;
+  database: string;
+  bookId: string;
+  /** Enable TLS. Required for any non-localhost deployment. */
+  ssl?: boolean;
+}
+
+/** Filename inside the OPFS root. */
+const FILE_NAME = "gnudash-server.json";
+
+/**
+ * Whether OPFS is available in this environment. Old browsers and test
+ * harnesses that don't stub navigator.storage return false; every persistence
+ * helper below fails gracefully when support is missing so callers don't need
+ * to guard.
+ */
+export function isServerConfigSupported(): boolean {
+  return (
+    typeof navigator !== "undefined" &&
+    "storage" in navigator &&
+    typeof navigator.storage?.getDirectory === "function"
+  );
+}
+
+/**
+ * Read and parse the persisted config, or return null if there isn't one
+ * (file missing) or the file is unreadable / corrupt. Returning null rather
+ * than throwing keeps the auto-reconnect path simple: the caller treats
+ * "nothing to restore" and "something went wrong restoring" identically by
+ * falling through to the upload screen.
+ */
+export async function loadServerConfig(): Promise<ServerConfig | null> {
+  if (!isServerConfigSupported()) return null;
+  try {
+    const root = await navigator.storage.getDirectory();
+    const handle = await root.getFileHandle(FILE_NAME);
+    const file = await handle.getFile();
+    const text = await file.text();
+    return parseServerConfig(text);
+  } catch {
+    // Either the file doesn't exist yet, or reading/parsing failed. Both
+    // collapse to "no usable config" — clearing a truly corrupt file is the
+    // caller's decision.
+    return null;
+  }
+}
+
+/**
+ * Write the config to OPFS, overwriting any existing one. Call this ONLY
+ * after a successful connect+dump round-trip — persisting on a failed
+ * connect would trap the user in an auto-reconnect loop on next load.
+ *
+ * Throws if OPFS isn't available or the write fails; callers should show
+ * the error to the user but the connection itself is still usable (this is
+ * a "remember for next time" convenience, not a data-integrity concern).
+ */
+export async function saveServerConfig(config: ServerConfig): Promise<void> {
+  if (!isServerConfigSupported()) {
+    throw new Error("OPFS is not available in this environment.");
+  }
+  const root = await navigator.storage.getDirectory();
+  const handle = await root.getFileHandle(FILE_NAME, { create: true });
+  const writable = await handle.createWritable();
+  try {
+    await writable.write(JSON.stringify(config));
+  } finally {
+    await writable.close();
+  }
+}
+
+/**
+ * Delete the persisted config. Used by logout / clear-data flows — after
+ * calling this, `loadServerConfig()` returns null.
+ *
+ * Idempotent: missing file is not an error.
+ */
+export async function clearServerConfig(): Promise<void> {
+  if (!isServerConfigSupported()) return;
+  try {
+    const root = await navigator.storage.getDirectory();
+    await root.removeEntry(FILE_NAME);
+  } catch {
+    // File already gone — fine.
+  }
+}
+
+/** Fast "is there a config?" probe that doesn't read or parse the file. */
+export async function hasServerConfig(): Promise<boolean> {
+  if (!isServerConfigSupported()) return false;
+  try {
+    const root = await navigator.storage.getDirectory();
+    await root.getFileHandle(FILE_NAME);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate and return a ServerConfig from raw text. Missing/wrong-typed
+ * fields cause a null return — we'd rather fall back to the upload screen
+ * than feed garbage into an auto-reconnect attempt.
+ */
+function parseServerConfig(text: string): ServerConfig | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+  if (!isRecord(parsed)) return null;
+  const cfg = parsed as Partial<ServerConfig>;
+  if (
+    typeof cfg.host !== "string" ||
+    typeof cfg.port !== "number" ||
+    typeof cfg.user !== "string" ||
+    typeof cfg.password !== "string" ||
+    typeof cfg.database !== "string" ||
+    typeof cfg.bookId !== "string"
+  ) {
+    return null;
+  }
+  return {
+    host: cfg.host,
+    port: cfg.port,
+    user: cfg.user,
+    password: cfg.password,
+    database: cfg.database,
+    bookId: cfg.bookId,
+    ssl: typeof cfg.ssl === "boolean" ? cfg.ssl : undefined,
+  };
+}
+
+function isRecord(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}


### PR DESCRIPTION
Fifth PR of the Server (Postgres) backend series. Refs #48.

## Summary

Small, focused helper that PR 6 will call on successful import/dump (persist-for-next-visit) and PR 8 will call on app boot (auto-reconnect).

**\`lib/storage/server-config.ts\`** exports:

| | |
|---|---|
| \`ServerConfig\` | \`{ host, port, user, password, database, bookId, ssl? }\` |
| \`loadServerConfig()\` | returns null on missing, corrupt, or wrong-typed data — "nothing to restore" and "restore failed" collapse to the same caller-side fallback (show the upload screen) |
| \`saveServerConfig(cfg)\` | whole-file JSON write; throws only when OPFS itself is unavailable |
| \`clearServerConfig()\` | idempotent delete |
| \`hasServerConfig()\` | fast probe without reading/parsing |
| \`isServerConfigSupported()\` | runtime capability check |

File lives at OPFS root as \`gnudash-server.json\`.

## Security note

Credentials are stored **plaintext** in OPFS. OPFS is origin-sandboxed (not reachable by other websites), but any script running on this origin (a malicious extension, a future XSS) can read it. The file header spells this out. Encryption at rest is tracked as out-of-scope in the #48 handoff — doing it properly needs a passphrase/WebAuthn derivation path that's more work than MVP justifies.

## Test plan

- [x] 17 unit tests passing (\`npm run test src/lib/storage\`)
  - roundtrip save/load including \`ssl=true\`
  - missing-file, corrupt-JSON, missing-fields, wrong-typed-field → null
  - \`ssl\` with an unknown type drops the field rather than rejecting the whole file
  - \`hasServerConfig\` tracks save/clear correctly
  - \`clearServerConfig\` is idempotent
  - no-OPFS branch: \`load\`/\`has\` return null/false, \`save\` throws with a clear message, \`clear\` is a no-op
- [x] Full suite **234/234 passing**
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run lint\` clean for new files

## Drive-by fix

\`postgres-adapter.test.ts\` (from PR 4) was emitting two \`TS2322\` errors under \`npx tsc --noEmit\` — vitest's esbuild transform accepted them but strict tsc didn't. Typed the \`makeFakeDb\` stubs explicitly so later \`db.selectObjects = vi.fn(...)\` reassignments with real row shapes type-check. Caught by running tsc on this branch; no runtime behaviour change.