### PR TITLE
Make the Server backend deployable in one docker compose command

### DIFF
--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,0 +1,47 @@
+# Standalone Node.js image for the Server (Postgres) backend.
+#
+# Build context = repo root:
+#   docker build -f Dockerfile.standalone -t gnudash-standalone .
+#
+# or via docker-compose.yml (uncomment the `gnudash-app` service there).
+#
+# The image ships the Next.js standalone bundle built with `npm run build`
+# (which is the default — no NEXT_OUTPUT=export). It includes the /api/pg/*
+# routes needed by the Server backend; the static-only nginx Dockerfile
+# (./Dockerfile) does NOT — use this file for self-hosted Postgres setups.
+
+FROM --platform=$BUILDPLATFORM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS build
+
+WORKDIR /app
+# Copy the app package manifests first so npm ci can be cached across builds
+# that only touch source.
+COPY app/package*.json ./
+RUN npm ci
+
+COPY app/ ./
+
+# Default build target is "standalone" (see app/next.config.ts) which produces
+# a self-contained bundle at app/.next/standalone/. NEXT_OUTPUT is explicitly
+# unset here so nothing accidentally flips us to the static-export path.
+RUN npm run build
+
+
+FROM node:20-alpine@sha256:f598378b5240225e6beab68fa9f356db1fb8efe55173e6d4d8153113bb8f333c AS runtime
+
+WORKDIR /app
+ENV NODE_ENV=production
+# Next.js listens on $PORT (defaults to 3000 in the standalone server).
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+# The standalone output bundles only the runtime deps Next traced, so we
+# don't need a separate `npm ci --omit=dev` — just copy the pre-wired tree.
+COPY --from=build /app/.next/standalone/ ./
+# Static assets and the public/ folder aren't bundled into standalone/; copy
+# them in alongside so the server can serve them at their expected paths.
+COPY --from=build /app/.next/static/ ./.next/static/
+COPY --from=build /app/public/ ./public/
+
+EXPOSE 3000
+# server.js is the entrypoint Next.js generates inside the standalone bundle.
+CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -29,7 +29,18 @@ To clear your data, use the dashboard's clear/reset option or clear your browser
 
 If you want the same book accessible from every device you use — phone, laptop, work machine — you can self-host GnuDash against your own Postgres database instead of relying on the per-browser OPFS cache. Pick **Server (Postgres)** on the upload screen, point it at your database, and GnuDash mirrors the book into a dedicated schema there. Writes round-trip to Postgres before the UI shows the "saved" state; reads hit a local SQLite WASM cache so the dashboard stays fast.
 
-This mode requires the standalone Node.js build (the public pages deployment is still fully static) and is fully documented in the [Deployment Guide](docs/deployment.md).
+You can also point GnuDash at an existing GnuCash desktop Postgres database in **read-only** mode — useful if you just want a browser dashboard over data you're already writing from the desktop app.
+
+This mode requires the standalone Node.js build (the static `gnudash.pages.dev` deployment stays fully local-only). The fastest way to try it:
+
+```bash
+git clone https://github.com/QuirkyTurtle94/GnuDash.git
+cd GnuDash
+docker compose up -d                     # gnudash + Postgres together
+open http://localhost:3000
+```
+
+Full walkthrough — reverse-proxy / TLS, existing-GnuCash read-only mode, troubleshooting — in the [Deployment Guide](docs/deployment.md).
 
 ## Features
 

--- a/app/scripts/next-build.mjs
+++ b/app/scripts/next-build.mjs
@@ -20,6 +20,12 @@ const API_DIR = "src/app/api";
 const PARKED_DIR = ".api-parked-for-export";
 const shouldPark = process.env.NEXT_OUTPUT === "export";
 
+// Expose the build target to the client bundle so the upload UI can hide the
+// Server (Postgres) tab when the API routes aren't going to exist at runtime.
+// `NEXT_PUBLIC_*` vars are inlined into the client bundle at build time by
+// Next.js, so this survives the static export as a constant string.
+process.env.NEXT_PUBLIC_HAS_SERVER_BACKEND = shouldPark ? "false" : "true";
+
 let parked = false;
 if (shouldPark && existsSync(API_DIR)) {
   renameSync(API_DIR, PARKED_DIR);

--- a/app/src/components/upload/file-upload.tsx
+++ b/app/src/components/upload/file-upload.tsx
@@ -24,6 +24,18 @@ type TabId = "local" | "server";
 const DEFAULT_TAB: TabId = "local";
 
 /**
+ * Whether the Server (Postgres) backend is reachable in this build. `false`
+ * for static-export builds where `/api/pg/*` routes were parked out by
+ * scripts/next-build.mjs, `true` for standalone builds (and dev servers,
+ * which default to true via Next.js env handling).
+ *
+ * Inlined at build time, so the upload UI can pretend the Server tab never
+ * existed rather than showing a tab whose Connect button would 404.
+ */
+const HAS_SERVER_BACKEND =
+  process.env.NEXT_PUBLIC_HAS_SERVER_BACKEND !== "false";
+
+/**
  * Upload wizard shown when no book is loaded. The two backend choices
  * (Local OPFS / Server Postgres) live behind tabs so the familiar drag-drop
  * experience stays the default for the public pages deployment, and
@@ -42,6 +54,9 @@ export function FileUpload() {
   // cascading render but there isn't a cleaner way short of
   // useSyncExternalStore, which is overkill for a single tab preference.
   useEffect(() => {
+    // Static-export builds don't have the Server backend at all, so every
+    // saved preference collapses to Local. Skip the hydration entirely.
+    if (!HAS_SERVER_BACKEND) return;
     try {
       // Session-level backend marker wins: a user returning after a failed
       // Postgres auto-reconnect should land on the Server tab even if they'd
@@ -70,6 +85,33 @@ export function FileUpload() {
       // Non-fatal — the tab choice just won't persist.
     }
   };
+
+  // Static-export builds collapse to the single Local panel — rendering the
+  // tab shell at all would be misleading because the Server panel has no
+  // API routes to talk to. Standalone builds and dev servers show both.
+  if (!HAS_SERVER_BACKEND) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-[#F4F5F7] p-4 sm:p-8">
+        <div className="w-full max-w-lg">
+          <div className="mb-6 text-center sm:mb-8">
+            <Image
+              src="/logo.png"
+              alt="GnuDash"
+              width={900}
+              height={600}
+              className="mx-auto mb-4 rounded-2xl"
+              loading="eager"
+              style={{ width: "auto", height: "auto" }}
+            />
+            <p className="mt-2 text-sm text-[#6F767E]">
+              Upload your .gnucash file to view your financial dashboard.
+            </p>
+          </div>
+          <LocalUploadPanel />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="flex min-h-screen items-center justify-center bg-[#F4F5F7] p-4 sm:p-8">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,14 +6,19 @@
 # in its own Postgres schema so a single database can cover multi-device usage.
 #
 # Usage:
-#   docker compose up -d postgres     # start the DB only
-#   docker compose down               # stop (keeps volume)
-#   ./scripts/db-reset.sh             # stop AND drop the data volume
+#   docker compose up -d postgres            # start the DB only
+#   docker compose up -d                     # start the DB AND the app
+#   docker compose down                      # stop (keeps volume)
+#   ./scripts/db-reset.sh                    # stop AND drop the data volume
 #
-# Connect from the upload screen's "Server" tab with:
-#   host=localhost port=5432 user=gnudash password=gnudash database=gnudash
+# After `docker compose up -d`, open http://localhost:3000, pick the
+# "Server (Postgres)" tab on the upload screen and connect with:
+#   host=postgres port=5432 user=gnudash password=gnudash database=gnudash
+#   (host `localhost` also works from the browser for port-mapped access)
 #
-# Production deployments MUST override the default password via env / secrets.
+# Production deployments MUST override the default password via env / secrets
+# and put the app behind a reverse proxy that terminates TLS — see
+# docs/deployment.md for worked examples.
 
 services:
   postgres:
@@ -34,21 +39,19 @@ services:
       timeout: 5s
       retries: 10
 
-  # Uncomment to run the GnuDash app in standalone mode alongside Postgres.
-  # Requires a standalone Dockerfile (not yet added — MVP expects users to run
-  # `npm run dev` locally or self-host the Next.js output themselves).
-  #
-  # gnudash-app:
-  #   build:
-  #     context: ./app
-  #     dockerfile: Dockerfile.standalone
-  #   ports:
-  #     - "3000:3000"
-  #   depends_on:
-  #     postgres:
-  #       condition: service_healthy
-  #   environment:
-  #     NODE_ENV: production
+  gnudash-app:
+    build:
+      context: .
+      dockerfile: Dockerfile.standalone
+    container_name: gnudash-app
+    ports:
+      - "${GNUDASH_PORT:-3000}:3000"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      NODE_ENV: production
+    restart: unless-stopped
 
 volumes:
   gnudash_pgdata:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -310,51 +310,122 @@ If you can't set custom headers (e.g. GitHub Pages), the app will still load but
 
 ---
 
-## Self-hosted Postgres backend
+## Self-hosted Server (Postgres) backend
 
-The Server (Postgres) backend is an alternative to the Local (OPFS) backend: your book lives in a Postgres database you control, so the same data is reachable from every browser that can reach the server. Every write made in the UI is applied to a local SQLite WASM cache first (keeps the dashboard fast) and round-tripped to Postgres before the UI shows the "saved" state.
+The Server backend runs your book against a Postgres database you control, so the same data is reachable from every browser that can reach the server. Every write is applied to a local SQLite WASM cache first (keeps the dashboard fast) and round-tripped to Postgres before the UI shows the "saved" state. Credentials are persisted in your browser's Origin Private File System so page reloads auto-reconnect without re-prompting.
 
-Requires the **standalone** build mode — the API routes that talk to Postgres can't be served by a static-file host. A static deployment (nginx, Cloudflare Pages, Netlify) cannot use this backend.
+> **Build-mode dependency.** This requires the **standalone** Node.js build. A static export (nginx / Cloudflare Pages / Netlify) doesn't have the `/api/pg/*` routes and the upload screen only shows the Local tab in that mode. If you want self-hostable, cross-device access, follow the steps below; if you only want the familiar local-file dashboard, stay on the static path from the sections earlier in this guide.
 
-### 1. Start Postgres
+### Quickstart with Docker Compose (easiest)
 
-The repo includes a ready-to-go `docker-compose.yml` that boots `postgres:16-alpine` with sensible defaults:
+From the repo root:
+
+```bash
+docker compose up -d
+# → gnudash on http://localhost:3000, Postgres on localhost:5432
+```
+
+Compose builds the app from the included `Dockerfile.standalone`, starts a `postgres:16-alpine` container, waits for it to be healthy, and runs the app. Open http://localhost:3000 and pick the **Server (Postgres)** tab on the upload screen. Defaults match compose:
+
+```
+host=localhost  port=5432  user=gnudash  password=gnudash  database=gnudash
+book id=default
+```
+
+Drop a `.gnucash` file to bootstrap the book and you're in.
+
+**Overrides before first `up`** (or in a `.env` next to `docker-compose.yml`):
+
+| env var | default | purpose |
+|---|---|---|
+| `POSTGRES_USER` | `gnudash` | DB role name |
+| `POSTGRES_PASSWORD` | `gnudash` | DB password (change for anything non-toy) |
+| `POSTGRES_DB` | `gnudash` | DB name |
+| `POSTGRES_PORT` | `5432` | Host-side port mapping |
+| `GNUDASH_PORT` | `3000` | Host-side port for the app |
+
+### Running only Postgres (dev-server against it)
+
+If you'd rather point `npm run dev` at a containerised Postgres:
 
 ```bash
 docker compose up -d postgres
+cd app && npm install && npm run dev
 ```
 
-Defaults: `host=localhost port=5432 user=gnudash password=gnudash database=gnudash`. Override before the first `up` via `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB`, `POSTGRES_PORT` env vars (or a `.env` file next to `docker-compose.yml`). `./scripts/db-reset.sh` wipes the data volume when you want to start over.
+Dev mode includes the API routes and hot-reloads on source changes.
 
-### 2. Run the app in standalone mode
-
-From the `app/` directory:
+### Running without Docker
 
 ```bash
+cd app
 npm install
-npm run build          # produces app/.next/standalone/
+npm run build          # produces app/.next/standalone/server.js
 node .next/standalone/server.js
 ```
 
-The Postgres API routes live under `/api/pg/*` and are automatically included in the standalone bundle. For a container-based deployment you can write a small Dockerfile that copies `.next/standalone/`, `.next/static/`, and `public/` into a `node:20-alpine` image and runs `server.js` on port 3000 — this repo doesn't ship one by default because the deployment shape is highly site-specific.
+You'll need Postgres reachable separately — install locally, rent a managed instance, or point at an existing one.
 
-### 3. Connect from the upload screen
+### Reverse proxy + TLS (required for any non-localhost deployment)
 
-Open the app in a browser, pick the **Server (Postgres)** tab on the upload screen, fill in the connection form (the defaults match `docker-compose.yml`), and click **Connect**:
+The browser posts the Postgres password in each request body, so the app **must** sit behind TLS unless it's on localhost. Minimal nginx example:
 
-- If the book doesn't exist yet, you'll be prompted to drop a `.gnucash` file (SQLite or XML — XML is converted to SQLite in the browser before upload). The file bootstraps the schema.
-- If the book already exists, the app loads it directly.
+```nginx
+server {
+  listen 443 ssl http2;
+  server_name gnudash.example.com;
 
-After a successful connect the connection is persisted to your browser's Origin Private File System so a page reload auto-reconnects without prompting. The **Reupload to Postgres** button in the sidebar replaces the server book in place; the **Disconnect** button returns you to the upload screen without touching the server.
+  ssl_certificate     /etc/letsencrypt/live/gnudash.example.com/fullchain.pem;
+  ssl_certificate_key /etc/letsencrypt/live/gnudash.example.com/privkey.pem;
 
-### 4. Security
+  # Cross-Origin-* headers so SharedArrayBuffer works (SQLite WASM needs it).
+  add_header Cross-Origin-Opener-Policy "same-origin" always;
+  add_header Cross-Origin-Embedder-Policy "require-corp" always;
 
-**Credentials are stored in plaintext** in OPFS so auto-reconnect works. OPFS is sandboxed per origin (no other website can read it) but any JavaScript running on this origin can. Treat the gnudash origin like any other app that handles its own credentials:
+  location / {
+    proxy_pass http://127.0.0.1:3000;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    # File imports can be large — raise this from the nginx default of 1m.
+    client_max_body_size 200m;
+  }
+}
+```
 
-- **Terminate TLS in front of the app for any non-localhost deployment.** The Server backend sends the Postgres password in each request body from the browser; without TLS it's exposed on the wire.
-- Use a strong, dedicated Postgres user for gnudash. Don't reuse the password anywhere else.
-- Consider host the app behind an auth reverse proxy (oauth2-proxy, Authelia, etc.) if it's on the open internet.
+Caddy is even simpler — it handles certs automatically:
 
-### 5. Storage model
+```caddy
+gnudash.example.com {
+  header Cross-Origin-Opener-Policy "same-origin"
+  header Cross-Origin-Embedder-Policy "require-corp"
+  reverse_proxy 127.0.0.1:3000
+  request_body {
+    max_size 200MB
+  }
+}
+```
 
-Each book lives in its own Postgres schema named `book_{bookId}` — the MVP ships with a single `book_default` but the schema indirection is there so per-user / multi-tenant deployments are an additive change rather than a redesign. The gnudash schema is **not interop-compatible with GnuCash desktop's Postgres backend**: if you have an existing GnuCash Postgres database, upload your data via the Server tab instead of pointing gnudash at it directly.
+If the app is on the open internet, consider also putting it behind an auth reverse proxy (oauth2-proxy, Authelia, Cloudflare Access) so the login to your Postgres isn't just a password field on a public form.
+
+### Pointing gnudash at an existing GnuCash desktop database (read-only)
+
+If you already have a GnuCash book saved to Postgres, you can load it in gnudash without re-importing:
+
+1. On the Server tab, choose **Existing GnuCash database (read-only)**.
+2. Fill in the connection fields and set `schema` to whatever GnuCash desktop writes to (usually `public`).
+3. Connect — gnudash shows a persistent amber banner and every edit affordance is disabled.
+
+**Close GnuCash desktop before you load the book here.** gnudash doesn't take the DBI session lock, so concurrent access between the two apps can corrupt data. The read-only mode is a safety rail, not an interlock.
+
+### Storage model
+
+Each gnudash-managed book lives in its own Postgres schema named `book_{bookId}` (default: `book_default`). Tables in the schema mirror GnuCash's own layout but are **not byte-for-byte identical**: we only declare the columns the gnudash engine reads or writes, and the NOT NULL policy is deliberately looser so real `.gnucash` imports don't fail. That's why the "existing GnuCash database" path is read-only — write-through to a foreign schema requires column-discovery logic we haven't shipped yet.
+
+### Troubleshooting
+
+- **"Invalid schema name" on Connect.** The `book id` / `schema` field accepts only `[a-z][a-z0-9_]*`, up to 63 chars. `public`, `book_alice`, `default` all work; hyphens, uppercase, semicolons don't.
+- **Import fails on `column "X" does not exist`.** You're hitting a column our PG DDL doesn't declare on import. Expected to be drift-proof as of PR 82 (we filter source columns); if you see a new one, file an issue with the GnuCash file's schema (`sqlite3 file.gnucash ".schema <tablename>"`).
+- **"SharedArrayBuffer is not defined" in the console.** Your reverse proxy isn't serving the COOP/COEP headers. See the nginx / Caddy snippets above.
+- **"Connection refused" on Connect with Compose.** Inside Docker use `host=postgres`; from a browser hitting the exposed port use `host=localhost`. If you changed `POSTGRES_PORT`, use that port, not 5432.
+- **Data looks stale after a server restart.** OPFS caches the last dump; reload the page to re-fetch from Postgres.


### PR DESCRIPTION
Closes the "server getting started" gap reported after PR 86. A fresh clone can now self-host the full Server backend in one command:

\`\`\`bash
docker compose up -d
open http://localhost:3000
\`\`\`

## What's in it

- **\`Dockerfile.standalone\`** — new two-stage image at repo root. Builds the Next.js standalone bundle (\`npm run build\`, default output) and runs \`server.js\` on port 3000. Includes the \`/api/pg/*\` routes. Separate from the existing static/nginx \`Dockerfile\`.
- **\`docker-compose.yml\`** — the \`gnudash-app\` service that was stubbed out in comments back in PR 1 is now wired up, depending on the Postgres healthcheck. New \`GNUDASH_PORT\` env var for host-side port remap.
- **Upload UI hides the Server tab in static-export builds.** The build wrapper sets \`NEXT_PUBLIC_HAS_SERVER_BACKEND\` based on output target; \`FileUpload\` renders only the Local panel when the API routes aren't there. A saved \`"server"\` tab preference is ignored in that mode so a user who switches deployment shape doesn't land on a dead tab.
- **\`docs/deployment.md\`** — reorganised: Compose-quickstart first, then dev-server-against-PG, then no-docker, then reverse-proxy (worked nginx + caddy examples with COOP/COEP and \`client_max_body_size\`), then existing-GnuCash-DB read-only, then troubleshooting covering the top 5 stumbles.
- **\`README.md\`** — expanded the Server-backend blurb with a three-line quickstart and a mention of read-only interop.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm test\` — 239/239 passing, no regressions
- [x] \`npm run lint\` clean on new/modified files
- [x] \`npm run build\` (standalone) — clean, API routes present
- [x] \`NEXT_OUTPUT=export npm run build\` (static) — clean, API dir parked, Server tab absent from the emitted UI
- [ ] **Manual**: fresh checkout → \`docker compose up -d\` → http://localhost:3000 → Server tab visible, connect + import works end-to-end. Then rebuild with \`NEXT_OUTPUT=export npm run build\` → inspect the emitted HTML and confirm no Server tab.

## Not in scope

The "full schema parity with GnuCash desktop" refactor you asked about in the same message isn't part of this PR — I'll write that up as a separate analysis reply in the conversation once this is through.