### PR TITLE
Auto-reconnect to Postgres on boot, final deployment docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ GnuDash is a fully client-side application. There is no server interaction with 
 
 To clear your data, use the dashboard's clear/reset option or clear your browser's site data.
 
+### Optional: self-hosted Server backend
+
+If you want the same book accessible from every device you use — phone, laptop, work machine — you can self-host GnuDash against your own Postgres database instead of relying on the per-browser OPFS cache. Pick **Server (Postgres)** on the upload screen, point it at your database, and GnuDash mirrors the book into a dedicated schema there. Writes round-trip to Postgres before the UI shows the "saved" state; reads hit a local SQLite WASM cache so the dashboard stays fast.
+
+This mode requires the standalone Node.js build (the public pages deployment is still fully static) and is fully documented in the [Deployment Guide](docs/deployment.md).
+
 ## Features
 
 ### Dashboard & Reports
@@ -45,6 +51,7 @@ To clear your data, use the dashboard's clear/reset option or clear your browser
 - **Accounting Engine** — Rational arithmetic (no floating point), multi-currency, GNUCash-compatible writes
 - **SQLite & XML** — Supports both GNUCash file formats (including gzip-compressed); XML files open as read-only
 - **OPFS Persistence** — Your database is stored in your browser's Origin Private File System, so it persists across sessions without re-uploading
+- **Self-hosted Postgres backend** — Optional alternative storage for cross-device access: every write is cache-and-synced to a Postgres schema you control, with auto-reconnect on app load. See the [Deployment Guide](docs/deployment.md).
 - **Multi-Currency** — Switch display currency across all views when your file contains multiple currencies
 - **Closing Transactions** — Toggle to exclude period-end closing entries from reports
 - **Export** — Download your modified `.gnucash` file for use in GNUCash desktop

--- a/app/src/components/upload/file-upload.tsx
+++ b/app/src/components/upload/file-upload.tsx
@@ -12,6 +12,14 @@ import { LocalUploadPanel } from "./local-upload-panel";
 import { ServerConnectPanel } from "./server-connect-panel";
 
 const TAB_PREF_KEY = "gnudash-upload-backend";
+/**
+ * When DashboardContext decides the last session was on Postgres, it keeps
+ * this session-storage marker in place so the upload screen can auto-select
+ * the Server tab — distinct from the localStorage tab preference because
+ * we want "was on PG last time" to beat a stale localStorage value from
+ * before the user ever touched Server.
+ */
+const BACKEND_KEY = "gnucash-dashboard-backend";
 type TabId = "local" | "server";
 const DEFAULT_TAB: TabId = "local";
 
@@ -35,13 +43,22 @@ export function FileUpload() {
   // useSyncExternalStore, which is overkill for a single tab preference.
   useEffect(() => {
     try {
+      // Session-level backend marker wins: a user returning after a failed
+      // Postgres auto-reconnect should land on the Server tab even if they'd
+      // previously picked Local. The marker is only set after a successful
+      // open/import, so a first-time visitor sees their localStorage pref.
+      const sessionBackend = sessionStorage.getItem(BACKEND_KEY);
+      if (sessionBackend === "postgres") {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setTab("server");
+        return;
+      }
       const saved = localStorage.getItem(TAB_PREF_KEY);
       if (saved === "local" || saved === "server") {
-        // eslint-disable-next-line react-hooks/set-state-in-effect
         setTab(saved);
       }
     } catch {
-      // localStorage unavailable (Safari private mode etc.) — ignore.
+      // localStorage / sessionStorage unavailable — stay on DEFAULT_TAB.
     }
   }, []);
 

--- a/app/src/components/upload/server-connect-panel.tsx
+++ b/app/src/components/upload/server-connect-panel.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Loader2, Server, Upload } from "lucide-react";
 import { useDashboard } from "@/lib/dashboard-context";
 import type { PostgresConnectionInfo } from "@/lib/gnucash/worker/messages";
+import { loadServerConfig } from "@/lib/storage/server-config";
 
 /**
  * Server (Postgres) backend panel of the upload screen (#48).
@@ -51,6 +52,34 @@ export function ServerConnectPanel() {
   const [localError, setLocalError] = useState<string | null>(null);
   const [fileSizeError, setFileSizeError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+
+  // Prefill from OPFS-persisted server-config when the panel mounts so users
+  // who land here after a failed auto-reconnect don't have to retype every
+  // field. Runs after first paint to keep SSR/CSR output identical (OPFS
+  // isn't accessible on the server).
+  useEffect(() => {
+    let cancelled = false;
+    loadServerConfig()
+      .then((saved) => {
+        if (cancelled || !saved) return;
+        const { bookId: savedBookId, ...rest } = saved;
+        setConnection({
+          host: rest.host,
+          port: rest.port,
+          user: rest.user,
+          password: rest.password,
+          database: rest.database,
+          ssl: rest.ssl ?? false,
+        });
+        setBookId(savedBookId);
+      })
+      .catch(() => {
+        // No saved config or OPFS unavailable — stay on defaults.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const updateConnection = useCallback(
     <K extends keyof PostgresConnectionInfo>(

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -14,6 +14,7 @@ import type { CreateTransactionPayload, DeleteTransactionPayload, EditTransactio
 import { generateDemoData } from "@/lib/demo-data";
 import { deleteFromOPFS } from "@/lib/gnucash/worker/opfs";
 import {
+  loadServerConfig,
   saveServerConfig,
   type ServerConfig,
 } from "@/lib/storage/server-config";
@@ -45,13 +46,20 @@ interface DashboardContextType {
   /**
    * Open a book from a Postgres server: fetch the dump, restore into the
    * worker's in-memory SQLite cache, and switch the backend to "postgres".
-   * Persists the connection to OPFS (plaintext — see server-config.ts) so a
-   * future PR can auto-reconnect.
+   * Persists the connection to OPFS (plaintext — see server-config.ts) so
+   * the next app load can auto-reconnect.
+   *
+   * Returns `true` on success and `false` if anything in the pipeline
+   * failed (server unreachable, credentials rejected, book missing, etc.)
+   * — failure is also surfaced via the `error` field on the context, so
+   * UI callers can usually ignore the return value; the boolean exists for
+   * the auto-reconnect path in `restore()` which needs to decide whether
+   * to clear the "was on Postgres last time" marker.
    */
   openPostgresBook: (
     connection: PostgresConnectionInfo,
     bookId: string,
-  ) => Promise<void>;
+  ) => Promise<boolean>;
   /**
    * Upload a .gnucash file (SQLite or XML) to a Postgres server and then
    * open the resulting book. XML files are converted to SQLite client-side
@@ -125,13 +133,31 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       const storedBackend =
         (sessionStorage.getItem(BACKEND_KEY) as Backend | null) ?? "local";
 
-      // Postgres sessions don't persist anything usable on the client, so
-      // skip the OPFS + session-storage restore paths outright and let the
-      // upload screen render. The Server tab preselect handles UX continuity.
+      // Postgres session: try to auto-reconnect from the OPFS-persisted
+      // credentials (written by openPostgresBook via saveServerConfig).
+      // On any failure (no config saved, server down, credentials rotated,
+      // book gone) we fall through to the upload screen with the Server tab
+      // preselected and fields prefilled so the user can retry without
+      // retyping. The `isLoading` flag keeps the upload form hidden until
+      // the auto-reconnect resolves one way or the other.
       if (storedBackend === "postgres") {
-        // Drop any local-mode caches that a previous local session may have
-        // left behind — we're in Postgres land now.
         sessionStorage.removeItem(STORAGE_KEY);
+        const cfg = await loadServerConfig();
+        if (cancelled || !cfg) {
+          // Either the config never made it to OPFS or it's been cleared.
+          // Fall through to the upload screen — the Server tab will preselect
+          // from the same BACKEND_KEY marker.
+          return;
+        }
+        const { bookId, ...connection } = cfg;
+        const ok = await openPostgresBook(connection, bookId);
+        if (!ok && !cancelled) {
+          // Clear the session marker so a reload doesn't silently retry the
+          // same broken auto-reconnect; next time the user must actively
+          // Connect. The Server tab still preselects via the panel's own
+          // loadServerConfig() read, so fields stay prefilled.
+          sessionStorage.removeItem(BACKEND_KEY);
+        }
         return;
       }
 
@@ -175,6 +201,11 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
     restore();
     return () => { cancelled = true; };
+    // `openPostgresBook` is defined in the same render and doesn't capture
+    // stale state (it reads everything through setters / refs), so the
+    // mount-only semantics here are intentional — adding it to deps would
+    // just re-run the whole restore-on-boot logic every render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // Persist to sessionStorage when data changes (fast restore cache)
@@ -242,7 +273,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   async function openPostgresBook(
     connection: PostgresConnectionInfo,
     bookId: string,
-  ) {
+  ): Promise<boolean> {
     setIsLoading(true);
     setError(null);
 
@@ -290,8 +321,10 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
         // If OPFS is unavailable the PG session is still fully usable —
         // the user will just have to re-enter credentials next time.
       });
+      return true;
     } catch (err) {
       setError(err instanceof Error ? err.message : "Open failed");
+      return false;
     } finally {
       setIsLoading(false);
     }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -310,15 +310,51 @@ If you can't set custom headers (e.g. GitHub Pages), the app will still load but
 
 ---
 
-## Self-hosted Postgres backend (in development)
+## Self-hosted Postgres backend
 
-The repo-root `docker-compose.yml` starts a Postgres 16 container that the upcoming Server backend ([issue #48](https://github.com/QuirkyTurtle94/GnuDash/issues/48)) will connect to. For developers following along with that work:
+The Server (Postgres) backend is an alternative to the Local (OPFS) backend: your book lives in a Postgres database you control, so the same data is reachable from every browser that can reach the server. Every write made in the UI is applied to a local SQLite WASM cache first (keeps the dashboard fast) and round-tripped to Postgres before the UI shows the "saved" state.
+
+Requires the **standalone** build mode — the API routes that talk to Postgres can't be served by a static-file host. A static deployment (nginx, Cloudflare Pages, Netlify) cannot use this backend.
+
+### 1. Start Postgres
+
+The repo includes a ready-to-go `docker-compose.yml` that boots `postgres:16-alpine` with sensible defaults:
 
 ```bash
-docker compose up -d postgres     # start the DB
-./scripts/db-reset.sh             # stop AND drop the data volume
+docker compose up -d postgres
 ```
 
-Defaults: `host=localhost port=5432 user=gnudash password=gnudash database=gnudash`. Override via environment variables (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT`) before `docker compose up`. **Any non-localhost deployment must terminate TLS in front of the app** — the Server backend sends Postgres credentials in request bodies from the browser.
+Defaults: `host=localhost port=5432 user=gnudash password=gnudash database=gnudash`. Override before the first `up` via `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT` env vars (or a `.env` file next to `docker-compose.yml`). `./scripts/db-reset.sh` wipes the data volume when you want to start over.
 
-End-user walkthrough (Server tab on the upload screen, auto-reconnect, credentials-in-OPFS security note) will land with the final PR of issue #48.
+### 2. Run the app in standalone mode
+
+From the `app/` directory:
+
+```bash
+npm install
+npm run build          # produces app/.next/standalone/
+node .next/standalone/server.js
+```
+
+The Postgres API routes live under `/api/pg/*` and are automatically included in the standalone bundle. For a container-based deployment you can write a small Dockerfile that copies `.next/standalone/`, `.next/static/`, and `public/` into a `node:20-alpine` image and runs `server.js` on port 3000 — this repo doesn't ship one by default because the deployment shape is highly site-specific.
+
+### 3. Connect from the upload screen
+
+Open the app in a browser, pick the **Server (Postgres)** tab on the upload screen, fill in the connection form (the defaults match `docker-compose.yml`), and click **Connect**:
+
+- If the book doesn't exist yet, you'll be prompted to drop a `.gnucash` file (SQLite or XML — XML is converted to SQLite in the browser before upload). The file bootstraps the schema.
+- If the book already exists, the app loads it directly.
+
+After a successful connect the connection is persisted to your browser's Origin Private File System so a page reload auto-reconnects without prompting. The **Reupload to Postgres** button in the sidebar replaces the server book in place; the **Disconnect** button returns you to the upload screen without touching the server.
+
+### 4. Security
+
+**Credentials are stored in plaintext** in OPFS so auto-reconnect works. OPFS is sandboxed per origin (no other website can read it) but any JavaScript running on this origin can. Treat the gnudash origin like any other app that handles its own credentials:
+
+- **Terminate TLS in front of the app for any non-localhost deployment.** The Server backend sends the Postgres password in each request body from the browser; without TLS it's exposed on the wire.
+- Use a strong, dedicated Postgres user for gnudash. Don't reuse the password anywhere else.
+- Consider host the app behind an auth reverse proxy (oauth2-proxy, Authelia, etc.) if it's on the open internet.
+
+### 5. Storage model
+
+Each book lives in its own Postgres schema named `book_{bookId}` — the MVP ships with a single `book_default` but the schema indirection is there so per-user / multi-tenant deployments are an additive change rather than a redesign. The gnudash schema is **not interop-compatible with GnuCash desktop's Postgres backend**: if you have an existing GnuCash Postgres database, upload your data via the Server tab instead of pointing gnudash at it directly.


### PR DESCRIPTION
Final PR of the Server (Postgres) backend series. **Closes #48.**

## Summary

Makes the Postgres backend self-sustaining across page reloads, and turns the placeholder deployment section into a full self-host walkthrough.

### Auto-reconnect on app boot

- \`DashboardContext.restore()\` gains a Postgres path: if the previous session set \`BACKEND_KEY=postgres\`, load the saved connection from OPFS (PR 5's \`server-config\`) and call \`openPostgresBook\` directly. A page refresh on a PG session lands back on the dashboard without prompting.
- \`openPostgresBook\` now returns \`Promise<boolean>\` — existing callers ignore the return value; \`restore()\` uses it to decide whether to clear \`BACKEND_KEY\` after a failed reconnect so a subsequent reload doesn't silently retry the same broken path.

### Graceful fall-through

If saved credentials are stale, the server is down, or the book is gone, the auto-reconnect fails, the error bubbles through the existing \`error\` channel, and the upload screen renders. The Server tab is preselected (session-storage \`BACKEND_KEY\` takes priority over the localStorage tab pref), and the connection fields are prefilled from the same OPFS config via \`ServerConnectPanel\`'s own mount-time \`loadServerConfig()\` read. Retrying is one click away.

### Final deployment docs

\`docs/deployment.md\`'s placeholder *Self-hosted Postgres backend (in development)* section is replaced with:

- **Start Postgres** — \`docker compose up -d postgres\`, env-var overrides, reset script
- **Run the app in standalone mode** — build + \`node .next/standalone/server.js\`, container-shape notes
- **Connect from the upload screen** — bootstrap-new-book vs. load-existing-book flows, reupload button, disconnect button
- **Security** — plaintext-credentials-in-OPFS caveat, TLS mandate for non-localhost, reverse-proxy auth suggestion
- **Storage model** — \`book_{bookId}\` schema, explicit note that this is NOT interop-compatible with GnuCash desktop's Postgres backend

\`README.md\` gains a short *Optional self-hosted Server backend* subsection pointing at the guide.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 234/234 passing
- [x] \`npm run lint\` clean for new/modified files
- [x] \`npm run build\` (standalone) clean
- [x] \`NEXT_OUTPUT=export npm run build\` (static) clean
- [ ] **Manual**: connect to PG on the Server tab → reload the page → should land on the dashboard without prompting. Then edit the OPFS config manually (break the password) or stop the PG container, reload → should fall through to the upload screen with the Server tab preselected, fields prefilled, and the error visible. Fix the creds / restart PG and click Connect — should work without retyping anything.

## Series wrap

This closes the Postgres backend series (#48). Summary of what landed:

| PR | Theme |
|---|---|
| #76 | Build foundation: standalone default, docker-compose, scripts |
| #77 | Schema DDL + SQL translator |
| #78 | API routes + connect helper + \`pg\` dep |
| #79 | Client adapter + sync client + worker wiring |
| #80 | OPFS-persisted server config |
| #81 | Upload UI — Local / Server tabs + context extensions |
| #84 | Reupload-from-dashboard button |
| **this** | Auto-reconnect + final docs |

Plus three hotfixes (#82 column filter, #83 NOT NULL + transactional import, the PR 6 branch follow-up to align local SQLite DDL) caught by real-world file testing.

Next up (separate issue): the GnuCash-desktop Postgres read-only interop feature we agreed to do after this closes.