### PR TITLE
Add reupload-to-Postgres button in the sidebar

### DIFF
--- a/app/src/components/dashboard/sidebar.tsx
+++ b/app/src/components/dashboard/sidebar.tsx
@@ -13,6 +13,7 @@ import {
   Wand2,
 } from "lucide-react";
 import { useDashboard } from "@/lib/dashboard-context";
+import { ReuploadButton } from "@/components/upload/reupload-button";
 
 const mainNav = [
   { icon: Home, label: "Dashboard", href: "/" },
@@ -30,7 +31,7 @@ interface SidebarProps {
 }
 
 export function Sidebar({ onNavigate, expanded }: SidebarProps) {
-  const { clearData, uploadedAt, exportFile } = useDashboard();
+  const { clearData, uploadedAt, exportFile, backend } = useDashboard();
   const pathname = usePathname();
 
   return (
@@ -82,7 +83,7 @@ export function Sidebar({ onNavigate, expanded }: SidebarProps) {
         </div>
       </div>
 
-      {/* Bottom: Export + Upload new file */}
+      {/* Bottom: Export + Reupload (PG only) + Upload new file */}
       <div className={`mt-auto border-t border-border ${expanded ? "p-5" : "p-2"}`}>
         <button
           onClick={exportFile}
@@ -96,9 +97,10 @@ export function Sidebar({ onNavigate, expanded }: SidebarProps) {
           <Download className="h-[18px] w-[18px] shrink-0 text-muted-foreground/70" />
           {expanded && "Export .gnucash file"}
         </button>
+        {backend === "postgres" && <ReuploadButton expanded={expanded} />}
         <button
           onClick={clearData}
-          title="Upload new file"
+          title={backend === "postgres" ? "Disconnect" : "Upload new file"}
           className={`flex items-center rounded-[10px] text-sm text-muted-foreground transition-colors hover:bg-muted whitespace-nowrap ${
             expanded
               ? "w-full gap-2.5 px-3 py-2"
@@ -106,7 +108,7 @@ export function Sidebar({ onNavigate, expanded }: SidebarProps) {
           }`}
         >
           <LogOut className="h-[18px] w-[18px] shrink-0 text-muted-foreground/70" />
-          {expanded && "Upload new file"}
+          {expanded && (backend === "postgres" ? "Disconnect" : "Upload new file")}
         </button>
         {expanded && uploadedAt && (
           <p className="mt-1.5 px-3 text-xs text-muted-foreground/70">

--- a/app/src/components/upload/reupload-button.tsx
+++ b/app/src/components/upload/reupload-button.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback } from "react";
+import { Upload } from "lucide-react";
+import { useDashboard } from "@/lib/dashboard-context";
+
+interface ReuploadButtonProps {
+  /** True when the sidebar is expanded so we show the label; icon-only otherwise. */
+  expanded?: boolean;
+}
+
+/**
+ * Sidebar button shown only when the active book is on the Postgres backend.
+ *
+ * Clicking prompts for confirmation (this destroys the server book), then a
+ * file picker, then calls `reuploadPostgresBook` which drops+imports+reloads
+ * in one go. The import route (PR 3 + fix/pg-import-schema-and-rollback)
+ * does the drop+recreate atomically in a single transaction, so a mid-import
+ * failure leaves the previous book intact on the server — the user just sees
+ * an inline error and can retry.
+ *
+ * Kept sibling to local-upload-panel / server-connect-panel so all
+ * upload-adjacent UI lives in one folder.
+ */
+export function ReuploadButton({ expanded = true }: ReuploadButtonProps) {
+  const { reuploadPostgresBook, isLoading } = useDashboard();
+
+  const handleClick = useCallback(() => {
+    if (isLoading) return;
+    if (
+      !window.confirm(
+        "This will drop the existing Postgres book and replace it with the " +
+          "file you pick. Continue?",
+      )
+    ) {
+      return;
+    }
+
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = ".gnucash";
+    input.onchange = async (e) => {
+      const file = (e.target as HTMLInputElement).files?.[0];
+      if (file) {
+        await reuploadPostgresBook(file);
+      }
+    };
+    input.click();
+  }, [isLoading, reuploadPostgresBook]);
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isLoading}
+      title="Reupload to Postgres"
+      className={`flex items-center rounded-[10px] text-sm text-muted-foreground transition-colors hover:bg-muted whitespace-nowrap disabled:opacity-50 ${
+        expanded
+          ? "w-full gap-2.5 px-3 py-2"
+          : "h-[42px] w-[42px] mx-auto justify-center"
+      }`}
+    >
+      <Upload className="h-[18px] w-[18px] shrink-0 text-muted-foreground/70" />
+      {expanded && "Reupload to Postgres"}
+    </button>
+  );
+}

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -62,6 +62,14 @@ interface DashboardContextType {
     connection: PostgresConnectionInfo,
     bookId: string,
   ) => Promise<void>;
+  /**
+   * Replace the currently-open Postgres book with the contents of `file`.
+   * Reuses the connection + bookId captured on the most recent
+   * openPostgresBook / importFileToPostgres call, so the sidebar can drive
+   * the reupload without re-prompting for credentials. Throws if called
+   * while not connected to a Postgres backend.
+   */
+  reuploadPostgresBook: (file: File) => Promise<void>;
   loadDemo: () => Promise<void>;
   clearData: () => void;
   createTransaction: (payload: CreateTransactionPayload) => Promise<void>;
@@ -91,6 +99,10 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [backend, setBackend] = useState<Backend>("local");
   const [postgresBookId, setPostgresBookId] = useState<string | null>(null);
   const clientRef = useRef<GnuCashWorkerClient | null>(null);
+  // Connection used by the currently-open Postgres book. Held in a ref, not
+  // state, so reuploadPostgresBook can see the freshly-set value synchronously
+  // even if React hasn't yet scheduled a re-render after openPostgresBook.
+  const postgresConnectionRef = useRef<PostgresConnectionInfo | null>(null);
 
   function getClient(): GnuCashWorkerClient {
     if (!clientRef.current) {
@@ -266,6 +278,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       setIsWritable(true);
       setBackend("postgres");
       setPostgresBookId(bookId);
+      postgresConnectionRef.current = connection;
       sessionStorage.setItem(UPLOADED_AT_KEY, now.toISOString());
       sessionStorage.setItem(WRITABLE_KEY, "true");
       sessionStorage.setItem(BACKEND_KEY, "postgres");
@@ -340,6 +353,25 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  /**
+   * Replace the active Postgres book with `file`. The sidebar's Reupload
+   * button calls this after confirming with the user; we reuse the connection
+   * + book id captured on the most recent openPostgresBook, so the user never
+   * has to retype credentials mid-session. The import route drops and
+   * recreates the book schema inside a single transaction (see
+   * fix/pg-import-schema-and-rollback), so a failure leaves the previous
+   * book intact on the server — though the local cache may have been
+   * clobbered by the conversion step, so on failure the UI should prompt a
+   * fresh reconnect rather than claim the old data is still there.
+   */
+  async function reuploadPostgresBook(file: File) {
+    const connection = postgresConnectionRef.current;
+    if (backend !== "postgres" || !connection || !postgresBookId) {
+      throw new Error("Reupload is only available when connected to Postgres");
+    }
+    await importFileToPostgres(file, connection, postgresBookId);
+  }
+
   async function loadDemo() {
     setIsLoading(true);
     setError(null);
@@ -363,6 +395,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setIsXmlSource(false);
     setBackend("local");
     setPostgresBookId(null);
+    postgresConnectionRef.current = null;
     sessionStorage.removeItem(STORAGE_KEY);
     sessionStorage.removeItem(UPLOADED_AT_KEY);
     sessionStorage.removeItem(WRITABLE_KEY);
@@ -468,7 +501,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
   return (
     <DashboardContext.Provider
-      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, exportFile, setCurrency: setCurrencyFn }}
+      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, reuploadPostgresBook, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, exportFile, setCurrency: setCurrencyFn }}
     >
       {children}
     </DashboardContext.Provider>


### PR DESCRIPTION
Seventh PR of the Server (Postgres) backend series. Refs #48.

## Summary

Lets a user on the Postgres backend replace their current book from inside the dashboard — no retyping credentials, no detour back to the upload screen.

- **\`DashboardContext\`** tracks the active Postgres connection in a ref (set on \`openPostgresBook\` / \`importFileToPostgres\`, cleared on \`clearData\`). New \`reuploadPostgresBook(file)\` method pulls the ref + stored \`postgresBookId\` and delegates to \`importFileToPostgres\`.
- **\`components/upload/reupload-button.tsx\`** — icon button with a \`window.confirm\` dialog (*"This will drop the existing Postgres book and replace it..."*), file picker on accept, disabled while \`isLoading\`.
- **\`sidebar.tsx\`** renders it between Export and the clear-data button, conditional on \`backend === "postgres"\`. The existing clear-data button is relabelled *"Disconnect"* on the PG backend — it drops local state and returns to the upload screen; the server book is untouched.

## Why it's safe

The import route (post \`fix/pg-import-schema-and-rollback\`) does the drop+recreate inside one transaction, so a failed reupload leaves the previous book intact on the server. The local cache may be in a torn state from the client-side XML→SQLite conversion, so on failure the user sees the standard error and can reconnect to re-sync from the untouched server copy.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 234/234 passing
- [x] \`npm run lint\` clean for new/modified files
- [x] \`npm run build\` — standalone mode clean
- [ ] **Manual verification** — open the dashboard on the PG backend, click the new Reupload button, confirm, pick a different \`.gnucash\` file. Dashboard should refresh with the new data. Cancelling the confirm should be a no-op. Clicking the Reupload button while on local backend — it shouldn't be visible (there's no server book to reupload to).

## Next / last

PR 8: auto-reconnect from OPFS-persisted \`ServerConfig\` on app boot, plus the final deployment docs pass. Closes #48.