### PR TITLE
Gate edit toggle off in existing-GnuCash-DB interop mode

### DIFF
--- a/app/src/app/(dashboard)/layout.tsx
+++ b/app/src/app/(dashboard)/layout.tsx
@@ -137,7 +137,16 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
                 <span className="hidden sm:inline">XML &middot; Read-only</span>
               </span>
             )}
-            {!isXmlSource && isWritable && (
+            {postgresSchemaOverride !== null && data && (
+              <span
+                className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground"
+                title="Existing GnuCash Postgres databases are opened read-only. Close GnuCash desktop and edit there."
+              >
+                <Lock className="h-3 w-3" />
+                <span className="hidden sm:inline">Read-only</span>
+              </span>
+            )}
+            {postgresSchemaOverride === null && !isXmlSource && isWritable && (
               <button
                 onClick={toggleWritable}
                 className="flex items-center gap-1.5 rounded-lg border border-[#3B6B8A] bg-[#3B6B8A]/10 px-3 py-1.5 text-xs font-medium text-[#3B6B8A] transition-colors hover:bg-[#3B6B8A]/20 dark:border-[#6FA4C7] dark:text-[#6FA4C7] dark:bg-[#6FA4C7]/10 dark:hover:bg-[#6FA4C7]/20"
@@ -147,7 +156,7 @@ function DashboardInner({ children }: { children: React.ReactNode }) {
                 <span className="hidden sm:inline">Editing</span>
               </button>
             )}
-            {!isXmlSource && !isWritable && data && (
+            {postgresSchemaOverride === null && !isXmlSource && !isWritable && data && (
               <button
                 onClick={toggleWritable}
                 className="flex items-center gap-1.5 rounded-lg border border-border px-3 py-1.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -249,6 +249,11 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
   }, [data]);
 
   async function toggleWritable() {
+    // Interop mode points at a schema gnudash doesn't own — flipping writable
+    // would re-open the local OPFS cache read-write and expose every edit
+    // affordance (top badge + per-row edit/delete), yet writes would never
+    // reach Postgres (no sync client is wired) and could corrupt on reupload.
+    if (postgresSchemaOverride !== null) return;
     const newWritable = !isWritable;
     try {
       const client = getClient();


### PR DESCRIPTION
## Summary
- The top-bar Read-only toggle called `toggleWritable()` without checking `postgresSchemaOverride`, so users could flip a foreign-schema connection into read-write. That lit up every per-row edit/delete affordance (they all gate only on `isWritable`), and writes landed in the local OPFS cache with no sync client — silently discarded on reload, with corruption risk via reupload.
- Two guards, mirroring the existing XML read-only pattern: `toggleWritable()` short-circuits when `postgresSchemaOverride` is set, and the layout renders a non-clickable Lock badge instead of the clickable toggle.

## Test plan
- [ ] Connect to an existing GnuCash Postgres DB via the Server tab (Existing GnuCash database mode, schema `public`).
- [ ] Confirm the header shows a non-clickable "Read-only" badge (not the blue "Editing" or clickable "Read-only" button).
- [ ] Confirm per-transaction rows in the account ledger show no edit/delete/duplicate buttons.
- [ ] Confirm the inline "add transaction" row at the bottom of the ledger is hidden.
- [ ] Confirm the Prices and Accounts tables show no edit affordances.
- [ ] Regression: open a gnudash-managed Postgres book and confirm the Editing/Read-only toggle still works as before.
- [ ] Regression: open a local SQLite book and confirm the toggle still works.
- [ ] Regression: open an XML file and confirm the "XML · Read-only" lock badge still appears.