### PR TITLE
Add read-only interop with existing GnuCash Postgres databases

### DIFF
--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -2,7 +2,16 @@
 
 import { useState, useRef, useEffect } from "react";
 import Image from "next/image";
-import { Menu, Eye, EyeOff, Pencil, Lock, BookX, ChevronDown } from "lucide-react";
+import {
+  AlertTriangle,
+  BookX,
+  ChevronDown,
+  Eye,
+  EyeOff,
+  Lock,
+  Menu,
+  Pencil,
+} from "lucide-react";
 import { useDashboard } from "@/lib/dashboard-context";
 import { PrivacyProvider, usePrivacy } from "@/lib/privacy-context";
 import { ClosingProvider, useClosing } from "@/lib/closing-context";
@@ -59,7 +68,13 @@ function CurrencySelector() {
 }
 
 function DashboardInner({ children }: { children: React.ReactNode }) {
-  const { data, isWritable, isXmlSource, toggleWritable } = useDashboard();
+  const {
+    data,
+    isWritable,
+    isXmlSource,
+    toggleWritable,
+    postgresSchemaOverride,
+  } = useDashboard();
   const { hideValues, toggleHideValues } = usePrivacy();
   const { excludeClosing, toggleExcludeClosing } = useClosing();
   const [sidebarOpen, setSidebarOpen] = useState(false);
@@ -172,6 +187,23 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
             <ThemeToggle />
           </div>
         </header>
+
+        {/* Existing-GnuCash-DB read-only banner. Shown across every page so
+            the user doesn't forget they're looking at (and can't change) a
+            database GnuCash desktop is the source of truth for. */}
+        {postgresSchemaOverride && (
+          <div className="flex items-center gap-2 border-b border-amber-300 bg-amber-50 px-4 py-2 text-xs text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200 sm:px-8">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              Connected to existing GnuCash database{" "}
+              <code className="rounded bg-amber-100 px-1 py-0.5 font-mono text-[11px] dark:bg-amber-900/50">
+                {postgresSchemaOverride}
+              </code>{" "}
+              in read-only mode. Close GnuCash desktop before editing on either
+              side to avoid data conflicts.
+            </span>
+          </div>
+        )}
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto p-4 sm:p-6 md:p-8">

--- a/app/src/app/api/pg/book/dump/route.ts
+++ b/app/src/app/api/pg/book/dump/route.ts
@@ -1,15 +1,22 @@
-import { withBookClient, type PgConnection } from "@/lib/pg/connect";
 import {
-  GNUCASH_POSTGRES_TABLES,
-  bookSchemaName,
-} from "@/lib/gnucash/db/postgres-schema";
+  resolveSchemaName,
+  withClient,
+  type PgConnection,
+} from "@/lib/pg/connect";
+import { GNUCASH_POSTGRES_TABLES } from "@/lib/gnucash/db/postgres-schema";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/**
+ * Accepts either a gnudash-managed `bookId` (the default flow) or a raw
+ * `schema` for the existing-GnuCash-DB read-only interop path. Exactly one
+ * must be supplied; see `resolveSchemaName` for validation.
+ */
 interface Body {
   connection: PgConnection;
-  bookId: string;
+  bookId?: string;
+  schema?: string;
 }
 
 /**
@@ -46,30 +53,52 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!body.connection || !body.bookId) {
+  if (!body.connection) {
     return new Response(
-      JSON.stringify({ error: "Missing 'connection' or 'bookId'" }),
+      JSON.stringify({ error: "Missing 'connection'" }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+  if ((!body.bookId && !body.schema) || (body.bookId && body.schema)) {
+    return new Response(
+      JSON.stringify({ error: "Provide exactly one of 'bookId' or 'schema'" }),
+      { status: 400, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  let schema: string;
+  try {
+    schema = resolveSchemaName({ bookId: body.bookId, schema: body.schema });
+  } catch (err) {
+    return new Response(
+      JSON.stringify({ error: (err as Error).message }),
       { status: 400, headers: { "content-type": "application/json" } },
     );
   }
 
   try {
-    const payload = await withBookClient(
-      body.connection,
-      body.bookId,
-      async (client) => {
-        // Tables we created via GNUCASH_POSTGRES_DDL. We always try them all,
-        // even if empty — the client expects a consistent shape.
-        const tables: DumpPayload["tables"] = {};
-        for (const table of GNUCASH_POSTGRES_TABLES) {
-          // Explicit schema-qualified name in case search_path was clobbered.
-          const qualified = `${bookSchemaName(body.bookId)}.${table}`;
-          const res = await client.query(`SELECT * FROM ${qualified}`);
-          tables[table] = res.rows;
-        }
-        return { version: 1 as const, tables };
-      },
-    );
+    const payload = await withClient(body.connection, async (client) => {
+      // Only dump tables that actually exist in the target schema. A real
+      // GnuCash database won't have `gnudash_meta`, and older GnuCash files
+      // may lack `lots` / `slots` until first use — skipping missing tables
+      // lets the same client handle both flavours without a schema branch.
+      const existing = await client.query<{ table_name: string }>(
+        `SELECT table_name FROM information_schema.tables
+         WHERE table_schema = $1 AND table_name = ANY($2::text[])`,
+        [schema, [...GNUCASH_POSTGRES_TABLES]],
+      );
+      const existingTables = new Set(existing.rows.map((r) => r.table_name));
+
+      const tables: DumpPayload["tables"] = {};
+      for (const table of GNUCASH_POSTGRES_TABLES) {
+        if (!existingTables.has(table)) continue;
+        // Explicit schema-qualified name in case search_path was clobbered.
+        const qualified = `${schema}.${table}`;
+        const res = await client.query(`SELECT * FROM ${qualified}`);
+        tables[table] = res.rows;
+      }
+      return { version: 1 as const, tables };
+    });
 
     const json = JSON.stringify(payload);
     const gzipped = await gzipString(json);

--- a/app/src/app/api/pg/book/status/route.ts
+++ b/app/src/app/api/pg/book/status/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse } from "next/server";
-import { withClient, type PgConnection } from "@/lib/pg/connect";
-import { bookSchemaName } from "@/lib/gnucash/db/postgres-schema";
+import {
+  resolveSchemaName,
+  withClient,
+  type PgConnection,
+} from "@/lib/pg/connect";
 import { REQUIRED_TABLES } from "@/lib/gnucash/db/validation";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
+/**
+ * Request body accepts exactly one of `bookId` (gnudash-managed schemas,
+ * `book_{bookId}`) or `schema` (existing-GnuCash-DB read-only interop).
+ * The shared `resolveSchemaName` helper in lib/pg/connect validates both.
+ */
 interface Body {
   connection: PgConnection;
-  bookId: string;
+  bookId?: string;
+  schema?: string;
 }
 
 /**
@@ -34,16 +43,22 @@ export async function POST(request: Request) {
     );
   }
 
-  if (!body.connection || !body.bookId) {
+  if (!body.connection) {
     return NextResponse.json(
-      { error: "Missing 'connection' or 'bookId'" },
+      { error: "Missing 'connection'" },
+      { status: 400 },
+    );
+  }
+  if ((!body.bookId && !body.schema) || (body.bookId && body.schema)) {
+    return NextResponse.json(
+      { error: "Provide exactly one of 'bookId' or 'schema'" },
       { status: 400 },
     );
   }
 
   let schema: string;
   try {
-    schema = bookSchemaName(body.bookId);
+    schema = resolveSchemaName({ bookId: body.bookId, schema: body.schema });
   } catch (err) {
     return NextResponse.json({ error: (err as Error).message }, { status: 400 });
   }

--- a/app/src/components/upload/server-connect-panel.tsx
+++ b/app/src/components/upload/server-connect-panel.tsx
@@ -1,26 +1,35 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { Loader2, Server, Upload } from "lucide-react";
+import { AlertTriangle, Loader2, Server, Upload } from "lucide-react";
 import { useDashboard } from "@/lib/dashboard-context";
 import type { PostgresConnectionInfo } from "@/lib/gnucash/worker/messages";
 import { loadServerConfig } from "@/lib/storage/server-config";
 
 /**
- * Server (Postgres) backend panel of the upload screen (#48).
+ * Server (Postgres) backend panel of the upload screen.
  *
- * Flow:
- *   1. Form collects host/port/user/password/database + book id.
- *   2. On Connect we POST /api/pg/test-connection to fail fast on bad creds.
- *   3. POST /api/pg/book/status — branch on `exists`.
- *   4. exists=true  → DashboardContext.openPostgresBook fetches the dump.
- *   5. exists=false → render a drag-and-drop step; on file pick,
- *      DashboardContext.importFileToPostgres uploads and then opens the book.
+ * Two modes, selected by the user via a radio at the top:
  *
- * Credentials do not leave the browser except via the API calls above.
- * DashboardContext persists them to OPFS on the first successful open so a
- * future PR can auto-reconnect on app boot.
+ * - **gnudash-managed** (default) — gnudash owns a dedicated schema named
+ *   `book_{bookId}`. Full read-write: every mutation applied locally first
+ *   and round-tripped to Postgres via the sync client. Flow:
+ *     connect form → test-connection → book/status → load-existing *or*
+ *     file-picker-to-import.
+ *
+ * - **existing GnuCash DB** — points gnudash at a schema maintained by
+ *   GnuCash desktop (usually `public`). Opened read-only: writes are
+ *   blocked at the context level, an amber banner is shown, and no sync
+ *   client is created. Flow:
+ *     connect form + schema field → book/status → openExistingGnuCashBook
+ *     (no import step, no file picker — we never write to this schema).
+ *
+ * Credentials never leave the browser except via the API calls above;
+ * DashboardContext persists them to OPFS on success so auto-reconnect works
+ * on next load.
  */
+
+type Mode = "gnudash" | "existing";
 
 type Stage =
   | { kind: "form" }
@@ -38,16 +47,24 @@ const DEFAULT_CONNECTION: PostgresConnectionInfo = {
 };
 
 const DEFAULT_BOOK_ID = "default";
+const DEFAULT_EXISTING_SCHEMA = "public";
 
 const MAX_FILE_SIZE_BYTES = 200 * 1024 * 1024;
 
 export function ServerConnectPanel() {
-  const { openPostgresBook, importFileToPostgres, isLoading, error } =
-    useDashboard();
+  const {
+    openPostgresBook,
+    importFileToPostgres,
+    openExistingGnuCashBook,
+    isLoading,
+    error,
+  } = useDashboard();
 
+  const [mode, setMode] = useState<Mode>("gnudash");
   const [connection, setConnection] =
     useState<PostgresConnectionInfo>(DEFAULT_CONNECTION);
   const [bookId, setBookId] = useState(DEFAULT_BOOK_ID);
+  const [existingSchema, setExistingSchema] = useState(DEFAULT_EXISTING_SCHEMA);
   const [stage, setStage] = useState<Stage>({ kind: "form" });
   const [localError, setLocalError] = useState<string | null>(null);
   const [fileSizeError, setFileSizeError] = useState<string | null>(null);
@@ -55,23 +72,27 @@ export function ServerConnectPanel() {
 
   // Prefill from OPFS-persisted server-config when the panel mounts so users
   // who land here after a failed auto-reconnect don't have to retype every
-  // field. Runs after first paint to keep SSR/CSR output identical (OPFS
-  // isn't accessible on the server).
+  // field. Runs after first paint to keep SSR/CSR output identical.
   useEffect(() => {
     let cancelled = false;
     loadServerConfig()
       .then((saved) => {
         if (cancelled || !saved) return;
-        const { bookId: savedBookId, ...rest } = saved;
         setConnection({
-          host: rest.host,
-          port: rest.port,
-          user: rest.user,
-          password: rest.password,
-          database: rest.database,
-          ssl: rest.ssl ?? false,
+          host: saved.host,
+          port: saved.port,
+          user: saved.user,
+          password: saved.password,
+          database: saved.database,
+          ssl: saved.ssl ?? false,
         });
-        setBookId(savedBookId);
+        if (saved.mode === "existing" && saved.schema) {
+          setMode("existing");
+          setExistingSchema(saved.schema);
+        } else if (saved.bookId) {
+          setMode("gnudash");
+          setBookId(saved.bookId);
+        }
       })
       .catch(() => {
         // No saved config or OPFS unavailable — stay on defaults.
@@ -108,39 +129,62 @@ export function ServerConnectPanel() {
         const body = (await testRes.json().catch(() => ({}))) as {
           error?: string;
         };
-        throw new Error(body.error ?? `Connect failed: HTTP ${testRes.status}`);
+        throw new Error(
+          body.error ?? `Connect failed: HTTP ${testRes.status}`,
+        );
       }
 
-      // 2. Does the book exist already in this DB?
+      // 2. Schema probe. Pass bookId OR schema depending on mode — the
+      //    route handler validates exactly one is supplied.
+      const statusBody =
+        mode === "existing"
+          ? { connection, schema: existingSchema }
+          : { connection, bookId };
       const statusRes = await fetch("/api/pg/book/status", {
         method: "POST",
         headers: { "content-type": "application/json" },
-        body: JSON.stringify({ connection, bookId }),
+        body: JSON.stringify(statusBody),
       });
       if (!statusRes.ok) {
         const body = (await statusRes.json().catch(() => ({}))) as {
           error?: string;
         };
-        throw new Error(body.error ?? `Status check failed: HTTP ${statusRes.status}`);
+        throw new Error(
+          body.error ?? `Status check failed: HTTP ${statusRes.status}`,
+        );
       }
       const status = (await statusRes.json()) as {
         exists: boolean;
         missingTables?: string[];
       };
 
+      if (mode === "existing") {
+        // Read-only: we never import into someone else's GnuCash schema. If
+        // the target is empty, we surface a clear error instead of offering
+        // to clobber it.
+        if (!status.exists) {
+          throw new Error(
+            `Schema "${existingSchema}" does not exist on this server.`,
+          );
+        }
+        if (status.missingTables && status.missingTables.length > 0) {
+          throw new Error(
+            `Schema "${existingSchema}" exists but is missing required ` +
+              `GnuCash tables: ${status.missingTables.join(", ")}.`,
+          );
+        }
+        await openExistingGnuCashBook(connection, existingSchema);
+        return;
+      }
+
+      // gnudash-managed flow: existing or bootstrap.
       if (
         status.exists &&
         (!status.missingTables || status.missingTables.length === 0)
       ) {
-        // 3a. Existing, fully-provisioned book → load it.
         await openPostgresBook(connection, bookId);
-        // openPostgresBook flips the backend state; this panel unmounts as
-        // the dashboard takes over, so no further local stage update needed.
         return;
       }
-
-      // 3b. Empty database (or an incomplete book) → ask the user to upload
-      //     a .gnucash file to bootstrap the book.
       setStage({
         kind: "needs-import",
         message: status.exists
@@ -151,7 +195,14 @@ export function ServerConnectPanel() {
       setLocalError(err instanceof Error ? err.message : "Connect failed");
       setStage({ kind: "form" });
     }
-  }, [connection, bookId, openPostgresBook]);
+  }, [
+    connection,
+    mode,
+    bookId,
+    existingSchema,
+    openPostgresBook,
+    openExistingGnuCashBook,
+  ]);
 
   const handleFile = useCallback(
     async (file: File) => {
@@ -212,6 +263,35 @@ export function ServerConnectPanel() {
           </span>
         </div>
 
+        {/* Mode selector */}
+        <div className="mb-4 space-y-2">
+          <ModeRadio
+            value="gnudash"
+            label="gnudash-managed database"
+            description="A schema gnudash owns — full read-write, cross-device sync."
+            selected={mode}
+            onSelect={setMode}
+          />
+          <ModeRadio
+            value="existing"
+            label="Existing GnuCash database (read-only)"
+            description="Point at a schema your GnuCash desktop already writes to."
+            selected={mode}
+            onSelect={setMode}
+          />
+        </div>
+
+        {mode === "existing" && (
+          <div className="mb-4 flex items-start gap-2 rounded-xl bg-amber-50 p-3 text-xs text-amber-900">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            <span>
+              Read-only mode is advised when pointing at a database GnuCash
+              desktop also uses. Close the desktop app before loading to avoid
+              lock / cache conflicts.
+            </span>
+          </div>
+        )}
+
         <div className="grid grid-cols-3 gap-3">
           <div className="col-span-2">
             <FieldLabel>Host</FieldLabel>
@@ -252,12 +332,25 @@ export function ServerConnectPanel() {
             />
           </div>
           <div>
-            <FieldLabel>Book id</FieldLabel>
-            <FieldInput
-              value={bookId}
-              onChange={setBookId}
-              placeholder="default"
-            />
+            {mode === "existing" ? (
+              <>
+                <FieldLabel>Schema</FieldLabel>
+                <FieldInput
+                  value={existingSchema}
+                  onChange={setExistingSchema}
+                  placeholder="public"
+                />
+              </>
+            ) : (
+              <>
+                <FieldLabel>Book id</FieldLabel>
+                <FieldInput
+                  value={bookId}
+                  onChange={setBookId}
+                  placeholder="default"
+                />
+              </>
+            )}
           </div>
         </div>
 
@@ -287,7 +380,7 @@ export function ServerConnectPanel() {
         </button>
       </div>
 
-      {stage.kind === "needs-import" && (
+      {stage.kind === "needs-import" && mode === "gnudash" && (
         <div className="mt-4 space-y-3">
           {stage.message && (
             <div className="rounded-xl bg-[#F4F5F7] p-3 text-xs text-[#6F767E]">
@@ -342,6 +435,48 @@ export function ServerConnectPanel() {
         deployment past localhost.
       </p>
     </div>
+  );
+}
+
+interface ModeRadioProps {
+  value: Mode;
+  label: string;
+  description: string;
+  selected: Mode;
+  onSelect: (v: Mode) => void;
+}
+
+function ModeRadio({
+  value,
+  label,
+  description,
+  selected,
+  onSelect,
+}: ModeRadioProps) {
+  const active = selected === value;
+  return (
+    <label
+      className={`flex cursor-pointer items-start gap-2.5 rounded-xl border p-3 transition-colors ${
+        active
+          ? "border-[#6C9B8B] bg-[#6C9B8B]/5"
+          : "border-[#D4DAE0] hover:border-[#6C9B8B]/50"
+      }`}
+    >
+      <input
+        type="radio"
+        name="server-mode"
+        value={value}
+        checked={active}
+        onChange={() => onSelect(value)}
+        className="mt-0.5 h-3.5 w-3.5 text-[#6C9B8B] accent-[#6C9B8B]"
+      />
+      <div>
+        <span className="block text-sm font-medium text-[#1A1D1F]">{label}</span>
+        <span className="mt-0.5 block text-xs text-[#9A9FA5]">
+          {description}
+        </span>
+      </div>
+    </label>
   );
 }
 

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -39,8 +39,14 @@ interface DashboardContextType {
   isXmlSource: boolean;
   /** Whether the active book is stored locally (OPFS) or on a Postgres server. */
   backend: Backend;
-  /** The book id of the currently open Postgres book, or null when on local backend. */
+  /** The book id of the currently open gnudash-managed Postgres book, or null. */
   postgresBookId: string | null;
+  /**
+   * Raw Postgres schema name for the existing-GnuCash-DB read-only path, or
+   * null. Non-null implies `backend === "postgres"` AND `isWritable === false`
+   * AND the UI should show the amber "existing database — read only" banner.
+   */
+  postgresSchemaOverride: string | null;
   toggleWritable: () => Promise<void>;
   uploadFile: (file: File, writable?: boolean) => Promise<void>;
   /**
@@ -75,9 +81,22 @@ interface DashboardContextType {
    * Reuses the connection + bookId captured on the most recent
    * openPostgresBook / importFileToPostgres call, so the sidebar can drive
    * the reupload without re-prompting for credentials. Throws if called
-   * while not connected to a Postgres backend.
+   * while not connected to a gnudash-managed Postgres backend — the
+   * existing-DB interop path is read-only and has no reupload.
    */
   reuploadPostgresBook: (file: File) => Promise<void>;
+  /**
+   * Open a pre-existing GnuCash Postgres database in read-only mode. Unlike
+   * `openPostgresBook`, the caller supplies a raw `schema` name (usually
+   * "public") instead of a bookId; the schema is used as-is without the
+   * `book_` prefix. The worker loads the dump into the local cache but
+   * wires up a non-writable adapter, so every mutation path in the UI is
+   * gated off by `isWritable: false`. No sync client is created.
+   */
+  openExistingGnuCashBook: (
+    connection: PostgresConnectionInfo,
+    schema: string,
+  ) => Promise<boolean>;
   loadDemo: () => Promise<void>;
   clearData: () => void;
   createTransaction: (payload: CreateTransactionPayload) => Promise<void>;
@@ -106,6 +125,9 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   const [isXmlSource, setIsXmlSource] = useState(false);
   const [backend, setBackend] = useState<Backend>("local");
   const [postgresBookId, setPostgresBookId] = useState<string | null>(null);
+  const [postgresSchemaOverride, setPostgresSchemaOverride] = useState<
+    string | null
+  >(null);
   const clientRef = useRef<GnuCashWorkerClient | null>(null);
   // Connection used by the currently-open Postgres book. Held in a ref, not
   // state, so reuploadPostgresBook can see the freshly-set value synchronously
@@ -149,8 +171,14 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
           // from the same BACKEND_KEY marker.
           return;
         }
-        const { bookId, ...connection } = cfg;
-        const ok = await openPostgresBook(connection, bookId);
+        const { mode, bookId, schema, ...connection } = cfg;
+        let ok = false;
+        if (mode === "existing" && schema) {
+          ok = await openExistingGnuCashBook(connection, schema);
+        } else if (mode !== "existing" && bookId) {
+          // gnudash mode (explicit or legacy-null).
+          ok = await openPostgresBook(connection, bookId);
+        }
         if (!ok && !cancelled) {
           // Clear the session marker so a reload doesn't silently retry the
           // same broken auto-reconnect; next time the user must actively
@@ -253,6 +281,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       setIsWritable(isXml ? false : writable);
       setBackend("local");
       setPostgresBookId(null);
+      setPostgresSchemaOverride(null);
       sessionStorage.setItem(UPLOADED_AT_KEY, now.toISOString());
       sessionStorage.setItem(WRITABLE_KEY, String(isXml ? false : writable));
       sessionStorage.setItem(BACKEND_KEY, "local");
@@ -309,6 +338,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
       setIsWritable(true);
       setBackend("postgres");
       setPostgresBookId(bookId);
+      setPostgresSchemaOverride(null);
       postgresConnectionRef.current = connection;
       sessionStorage.setItem(UPLOADED_AT_KEY, now.toISOString());
       sessionStorage.setItem(WRITABLE_KEY, "true");
@@ -316,7 +346,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
       // Persist the connection so a page refresh can reconnect without
       // prompting. Plaintext on disk — see server-config.ts security note.
-      const cfg: ServerConfig = { ...connection, bookId };
+      const cfg: ServerConfig = { ...connection, mode: "gnudash", bookId };
       await saveServerConfig(cfg).catch(() => {
         // If OPFS is unavailable the PG session is still fully usable —
         // the user will just have to re-enter credentials next time.
@@ -399,10 +429,81 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
    */
   async function reuploadPostgresBook(file: File) {
     const connection = postgresConnectionRef.current;
-    if (backend !== "postgres" || !connection || !postgresBookId) {
-      throw new Error("Reupload is only available when connected to Postgres");
+    if (
+      backend !== "postgres" ||
+      !connection ||
+      !postgresBookId ||
+      postgresSchemaOverride !== null
+    ) {
+      throw new Error(
+        "Reupload is only available on a gnudash-managed Postgres book",
+      );
     }
     await importFileToPostgres(file, connection, postgresBookId);
+  }
+
+  /**
+   * Open a pre-existing GnuCash desktop Postgres database read-only. Same
+   * fetch-dump → worker flow as `openPostgresBook` but:
+   * - Uses the raw `schema` name instead of `book_{bookId}`.
+   * - Initialises the worker via `openFromPostgresDumpReadOnly`, which wires
+   *   a non-writable adapter. Every mutation method on this context is
+   *   already gated by `isWritable`, so no engine SQL can reach the foreign
+   *   schema.
+   * - Persists the connection with `mode: "existing"` so auto-reconnect
+   *   restores this path on next load.
+   */
+  async function openExistingGnuCashBook(
+    connection: PostgresConnectionInfo,
+    schema: string,
+  ): Promise<boolean> {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const client = getClient();
+      await client.waitForReady();
+
+      const res = await fetch("/api/pg/book/dump", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ connection, schema }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Dump failed: HTTP ${res.status}`);
+      }
+      const dump = (await res.json()) as PostgresDumpPayload;
+
+      await client.openFromPostgresDumpReadOnly(dump);
+      const dashboardData = await client.getFullDashboardData();
+      const now = new Date();
+
+      // Drop any stray OPFS SQLite a previous local session may have left.
+      await deleteFromOPFS().catch(() => {});
+
+      setData(dashboardData);
+      setUploadedAt(now);
+      setIsXmlSource(false);
+      setIsWritable(false);
+      setBackend("postgres");
+      setPostgresBookId(null);
+      setPostgresSchemaOverride(schema);
+      postgresConnectionRef.current = connection;
+      sessionStorage.setItem(UPLOADED_AT_KEY, now.toISOString());
+      sessionStorage.setItem(WRITABLE_KEY, "false");
+      sessionStorage.setItem(BACKEND_KEY, "postgres");
+
+      const cfg: ServerConfig = { ...connection, mode: "existing", schema };
+      await saveServerConfig(cfg).catch(() => {});
+
+      return true;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Open failed");
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
   }
 
   async function loadDemo() {
@@ -428,6 +529,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setIsXmlSource(false);
     setBackend("local");
     setPostgresBookId(null);
+    setPostgresSchemaOverride(null);
     postgresConnectionRef.current = null;
     sessionStorage.removeItem(STORAGE_KEY);
     sessionStorage.removeItem(UPLOADED_AT_KEY);
@@ -534,7 +636,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
   return (
     <DashboardContext.Provider
-      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, reuploadPostgresBook, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, exportFile, setCurrency: setCurrencyFn }}
+      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, postgresSchemaOverride, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, reuploadPostgresBook, openExistingGnuCashBook, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, exportFile, setCurrency: setCurrencyFn }}
     >
       {children}
     </DashboardContext.Provider>

--- a/app/src/lib/gnucash/worker/client.ts
+++ b/app/src/lib/gnucash/worker/client.ts
@@ -231,6 +231,37 @@ export class GnuCashWorkerClient {
   }
 
   /**
+   * Read-only sibling of `openFromPostgresDump` used by the existing-GnuCash-
+   * DB interop path. Populates the local cache from the dump but wires the
+   * engine to a non-writable adapter, so every mutation path in the UI is
+   * gated off by the existing `isWritable` check and no SQL ever reaches a
+   * schema that doesn't belong to gnudash.
+   */
+  async openFromPostgresDumpReadOnly(
+    dump: PostgresDumpPayload,
+  ): Promise<void> {
+    await this.wasmReady;
+
+    return new Promise<void>((resolve, reject) => {
+      const prevHandler = this.worker.onmessage;
+      this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+        const msg = e.data;
+        if (msg.type === "ready") {
+          this.worker.onmessage = prevHandler;
+          resolve();
+        } else if (msg.type === "init-error") {
+          this.worker.onmessage = prevHandler;
+          reject(new Error(msg.message));
+        } else {
+          this.handleMessage(msg);
+        }
+      };
+
+      this.send({ type: "init-pg-dump-readonly", dump });
+    });
+  }
+
+  /**
    * Try to open a previously persisted DB from OPFS.
    * Returns true if successful, false if no file found.
    */

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -309,6 +309,49 @@ function closeDb(): void {
 }
 
 /**
+ * Look up the column names declared by the local SQLite schema for `table`.
+ * Used to filter dump rows on insert — real GnuCash Postgres schemas (the
+ * read-only interop path) carry extra columns like `commodities.quote_flag`
+ * that our SQLite DDL doesn't declare, and passing them through would fail
+ * the INSERT.
+ */
+function getLocalTableColumns(database: WasmDatabase, table: string): Set<string> {
+  const rows = database.selectObjects(`PRAGMA table_info(${table})`);
+  return new Set(rows.map((r) => (r as { name: string }).name));
+}
+
+/**
+ * Populate an open SQLite WASM cache from a Postgres dump payload. Skips
+ * tables that don't exist locally and drops any columns the local DDL
+ * doesn't declare. Used by both the writable (gnudash-managed) and
+ * read-only (existing GnuCash DB) init paths.
+ */
+function insertDumpIntoCache(
+  database: WasmDatabase,
+  dump: PostgresDumpPayload,
+): void {
+  for (const [table, rows] of Object.entries(dump.tables)) {
+    if (rows.length === 0) continue;
+    // `gnudash_meta` is a Postgres-only metadata table — the local cache has
+    // no schema for it and the engine never reads it.
+    if (table === "gnudash_meta") continue;
+
+    const targetColumns = getLocalTableColumns(database, table);
+    if (targetColumns.size === 0) continue; // table not in local DDL
+    const columns = Object.keys(rows[0]).filter((c) => targetColumns.has(c));
+    if (columns.length === 0) continue;
+
+    const placeholders = columns.map(() => "?").join(", ");
+    const sql = `INSERT INTO ${table} (${columns.join(", ")}) VALUES (${placeholders})`;
+    for (const row of rows) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const values = columns.map((c) => row[c]) as any[];
+      database.exec({ sql, bind: values });
+    }
+  }
+}
+
+/**
  * Build an in-memory SQLite WASM cache from a `/api/pg/book/dump` payload and
  * wrap it with a Postgres-backed writable adapter. The local cache uses the
  * engine's existing SQLite DDL (INTEGER / TEXT affinities) — SQLite's type
@@ -332,29 +375,41 @@ function initFromPostgresDump(
   db.exec({ sql: GNUCASH_SCHEMA_DDL });
   db.exec({ sql: EXTRA_ENGINE_TABLES_SQL });
 
-  for (const [table, rows] of Object.entries(dump.tables)) {
-    if (rows.length === 0) continue;
-    // `gnudash_meta` is a Postgres-only metadata table — the local cache has
-    // no schema for it and the engine never reads it.
-    if (table === "gnudash_meta") continue;
-    // Defensive: drop any columns the local SQLite schema does not declare.
-    // In practice the two match, but this keeps us forward-compatible if the
-    // Postgres schema ever gains a column the engine doesn't know about.
-    const columns = Object.keys(rows[0]);
-    const placeholders = columns.map(() => "?").join(", ");
-    const sql = `INSERT INTO ${table} (${columns.join(", ")}) VALUES (${placeholders})`;
-    for (const row of rows) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const values = columns.map((c) => row[c]) as any[];
-      db.exec({ sql, bind: values });
-    }
-  }
+  insertDumpIntoCache(db, dump);
 
   syncClient = new PostgresSyncClient(connection, bookId);
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   writableAdapter = createWritablePostgresAdapter(db as any, syncClient);
   validateSchema(writableAdapter);
   ctx = buildParseContext(writableAdapter);
+}
+
+/**
+ * Read-only variant of `initFromPostgresDump` for the existing-GnuCash-DB
+ * interop path (#48 follow-up). Populates the local cache from the dump but
+ * wires the engine to a NON-writable adapter — every mutation helper in the
+ * dashboard context already gates on `isWritable`, so the engine never gets
+ * to emit a statement that could end up against a foreign schema we don't
+ * control.
+ *
+ * No sync client is created; the caller's responsibility for subsequent
+ * reloads is to fetch a fresh dump via the connection stored in OPFS.
+ */
+function initFromPostgresDumpReadOnly(dump: PostgresDumpPayload): void {
+  closeDb();
+  isWritable = false;
+  writableAdapter = null;
+  syncClient = null;
+
+  db = new sqlite3.oo1.DB();
+  db.exec({ sql: GNUCASH_SCHEMA_DDL });
+  db.exec({ sql: EXTRA_ENGINE_TABLES_SQL });
+
+  insertDumpIntoCache(db, dump);
+
+  const adapter = createWasmAdapter(db);
+  validateSchema(adapter);
+  ctx = buildParseContext(adapter);
 }
 
 function getFullDashboardData(): DashboardData {
@@ -810,6 +865,19 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
           "[db-worker] DB restored from Postgres dump",
           `book=${msg.bookId}`,
           "(read-write, syncing)",
+        );
+        post({ type: "ready" });
+      } catch (err) {
+        post({ type: "init-error", message: (err as Error).message });
+      }
+      break;
+    }
+
+    case "init-pg-dump-readonly": {
+      try {
+        initFromPostgresDumpReadOnly(msg.dump);
+        console.log(
+          "[db-worker] DB restored from Postgres dump (read-only interop)",
         );
         post({ type: "ready" });
       } catch (err) {

--- a/app/src/lib/gnucash/worker/messages.ts
+++ b/app/src/lib/gnucash/worker/messages.ts
@@ -33,6 +33,10 @@ export type WorkerRequest =
       connection: PostgresConnectionInfo;
       bookId: string;
     }
+  | {
+      type: "init-pg-dump-readonly";
+      dump: PostgresDumpPayload;
+    }
   | { type: "query"; id: string; fn: DomainFunction }
   | { type: "mutation"; id: string; action: MutationAction; payload: unknown }
   | { type: "set-currency"; id: string; currencyGuid: string }

--- a/app/src/lib/pg/connect.ts
+++ b/app/src/lib/pg/connect.ts
@@ -16,6 +16,44 @@
 import { Client } from "pg";
 import { bookSchemaName } from "../gnucash/db/postgres-schema";
 
+/**
+ * Validate a raw Postgres schema name supplied by the user for the
+ * existing-GnuCash-DB interop path. Mirrors `sanitizeBookId`'s strictness —
+ * the value is interpolated into unquoted SQL (`SET search_path TO ...`) so
+ * anything that could break out of an identifier is rejected. Allows the
+ * typical GnuCash defaults like `public`.
+ */
+const SCHEMA_NAME_PATTERN = /^[a-z_][a-z0-9_]{0,62}$/;
+
+export function sanitizeSchemaName(name: string): string {
+  if (typeof name !== "string" || !SCHEMA_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid schema name ${JSON.stringify(name)}: must match /^[a-z_][a-z0-9_]{0,62}$/`,
+    );
+  }
+  return name;
+}
+
+/**
+ * Resolve the Postgres schema name for a request that carries either a
+ * gnudash-managed `bookId` (mapped through `book_` prefix + sanitisation)
+ * or a raw `schema` for the existing-GnuCash-DB read-only interop path.
+ * Exactly one of the two must be present — the route's body validator
+ * enforces that before calling in.
+ */
+export function resolveSchemaName(args: {
+  bookId?: string;
+  schema?: string;
+}): string {
+  if (args.schema !== undefined) {
+    return sanitizeSchemaName(args.schema);
+  }
+  if (args.bookId !== undefined) {
+    return bookSchemaName(args.bookId);
+  }
+  throw new Error("resolveSchemaName: neither bookId nor schema supplied");
+}
+
 /** Connection parameters sent from the browser. */
 export interface PgConnection {
   host: string;
@@ -80,6 +118,24 @@ export async function withBookClient<T>(
 
   return withClient(connection, async (client) => {
     await client.query(`SET search_path TO ${schema}`);
+    return fn(client);
+  });
+}
+
+/**
+ * Same shape as `withBookClient` but pins `search_path` to a caller-supplied
+ * schema name. Used by the existing-GnuCash-DB read-only path where the
+ * user picks the schema directly instead of using gnudash's `book_` prefix.
+ */
+export async function withSchemaClient<T>(
+  connection: PgConnection,
+  schema: string,
+  fn: (client: Client) => Promise<T>,
+): Promise<T> {
+  const sanitized = sanitizeSchemaName(schema);
+
+  return withClient(connection, async (client) => {
+    await client.query(`SET search_path TO ${sanitized}`);
     return fn(client);
   });
 }

--- a/app/src/lib/storage/__tests__/server-config.test.ts
+++ b/app/src/lib/storage/__tests__/server-config.test.ts
@@ -71,7 +71,18 @@ const validConfig: ServerConfig = {
   user: "gnudash",
   password: "hunter2",
   database: "gnudash",
+  mode: "gnudash",
   bookId: "default",
+};
+
+const validExistingConfig: ServerConfig = {
+  host: "db.example",
+  port: 5432,
+  user: "gnudash",
+  password: "hunter2",
+  database: "gnudash",
+  mode: "existing",
+  schema: "public",
 };
 
 describe("isServerConfigSupported", () => {
@@ -133,6 +144,90 @@ describe("OPFS round-trip", () => {
 
   it("clearServerConfig is idempotent when no file exists", async () => {
     await expect(clearServerConfig()).resolves.toBeUndefined();
+  });
+
+  it("roundtrips an existing-mode config with a schema field", async () => {
+    await saveServerConfig(validExistingConfig);
+    const loaded = await loadServerConfig();
+    expect(loaded).toEqual(validExistingConfig);
+  });
+});
+
+describe("legacy / mode compatibility", () => {
+  beforeEach(() => {
+    installOpfsMock();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads a pre-v1 config (no mode field) as gnudash", async () => {
+    const files = installOpfsMock();
+    files.set(
+      "gnudash-server.json",
+      JSON.stringify({
+        host: "db",
+        port: 5432,
+        user: "u",
+        password: "p",
+        database: "d",
+        bookId: "default",
+      }),
+    );
+    const loaded = await loadServerConfig();
+    expect(loaded?.mode).toBe("gnudash");
+    expect(loaded?.bookId).toBe("default");
+  });
+
+  it("rejects an existing-mode config missing the schema field", async () => {
+    const files = installOpfsMock();
+    files.set(
+      "gnudash-server.json",
+      JSON.stringify({
+        host: "db",
+        port: 5432,
+        user: "u",
+        password: "p",
+        database: "d",
+        mode: "existing",
+      }),
+    );
+    expect(await loadServerConfig()).toBeNull();
+  });
+
+  it("rejects a gnudash-mode config missing the bookId field", async () => {
+    const files = installOpfsMock();
+    files.set(
+      "gnudash-server.json",
+      JSON.stringify({
+        host: "db",
+        port: 5432,
+        user: "u",
+        password: "p",
+        database: "d",
+        mode: "gnudash",
+      }),
+    );
+    expect(await loadServerConfig()).toBeNull();
+  });
+
+  it("falls back to gnudash mode for an unrecognised mode string", async () => {
+    const files = installOpfsMock();
+    files.set(
+      "gnudash-server.json",
+      JSON.stringify({
+        host: "db",
+        port: 5432,
+        user: "u",
+        password: "p",
+        database: "d",
+        mode: "nonsense",
+        bookId: "default",
+      }),
+    );
+    const loaded = await loadServerConfig();
+    expect(loaded?.mode).toBe("gnudash");
   });
 });
 

--- a/app/src/lib/storage/server-config.ts
+++ b/app/src/lib/storage/server-config.ts
@@ -22,10 +22,19 @@
  * and not worth gating MVP on.
  */
 
+/** How the active Postgres session is scoped. */
+export type ServerConfigMode = "gnudash" | "existing";
+
 /**
  * Shape of the config we persist. Mirrors `PgConnection` (from
- * `lib/pg/connect`) plus the active `bookId` so the auto-reconnect path can
- * target the same schema without prompting.
+ * `lib/pg/connect`) plus enough context to re-open the same book on
+ * auto-reconnect:
+ *
+ * - `mode: "gnudash"` (default) — gnudash owns the schema, named
+ *   `book_{bookId}`. Writes round-trip to Postgres via the sync client.
+ * - `mode: "existing"` — a real GnuCash desktop database; `schema` names
+ *   the target (usually `public`). Opened read-only; the engine's write
+ *   paths are gated off by `isWritable=false`.
  */
 export interface ServerConfig {
   host: string;
@@ -33,9 +42,14 @@ export interface ServerConfig {
   user: string;
   password: string;
   database: string;
-  bookId: string;
   /** Enable TLS. Required for any non-localhost deployment. */
   ssl?: boolean;
+  /** "gnudash" or "existing"; defaults to "gnudash" for pre-v1 saves. */
+  mode?: ServerConfigMode;
+  /** Book id for gnudash mode (required when mode === "gnudash"). */
+  bookId?: string;
+  /** Raw schema name for existing mode (required when mode === "existing"). */
+  schema?: string;
 }
 
 /** Filename inside the OPFS root. */
@@ -133,6 +147,9 @@ export async function hasServerConfig(): Promise<boolean> {
  * Validate and return a ServerConfig from raw text. Missing/wrong-typed
  * fields cause a null return — we'd rather fall back to the upload screen
  * than feed garbage into an auto-reconnect attempt.
+ *
+ * `mode` is optional and defaults to "gnudash" when missing so configs
+ * written before the existing-DB interop landed still load cleanly.
  */
 function parseServerConfig(text: string): ServerConfig | null {
   let parsed: unknown;
@@ -148,20 +165,30 @@ function parseServerConfig(text: string): ServerConfig | null {
     typeof cfg.port !== "number" ||
     typeof cfg.user !== "string" ||
     typeof cfg.password !== "string" ||
-    typeof cfg.database !== "string" ||
-    typeof cfg.bookId !== "string"
+    typeof cfg.database !== "string"
   ) {
     return null;
   }
-  return {
+
+  const mode: ServerConfigMode =
+    cfg.mode === "existing" || cfg.mode === "gnudash" ? cfg.mode : "gnudash";
+
+  const base = {
     host: cfg.host,
     port: cfg.port,
     user: cfg.user,
     password: cfg.password,
     database: cfg.database,
-    bookId: cfg.bookId,
     ssl: typeof cfg.ssl === "boolean" ? cfg.ssl : undefined,
   };
+
+  if (mode === "existing") {
+    if (typeof cfg.schema !== "string") return null;
+    return { ...base, mode: "existing", schema: cfg.schema };
+  }
+  // gnudash mode (including legacy configs without a mode field)
+  if (typeof cfg.bookId !== "string") return null;
+  return { ...base, mode: "gnudash", bookId: cfg.bookId };
 }
 
 function isRecord(v: unknown): v is Record<string, unknown> {


### PR DESCRIPTION
v1 of the post-#48 interop feature. Lets users point gnudash at a schema GnuCash desktop already writes to (typically \`public\`) instead of making gnudash own the schema. Read-only — the engine's write paths stay fully gated so no SQL ever reaches a foreign schema.

## UI

The Server tab now starts with a mode selector:

| Mode | Behaviour |
|---|---|
| **gnudash-managed database** (default) | Unchanged: \`book_{bookId}\`, cache-and-sync writes |
| **Existing GnuCash database (read-only)** | User supplies a raw \`schema\` (default \`public\`), opens read-only |

Amber in-form warning in existing mode calls out the concurrent-access caveat. A persistent amber banner across every dashboard page reminds the user they're in read-only interop.

## Wire surface

- \`/api/pg/book/status\` and \`/api/pg/book/dump\` accept exactly one of \`bookId\` or \`schema\`; new \`resolveSchemaName\` helper validates both inputs via the same strict identifier regex. The dump route gracefully skips tables that don't exist in the target schema (real GnuCash DBs have no \`gnudash_meta\`; older files may lack \`lots\`/\`slots\`).
- New \`init-pg-dump-readonly\` worker message → populates local SQLite, wires a non-writable adapter, no sync client. Every mutation method on \`DashboardContext\` already gates on \`isWritable\`, so edit affordances disappear for free.
- Defensive column filter in dump→cache insert: real GnuCash schemas have columns our SQLite DDL doesn't declare (\`commodities.quote_flag\` etc.); we PRAGMA the local table and drop extras, mirroring the fix already applied to the Postgres import route.

## Config + auto-reconnect

\`ServerConfig\` now carries \`mode: "gnudash" | "existing"\` plus either \`bookId\` or \`schema\`. Pre-v1 saved configs (no \`mode\` field) load as gnudash — migration-free. \`DashboardContext.restore()\` reads the saved mode and routes to the right open helper.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 239/239 passing (5 new server-config tests for the mode field)
- [x] \`npm run lint\` clean for new/modified files
- [x] \`npm run build\` standalone clean
- [x] \`NEXT_OUTPUT=export npm run build\` static clean
- [x] **Manual**: 
  1. From within GnuCash desktop, save your book to \`postgres://gnudash:gnudash@localhost:5432/gnudash\` (GnuCash → File → Save As → Postgres).
  2. In gnudash, Server tab → pick *Existing GnuCash database (read-only)*, schema \`public\`, Connect.
  3. Dashboard should load with amber banner visible. Accounts, transactions, investments should all render.
  4. Edit affordances (Edit / Delete / New transaction buttons) should all be hidden or disabled.
  5. Reload the page — auto-reconnect should bring you straight back to the dashboard.
  6. Clear data → back to upload screen. Pick *gnudash-managed* mode → connect to \`book_default\` → verify the original gnudash flow still works end-to-end.

## Follow-up (v2)

The write-capable interop path (discovery of NOT-NULL columns we don't populate + safe-default supply) is still on the list as the logical v2. Parked until someone asks; v1 covers the "I just want to see my data" use case.