### PR TITLE
Filter import columns to match the target PG schema

### DIFF
--- a/app/src/app/api/pg/book/import/route.ts
+++ b/app/src/app/api/pg/book/import/route.ts
@@ -133,7 +133,17 @@ export async function POST(request: Request) {
             if (table === "gnudash_meta") continue;
             const rows = rowsByTable[table];
             if (!rows || rows.length === 0) continue;
-            await bulkInsert(client, schema, table, rows);
+            // Real .gnucash SQLite files carry a wider column set than our
+            // PG DDL — e.g. commodities has quote_flag/quote_source/quote_tz
+            // that the engine never touches. Ask PG what columns actually
+            // exist in the freshly-created table and only copy those, so
+            // source-schema drift never produces an INSERT failure.
+            const targetColumns = await fetchTableColumns(
+              client,
+              schema,
+              table,
+            );
+            await bulkInsert(client, schema, table, rows, targetColumns);
           }
 
           // Bump the underlying sequence past any explicit `id` values we
@@ -261,14 +271,36 @@ function readSourceTables(
   return out;
 }
 
-/** Insert rows in chunks so we don't exceed PG's parameter limit (~65k). */
+/** Column names present in `schema.table` in the target Postgres. */
+async function fetchTableColumns(
+  client: import("pg").Client,
+  schema: string,
+  table: string,
+): Promise<Set<string>> {
+  const res = await client.query<{ column_name: string }>(
+    `SELECT column_name FROM information_schema.columns
+     WHERE table_schema = $1 AND table_name = $2`,
+    [schema, table],
+  );
+  return new Set(res.rows.map((r) => r.column_name));
+}
+
+/**
+ * Insert rows in chunks so we don't exceed PG's parameter limit (~65k).
+ * Only columns in `targetColumns` are copied; extra columns present in the
+ * source .gnucash file (e.g. `quote_flag` on `commodities`) are silently
+ * dropped because our schema doesn't declare them and the engine doesn't
+ * use them.
+ */
 async function bulkInsert(
   client: import("pg").Client,
   schema: string,
   table: string,
   rows: Record<string, unknown>[],
+  targetColumns: Set<string>,
 ): Promise<void> {
-  const columns = Object.keys(rows[0]);
+  const columns = Object.keys(rows[0]).filter((c) => targetColumns.has(c));
+  if (columns.length === 0) return;
   const CHUNK = 500;
   for (let start = 0; start < rows.length; start += CHUNK) {
     const chunk = rows.slice(start, start + CHUNK);


### PR DESCRIPTION
Hotfix for the Postgres backend import route. Refs #48.

## What you saw

\`column \"quote_flag\" of relation \"commodities\" does not exist\` when uploading a real \`.gnucash\` file via the Server tab in PR 6.

## Why

Real GnuCash SQLite files include a wider column set than the engine uses — \`commodities\` has \`quote_flag\`, \`quote_source\`, \`quote_tz\` and other tables have similar extras. \`GNUCASH_POSTGRES_DDL\` (PR 2) was modeled off \`xml/schema.ts\`'s minimal DDL and only declares the columns the engine reads or writes, so the superset from the source file has nowhere to land.

PR 3's import route did \`SELECT * FROM <source.table>\` and piped the keys verbatim into \`INSERT\`, which blew up the first time someone hit it with a real file.

## Fix

Query \`information_schema.columns\` for the freshly-created target table, intersect with the source row's keys, only copy the intersection. Extra source columns are silently dropped — the engine doesn't use them anyway. Missing engine-required columns still fail early via \`validateSourceFile\` (unchanged).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 234/234 passing
- [x] PR 3's integration tests still pass — the fixture doesn't have the extra columns, so behaviour on it is unchanged
- [ ] **Manual verification with a real file** — after merging, please retry the import flow from PR 6 (\`docker compose up -d postgres && cd app && npm run dev\`, Server tab, drop a \`.gnucash\` file)

## Follow-up

Once this merges I'll rebase PR 6 on updated main so it picks up the fix.