### PR TITLE
Budget management UI under Special Functions

### DIFF
--- a/app/src/app/(dashboard)/special-functions/budgets/[guid]/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/budgets/[guid]/page.tsx
@@ -1,0 +1,607 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useCallback, useMemo, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { useDashboard } from "@/lib/dashboard-context";
+import type {
+  AccountNode,
+  BudgetInfo,
+  BudgetPeriodType,
+  RawBudgetCell,
+} from "@/lib/types/gnucash";
+import { ArrowLeft, AlertTriangle, Save, Target, Trash2 } from "lucide-react";
+
+/**
+ * Inline budget editor: set any budget amount for any EXPENSE or INCOME
+ * account, for any period. No modals — each cell is a direct input that
+ * writes through on blur. Parent accounts left blank show a greyed rollup
+ * from their children; a parent with an explicit amount that differs from
+ * its children's sum is flagged with an imbalance warning, mirroring the
+ * existing /cash-flow read-only view.
+ *
+ * URL: /special-functions/budgets/[guid]
+ */
+
+const PERIOD_TYPE_OPTIONS: { value: BudgetPeriodType; label: string }[] = [
+  { value: "day", label: "day" },
+  { value: "week", label: "week" },
+  { value: "month", label: "month" },
+  { value: "year", label: "year" },
+];
+
+const MONTH_LABELS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+];
+
+/**
+ * Turn a budget's recurrence shape into an array of column labels. The
+ * goal is human-readable, not machine-parsable — GnuCash desktop uses
+ * equivalent short labels in its budget window.
+ */
+function buildPeriodLabels(budget: BudgetInfo): string[] {
+  const start = budget.recurrenceStart;
+  const startDate = start && /^\d{4}-\d{2}-\d{2}$/.test(start)
+    ? new Date(`${start}T00:00:00`)
+    : null;
+  const labels: string[] = [];
+  for (let i = 0; i < budget.numPeriods; i++) {
+    if (!startDate) {
+      labels.push(`Period ${i + 1}`);
+      continue;
+    }
+    const d = new Date(startDate);
+    switch (budget.periodType) {
+      case "day":
+        d.setDate(d.getDate() + i * budget.recurrenceMult);
+        labels.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`);
+        break;
+      case "week":
+        d.setDate(d.getDate() + i * 7 * budget.recurrenceMult);
+        labels.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`);
+        break;
+      case "month":
+        d.setMonth(d.getMonth() + i * budget.recurrenceMult);
+        if (budget.recurrenceMult === 3) {
+          labels.push(`Q${Math.floor(d.getMonth() / 3) + 1} ${d.getFullYear()}`);
+        } else if (budget.recurrenceMult === 1) {
+          labels.push(`${MONTH_LABELS[d.getMonth()]} ${d.getFullYear()}`);
+        } else {
+          labels.push(`${MONTH_LABELS[d.getMonth()]} ${d.getFullYear()}`);
+        }
+        break;
+      case "year":
+        d.setFullYear(d.getFullYear() + i * budget.recurrenceMult);
+        labels.push(`${d.getFullYear()}`);
+        break;
+    }
+  }
+  return labels;
+}
+
+/**
+ * Flatten an account tree into a depth-indexed list, keeping only EXPENSE
+ * and INCOME subtrees (matching the read-side filter in `computeBudgetData`).
+ * Placeholders are included — a GnuCash budget can legally target a
+ * placeholder account as a roll-up destination.
+ */
+function flattenBudgetableAccounts(
+  nodes: AccountNode[],
+): { node: AccountNode; depth: number; isIncomeSection: boolean }[] {
+  const out: { node: AccountNode; depth: number; isIncomeSection: boolean }[] = [];
+  function walk(node: AccountNode, depth: number, isIncomeSection: boolean) {
+    if (node.type !== "EXPENSE" && node.type !== "INCOME") {
+      // Descend through ROOT / TRADING to find the EXPENSE and INCOME
+      // subtrees; skip the rest of the chart of accounts.
+      for (const c of node.children) walk(c, depth, c.type === "INCOME");
+      return;
+    }
+    out.push({ node, depth, isIncomeSection });
+    for (const c of node.children) walk(c, depth + 1, isIncomeSection);
+  }
+  for (const n of nodes) walk(n, 0, n.type === "INCOME");
+  return out;
+}
+
+function cellKey(accountGuid: string, periodNum: number) {
+  return `${accountGuid}|${periodNum}`;
+}
+
+function parseDecimal(value: string): { num: number; denom: number } | null {
+  const trimmed = value.trim();
+  if (trimmed === "") return null;
+  const match = /^(-?)(\d+)(?:\.(\d+))?$/.exec(trimmed);
+  if (!match) return null;
+  const sign = match[1] === "-" ? -1 : 1;
+  const intPart = match[2];
+  const fracPart = match[3] ?? "";
+  const denom = 10 ** fracPart.length || 1;
+  const num = sign * (parseInt(intPart) * denom + (fracPart ? parseInt(fracPart) : 0));
+  return { num, denom };
+}
+
+function formatAmount(num: number, denom: number): string {
+  if (denom === 0) return "";
+  const v = num / denom;
+  // Preserve the stored decimal scale: denom=100 ⇒ 2dp, denom=1000 ⇒ 3dp, etc.
+  const scale = Math.max(0, Math.round(Math.log10(denom)));
+  return v.toFixed(scale);
+}
+
+export default function BudgetEditorPage() {
+  const router = useRouter();
+  const params = useParams<{ guid: string }>();
+  const budgetGuid = params.guid;
+  const {
+    data,
+    isWritable,
+    updateBudget,
+    deleteBudget,
+    setBudgetAmount,
+    clearBudgetAmount,
+  } = useDashboard();
+
+  const [error, setError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [savingMeta, setSavingMeta] = useState(false);
+
+  const budget = data?.budgetData?.budgets.find((b) => b.guid === budgetGuid);
+  const rawCells: RawBudgetCell[] = useMemo(
+    () => data?.budgetData?.rawAmountsByBudget[budgetGuid] ?? [],
+    [data, budgetGuid],
+  );
+
+  // Amounts indexed by accountGuid|periodNum for O(1) cell lookup.
+  const amounts = useMemo(() => {
+    const m = new Map<string, { num: number; denom: number }>();
+    for (const c of rawCells) {
+      m.set(cellKey(c.accountGuid, c.periodNum), { num: c.amountNum, denom: c.amountDenom });
+    }
+    return m;
+  }, [rawCells]);
+
+  const flatAccounts = useMemo(
+    () => (data ? flattenBudgetableAccounts(data.accounts) : []),
+    [data],
+  );
+
+  // For each (parent, period), sum the explicit amounts of all descendants.
+  // Used to render greyed rollup placeholders and to flag imbalance when a
+  // parent has its own explicit amount that differs from the child sum.
+  const rollup = useMemo(() => {
+    if (!data) return new Map<string, number>();
+    // Build descendantsOf for every account in the flattened list.
+    const byGuid = new Map<string, AccountNode>();
+    function collect(n: AccountNode) {
+      byGuid.set(n.guid, n);
+      for (const c of n.children) collect(c);
+    }
+    for (const n of data.accounts) collect(n);
+
+    const descendantsOf = new Map<string, string[]>();
+    function getDescendants(guid: string): string[] {
+      const cached = descendantsOf.get(guid);
+      if (cached) return cached;
+      const n = byGuid.get(guid);
+      if (!n) return [];
+      const out: string[] = [];
+      for (const c of n.children) {
+        out.push(c.guid, ...getDescendants(c.guid));
+      }
+      descendantsOf.set(guid, out);
+      return out;
+    }
+
+    const out = new Map<string, number>();
+    const numPeriods = budget?.numPeriods ?? 0;
+    for (const { node } of flatAccounts) {
+      const descendants = getDescendants(node.guid);
+      if (descendants.length === 0) continue;
+      for (let p = 0; p < numPeriods; p++) {
+        let sum = 0;
+        for (const d of descendants) {
+          const explicit = amounts.get(cellKey(d, p));
+          if (explicit) sum += explicit.num / explicit.denom;
+        }
+        if (sum !== 0) out.set(cellKey(node.guid, p), sum);
+      }
+    }
+    return out;
+  }, [data, flatAccounts, amounts, budget?.numPeriods]);
+
+  const periodLabels = useMemo(
+    () => (budget ? buildPeriodLabels(budget) : []),
+    [budget],
+  );
+
+  // ── Meta form local state ─────────────────────────────────────────
+  const [metaName, setMetaName] = useState("");
+  const [metaDescription, setMetaDescription] = useState("");
+  const [metaPeriodType, setMetaPeriodType] = useState<BudgetPeriodType>("month");
+  const [metaMult, setMetaMult] = useState(1);
+  const [metaNumPeriods, setMetaNumPeriods] = useState(12);
+  const [metaStart, setMetaStart] = useState("");
+  // Hydrate the meta form whenever the budget changes. Using a useMemo to
+  // detect first-load vs. user-edit would over-complicate things; a plain
+  // reset-on-identity-change keyed on budget.guid is clearer.
+  const [hydratedForGuid, setHydratedForGuid] = useState<string | null>(null);
+  if (budget && hydratedForGuid !== budget.guid) {
+    setMetaName(budget.name);
+    setMetaDescription(budget.description);
+    setMetaPeriodType(budget.periodType);
+    setMetaMult(budget.recurrenceMult);
+    setMetaNumPeriods(budget.numPeriods);
+    setMetaStart(budget.recurrenceStart);
+    setHydratedForGuid(budget.guid);
+  }
+
+  const handleSaveMeta = useCallback(async () => {
+    if (!budget) return;
+    if (!metaName.trim()) {
+      setError("Budget name is required");
+      return;
+    }
+    setSavingMeta(true);
+    try {
+      await updateBudget({
+        budgetGuid: budget.guid,
+        name: metaName.trim(),
+        description: metaDescription.trim(),
+        periodType: metaPeriodType,
+        recurrenceMult: metaMult,
+        numPeriods: metaNumPeriods,
+        recurrenceStart: metaStart,
+      });
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setSavingMeta(false);
+    }
+  }, [budget, metaName, metaDescription, metaPeriodType, metaMult, metaNumPeriods, metaStart, updateBudget]);
+
+  const handleCellCommit = useCallback(
+    async (accountGuid: string, periodNum: number, raw: string) => {
+      if (!budget) return;
+      const parsed = parseDecimal(raw);
+      try {
+        if (parsed === null) {
+          await clearBudgetAmount({ budgetGuid: budget.guid, accountGuid, periodNum });
+        } else {
+          await setBudgetAmount({
+            budgetGuid: budget.guid,
+            accountGuid,
+            periodNum,
+            amountNum: parsed.num,
+            amountDenom: parsed.denom,
+          });
+        }
+      } catch (err) {
+        setError((err as Error).message);
+      }
+    },
+    [budget, clearBudgetAmount, setBudgetAmount],
+  );
+
+  const handleDelete = useCallback(async () => {
+    if (!budget) return;
+    try {
+      await deleteBudget({ budgetGuid: budget.guid });
+      router.push("/special-functions/budgets");
+    } catch (err) {
+      setError((err as Error).message);
+      setConfirmingDelete(false);
+    }
+  }, [budget, deleteBudget, router]);
+
+  if (!data) return null;
+
+  if (!budget) {
+    return (
+      <div className="mx-auto max-w-4xl space-y-4">
+        <BreadcrumbBar />
+        <Card>
+          <CardContent className="p-6 text-sm text-[#6F767E]">
+            Budget not found. It may have been deleted in another session.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!isWritable) {
+    return (
+      <div className="mx-auto max-w-4xl space-y-4">
+        <BreadcrumbBar />
+        <Card>
+          <CardContent className="p-6 text-sm text-[#6F767E]">
+            Budget editing requires the database to be open in editing mode.
+            Click the
+            <span className="mx-1 font-medium text-[#3B6B8A]">Read-only</span>
+            button in the top bar to enable editing.
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-[1400px] space-y-4">
+      <BreadcrumbBar />
+
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-3">
+          <div className="mt-1 rounded-lg bg-[#6C9B8B]/10 p-2 text-[#6C9B8B]">
+            <Target className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-[#1A1D1F]">{budget.name}</h1>
+            <p className="mt-1 text-sm text-[#6F767E]">
+              Set amounts in each account&apos;s own commodity. Blank cells on
+              parent accounts auto-sum from their children.
+            </p>
+          </div>
+        </div>
+        <button
+          onClick={() => setConfirmingDelete(true)}
+          className="flex items-center gap-1.5 rounded-lg border border-[#C86A6A]/30 px-3 py-1.5 text-sm font-medium text-[#C86A6A] hover:bg-[#C86A6A]/10"
+        >
+          <Trash2 className="h-4 w-4" />
+          Delete
+        </button>
+      </header>
+
+      {error && (
+        <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {error}
+        </div>
+      )}
+
+      {/* ── Metadata section ────────────────────────────────────── */}
+      <Card>
+        <CardContent className="p-4">
+          <div className="grid gap-3 sm:grid-cols-3">
+            <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+              Name
+              <input
+                type="text"
+                value={metaName}
+                onChange={(e) => setMetaName(e.target.value)}
+                className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E] sm:col-span-2">
+              Description
+              <input
+                type="text"
+                value={metaDescription}
+                onChange={(e) => setMetaDescription(e.target.value)}
+                className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+              Period type
+              <select
+                value={metaPeriodType}
+                onChange={(e) => setMetaPeriodType(e.target.value as BudgetPeriodType)}
+                className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+              >
+                {PERIOD_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+              Every N {metaPeriodType}s
+              <input
+                type="number"
+                min={1}
+                value={metaMult}
+                onChange={(e) => setMetaMult(Math.max(1, parseInt(e.target.value) || 1))}
+                className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+              Number of periods
+              <input
+                type="number"
+                min={1}
+                value={metaNumPeriods}
+                onChange={(e) => setMetaNumPeriods(Math.max(1, parseInt(e.target.value) || 1))}
+                className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+              />
+            </label>
+            <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+              First period starts
+              <input
+                type="date"
+                value={metaStart}
+                onChange={(e) => setMetaStart(e.target.value)}
+                className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+              />
+            </label>
+          </div>
+          <div className="mt-3 flex items-center justify-end">
+            <button
+              onClick={handleSaveMeta}
+              disabled={savingMeta}
+              className="flex items-center gap-1.5 rounded-lg bg-[#6C9B8B] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#5A8475] disabled:opacity-50"
+            >
+              <Save className="h-4 w-4" />
+              {savingMeta ? "Saving…" : "Save metadata"}
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* ── Grid ────────────────────────────────────────────────── */}
+      <Card>
+        <CardContent className="p-0">
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse text-sm">
+              <thead>
+                <tr className="bg-[#FAFAFA] text-xs uppercase tracking-wide text-[#9A9FA5]">
+                  <th className="sticky left-0 z-10 bg-[#FAFAFA] px-4 py-3 text-left">
+                    Account
+                  </th>
+                  {periodLabels.map((label, i) => (
+                    <th key={i} className="px-2 py-3 text-right font-medium">
+                      {label}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {flatAccounts.map(({ node, depth, isIncomeSection }) => (
+                  <BudgetRow
+                    key={node.guid}
+                    node={node}
+                    depth={depth}
+                    isIncomeSection={isIncomeSection}
+                    numPeriods={budget.numPeriods}
+                    amounts={amounts}
+                    rollup={rollup}
+                    onCommit={handleCellCommit}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
+
+      {confirmingDelete && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
+          <Card className="w-full max-w-md">
+            <CardContent className="p-5">
+              <h3 className="text-base font-semibold text-[#1A1D1F]">Delete budget?</h3>
+              <p className="mt-2 text-sm text-[#6F767E]">
+                This removes the budget and every amount row attached to it.
+              </p>
+              <div className="mt-4 flex items-center justify-end gap-2">
+                <button
+                  onClick={() => setConfirmingDelete(false)}
+                  className="rounded-lg border border-border px-3 py-1.5 text-sm text-[#6F767E] hover:bg-muted"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={handleDelete}
+                  className="rounded-lg bg-[#C86A6A] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#B45555]"
+                >
+                  Delete
+                </button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function BreadcrumbBar() {
+  return (
+    <div className="flex items-center text-sm text-[#6F767E]">
+      <Link
+        href="/special-functions/budgets"
+        className="flex items-center gap-1 hover:text-[#1A1D1F]"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to budgets
+      </Link>
+    </div>
+  );
+}
+
+/**
+ * One row in the grid. Each cell is an uncontrolled input keyed by
+ * `${accountGuid}|${periodNum}` — the input's `defaultValue` is re-keyed
+ * whenever the underlying amount changes, so an external mutation (another
+ * tab editing the same book, a meta update that drops a period) resets the
+ * visible value. Writes happen on blur; changes propagate back through the
+ * dashboard context and the parent recomputes `amounts` + `rollup`.
+ */
+function BudgetRow({
+  node,
+  depth,
+  isIncomeSection,
+  numPeriods,
+  amounts,
+  rollup,
+  onCommit,
+}: {
+  node: AccountNode;
+  depth: number;
+  isIncomeSection: boolean;
+  numPeriods: number;
+  amounts: Map<string, { num: number; denom: number }>;
+  rollup: Map<string, number>;
+  onCommit: (accountGuid: string, periodNum: number, raw: string) => void;
+}) {
+  const hasChildren = node.children.length > 0;
+  return (
+    <tr className="border-b border-[#F4F4F4] last:border-b-0">
+      <td
+        className="sticky left-0 z-10 whitespace-nowrap bg-white px-4 py-2"
+        style={{ paddingLeft: 16 + depth * 20 }}
+      >
+        <span className={`${depth === 0 ? "font-semibold text-[#1A1D1F]" : "text-[#1A1D1F]"}`}>
+          {node.name}
+        </span>
+        <span className="ml-2 text-xs text-[#9A9FA5]">
+          {isIncomeSection ? "INCOME" : "EXPENSE"} · {node.commodityMnemonic}
+        </span>
+      </td>
+      {Array.from({ length: numPeriods }).map((_, p) => {
+        const key = cellKey(node.guid, p);
+        const explicit = amounts.get(key);
+        const rollupVal = rollup.get(key);
+        const hasImbalance = !!explicit && hasChildren && rollupVal !== undefined && Math.abs(explicit.num / explicit.denom - rollupVal) > 1e-9;
+        const placeholder = !explicit && hasChildren && rollupVal !== undefined
+          ? rollupVal.toFixed(2)
+          : "";
+        // Re-key the input whenever the stored value changes so the DOM
+        // default value tracks external mutations (e.g. deleting a row,
+        // switching budgets). Without this, the input keeps the user's last
+        // typed value after a server-side clear.
+        const inputKey = explicit ? `${key}:${explicit.num}:${explicit.denom}` : `${key}:empty`;
+        return (
+          <td key={p} className="px-1 py-1">
+            <div className="relative">
+              <input
+                key={inputKey}
+                type="text"
+                inputMode="decimal"
+                defaultValue={explicit ? formatAmount(explicit.num, explicit.denom) : ""}
+                placeholder={placeholder}
+                onBlur={(e) => {
+                  const raw = e.currentTarget.value;
+                  const prev = explicit ? formatAmount(explicit.num, explicit.denom) : "";
+                  if (raw.trim() === prev.trim()) return;
+                  onCommit(node.guid, p, raw);
+                }}
+                className={`w-24 rounded border px-1.5 py-1 text-right text-sm ${
+                  hasImbalance
+                    ? "border-amber-400 bg-amber-50 text-amber-900"
+                    : explicit
+                    ? "border-border text-[#1A1D1F]"
+                    : "border-transparent bg-transparent text-[#BDBDBD] hover:border-border hover:bg-white focus:border-border focus:bg-white focus:text-[#1A1D1F]"
+                }`}
+              />
+              {hasImbalance && (
+                <span
+                  className="pointer-events-none absolute -right-0.5 -top-0.5"
+                  title={`Children sum to ${rollupVal?.toFixed(2)} — differs from this parent's explicit amount`}
+                >
+                  <AlertTriangle className="h-3 w-3 text-amber-500" />
+                </span>
+              )}
+            </div>
+          </td>
+        );
+      })}
+    </tr>
+  );
+}

--- a/app/src/app/(dashboard)/special-functions/budgets/[guid]/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/budgets/[guid]/page.tsx
@@ -11,7 +11,7 @@ import type {
   BudgetPeriodType,
   RawBudgetCell,
 } from "@/lib/types/gnucash";
-import { ArrowLeft, AlertTriangle, Save, Target, Trash2 } from "lucide-react";
+import { ArrowLeft, AlertTriangle, ChevronDown, ChevronRight, Save, Target, Trash2 } from "lucide-react";
 
 /**
  * Inline budget editor: set any budget amount for any EXPENSE or INCOME
@@ -81,16 +81,39 @@ function buildPeriodLabels(budget: BudgetInfo): string[] {
   return labels;
 }
 
+interface FlatRow {
+  node: AccountNode;
+  depth: number;
+  isIncomeSection: boolean;
+  /** True if the account has at least one EXPENSE/INCOME child in the tree. */
+  hasBudgetableChildren: boolean;
+}
+
+
 /**
  * Flatten an account tree into a depth-indexed list, keeping only EXPENSE
  * and INCOME subtrees (matching the read-side filter in `computeBudgetData`).
  * Placeholders are included — a GnuCash budget can legally target a
  * placeholder account as a roll-up destination.
+ *
+ * `expandedGuids` controls which parents reveal their children; a parent
+ * whose guid is absent from the set is collapsed and its descendants are
+ * elided from the output. The top-level EXPENSE / INCOME container rows
+ * are always included so the user can see the two sections even when
+ * everything is fully collapsed.
+ */
+/**
+ * `expandedGuids = null` flattens every budgetable account (used when
+ * computing rollups that must see the full tree regardless of the user's
+ * collapse choices); passing a Set only reveals children of parents whose
+ * guid is in the set.
  */
 function flattenBudgetableAccounts(
   nodes: AccountNode[],
-): { node: AccountNode; depth: number; isIncomeSection: boolean }[] {
-  const out: { node: AccountNode; depth: number; isIncomeSection: boolean }[] = [];
+  expandedGuids: Set<string> | null,
+): FlatRow[] {
+  const out: FlatRow[] = [];
+
   function walk(node: AccountNode, depth: number, isIncomeSection: boolean) {
     if (node.type !== "EXPENSE" && node.type !== "INCOME") {
       // Descend through ROOT / TRADING to find the EXPENSE and INCOME
@@ -98,9 +121,15 @@ function flattenBudgetableAccounts(
       for (const c of node.children) walk(c, depth, c.type === "INCOME");
       return;
     }
-    out.push({ node, depth, isIncomeSection });
+    const hasChildren = node.children.some(
+      (c) => c.type === "EXPENSE" || c.type === "INCOME",
+    );
+    out.push({ node, depth, isIncomeSection, hasBudgetableChildren: hasChildren });
+    if (!hasChildren) return;
+    if (expandedGuids !== null && !expandedGuids.has(node.guid)) return;
     for (const c of node.children) walk(c, depth + 1, isIncomeSection);
   }
+
   for (const n of nodes) walk(n, 0, n.type === "INCOME");
   return out;
 }
@@ -146,6 +175,18 @@ export default function BudgetEditorPage() {
   const [error, setError] = useState<string | null>(null);
   const [confirmingDelete, setConfirmingDelete] = useState(false);
   const [savingMeta, setSavingMeta] = useState(false);
+  // Tracks which parent accounts are currently expanded in the grid.
+  // Default is fully collapsed — the user sees top-level EXPENSE/INCOME
+  // containers with their child rollups, and clicks a chevron to drill in.
+  const [expandedGuids, setExpandedGuids] = useState<Set<string>>(() => new Set());
+  const toggleExpanded = useCallback((guid: string) => {
+    setExpandedGuids((prev) => {
+      const next = new Set(prev);
+      if (next.has(guid)) next.delete(guid);
+      else next.add(guid);
+      return next;
+    });
+  }, []);
 
   const budget = data?.budgetData?.budgets.find((b) => b.guid === budgetGuid);
   const rawCells: RawBudgetCell[] = useMemo(
@@ -162,9 +203,18 @@ export default function BudgetEditorPage() {
     return m;
   }, [rawCells]);
 
-  const flatAccounts = useMemo(
-    () => (data ? flattenBudgetableAccounts(data.accounts) : []),
+  // Every budgetable account, regardless of expansion — used as input to
+  // the rollup computation so that a collapsed parent's placeholder value
+  // doesn't disappear when its children are hidden from the grid.
+  const allBudgetableAccounts = useMemo(
+    () => (data ? flattenBudgetableAccounts(data.accounts, null) : []),
     [data],
+  );
+
+  // The visible subset — applies the user's expand/collapse choices.
+  const flatAccounts = useMemo(
+    () => (data ? flattenBudgetableAccounts(data.accounts, expandedGuids) : []),
+    [data, expandedGuids],
   );
 
   // For each (parent, period), sum the explicit amounts of all descendants.
@@ -172,7 +222,7 @@ export default function BudgetEditorPage() {
   // parent has its own explicit amount that differs from the child sum.
   const rollup = useMemo(() => {
     if (!data) return new Map<string, number>();
-    // Build descendantsOf for every account in the flattened list.
+    // Build descendantsOf for every account in the full budgetable list.
     const byGuid = new Map<string, AccountNode>();
     function collect(n: AccountNode) {
       byGuid.set(n.guid, n);
@@ -196,7 +246,7 @@ export default function BudgetEditorPage() {
 
     const out = new Map<string, number>();
     const numPeriods = budget?.numPeriods ?? 0;
-    for (const { node } of flatAccounts) {
+    for (const { node } of allBudgetableAccounts) {
       const descendants = getDescendants(node.guid);
       if (descendants.length === 0) continue;
       for (let p = 0; p < numPeriods; p++) {
@@ -209,7 +259,7 @@ export default function BudgetEditorPage() {
       }
     }
     return out;
-  }, [data, flatAccounts, amounts, budget?.numPeriods]);
+  }, [data, allBudgetableAccounts, amounts, budget?.numPeriods]);
 
   const periodLabels = useMemo(
     () => (budget ? buildPeriodLabels(budget) : []),
@@ -453,12 +503,15 @@ export default function BudgetEditorPage() {
                 </tr>
               </thead>
               <tbody>
-                {flatAccounts.map(({ node, depth, isIncomeSection }) => (
+                {flatAccounts.map(({ node, depth, isIncomeSection, hasBudgetableChildren }) => (
                   <BudgetRow
                     key={node.guid}
                     node={node}
                     depth={depth}
                     isIncomeSection={isIncomeSection}
+                    hasBudgetableChildren={hasBudgetableChildren}
+                    isExpanded={expandedGuids.has(node.guid)}
+                    onToggleExpanded={toggleExpanded}
                     numPeriods={budget.numPeriods}
                     amounts={amounts}
                     rollup={rollup}
@@ -527,6 +580,9 @@ function BudgetRow({
   node,
   depth,
   isIncomeSection,
+  hasBudgetableChildren,
+  isExpanded,
+  onToggleExpanded,
   numPeriods,
   amounts,
   rollup,
@@ -535,11 +591,18 @@ function BudgetRow({
   node: AccountNode;
   depth: number;
   isIncomeSection: boolean;
+  hasBudgetableChildren: boolean;
+  isExpanded: boolean;
+  onToggleExpanded: (guid: string) => void;
   numPeriods: number;
   amounts: Map<string, { num: number; denom: number }>;
   rollup: Map<string, number>;
   onCommit: (accountGuid: string, periodNum: number, raw: string) => void;
 }) {
+  // `hasChildren` below drives the imbalance badge — uses the generic
+  // AccountNode check (not just budgetable children) because a parent with
+  // a non-EXPENSE child still has a rollup to reconcile against. In
+  // practice the two agree for EXPENSE/INCOME subtrees.
   const hasChildren = node.children.length > 0;
   return (
     <tr className="border-b border-[#F4F4F4] last:border-b-0">
@@ -547,6 +610,22 @@ function BudgetRow({
         className="sticky left-0 z-10 whitespace-nowrap bg-white px-4 py-2"
         style={{ paddingLeft: 16 + depth * 20 }}
       >
+        {hasBudgetableChildren ? (
+          <button
+            onClick={() => onToggleExpanded(node.guid)}
+            className="mr-1 inline-flex h-4 w-4 items-center justify-center rounded text-[#6F767E] hover:bg-[#EFEFEF] hover:text-[#1A1D1F] align-middle"
+            title={isExpanded ? "Collapse" : "Expand"}
+            aria-label={isExpanded ? "Collapse" : "Expand"}
+          >
+            {isExpanded ? (
+              <ChevronDown className="h-3.5 w-3.5" />
+            ) : (
+              <ChevronRight className="h-3.5 w-3.5" />
+            )}
+          </button>
+        ) : (
+          <span className="mr-1 inline-block h-4 w-4 align-middle" />
+        )}
         <span className={`${depth === 0 ? "font-semibold text-[#1A1D1F]" : "text-[#1A1D1F]"}`}>
           {node.name}
         </span>

--- a/app/src/app/(dashboard)/special-functions/budgets/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/budgets/page.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { useDashboard } from "@/lib/dashboard-context";
+import type { BudgetInfo, BudgetPeriodType } from "@/lib/types/gnucash";
+import { ArrowLeft, Pencil, Plus, Target, Trash2, X } from "lucide-react";
+
+/**
+ * Budgets list view under /special-functions.
+ *
+ * Each row represents one GnuCash budget (guid + name + description + the
+ * attached `recurrences` row describing its period shape). Creating a new
+ * budget is done through an inline expander at the foot of the table — no
+ * modals, per the project's no-modal-for-entry convention — and the user is
+ * immediately navigated into the per-account editor on success. Edit and
+ * Delete are per-row controls; edit navigates into the same editor, delete
+ * removes the budget + its amounts + recurrence row after a confirm.
+ */
+
+const PERIOD_TYPE_OPTIONS: { value: BudgetPeriodType; label: string }[] = [
+  { value: "day", label: "day" },
+  { value: "week", label: "week" },
+  { value: "month", label: "month" },
+  { value: "year", label: "year" },
+];
+
+function formatPeriodSummary(b: BudgetInfo): string {
+  const unit = b.recurrenceMult === 1 ? b.periodType : `${b.recurrenceMult} ${b.periodType}s`;
+  const periodWord = b.numPeriods === 1 ? "period" : "periods";
+  const start = b.recurrenceStart || "—";
+  return `${b.numPeriods} ${periodWord} of 1 ${unit} starting ${start}`;
+}
+
+function BreadcrumbBar() {
+  return (
+    <div className="flex items-center text-sm text-[#6F767E]">
+      <Link
+        href="/special-functions"
+        className="flex items-center gap-1 hover:text-[#1A1D1F]"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to special functions
+      </Link>
+    </div>
+  );
+}
+
+export default function BudgetsListPage() {
+  const { data, isWritable, deleteBudget } = useDashboard();
+  const [deletingGuid, setDeletingGuid] = useState<string | null>(null);
+  const [showNewForm, setShowNewForm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!data) return null;
+
+  const budgets = data.budgetData?.budgets ?? [];
+
+  async function handleDelete(guid: string) {
+    try {
+      await deleteBudget({ budgetGuid: guid });
+      setDeletingGuid(null);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  }
+
+  if (!isWritable) {
+    return (
+      <div className="mx-auto max-w-4xl space-y-4">
+        <BreadcrumbBar />
+        <header className="flex items-start gap-3">
+          <div className="mt-1 rounded-lg bg-[#6C9B8B]/10 p-2 text-[#6C9B8B]">
+            <Target className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-[#1A1D1F]">Budgets</h1>
+            <p className="mt-1 text-sm text-[#6F767E]">
+              Budget editing requires the database to be open in editing mode.
+              Click the
+              <span className="mx-1 font-medium text-[#3B6B8A]">Read-only</span>
+              button in the top bar to enable editing.
+            </p>
+          </div>
+        </header>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-5xl space-y-4">
+      <BreadcrumbBar />
+
+      <header className="flex items-start gap-3">
+        <div className="mt-1 rounded-lg bg-[#6C9B8B]/10 p-2 text-[#6C9B8B]">
+          <Target className="h-5 w-5" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-[#1A1D1F]">Budgets</h1>
+          <p className="mt-1 text-sm text-[#6F767E]">
+            Create budgets against any EXPENSE or INCOME account. Parent accounts
+            auto-sum from their children when left blank, and cells where the
+            parent&apos;s explicit total differs from the children are flagged.
+          </p>
+        </div>
+      </header>
+
+      {error && (
+        <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          <span className="flex-1">{error}</span>
+          <button onClick={() => setError(null)} className="text-red-500 hover:text-red-700">
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      )}
+
+      <Card>
+        <CardContent className="p-0">
+          {budgets.length === 0 && !showNewForm && (
+            <div className="p-8 text-center text-sm text-[#6F767E]">
+              No budgets defined yet. Use the button below to create one.
+            </div>
+          )}
+
+          {budgets.length > 0 && (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-[#EFEFEF] text-left text-xs uppercase tracking-wide text-[#9A9FA5]">
+                  <th className="px-4 py-3">Name</th>
+                  <th className="px-4 py-3">Description</th>
+                  <th className="px-4 py-3">Period</th>
+                  <th className="px-4 py-3 w-24" />
+                </tr>
+              </thead>
+              <tbody>
+                {budgets.map((b) => (
+                  <tr key={b.guid} className="border-b border-[#F4F4F4] last:border-b-0">
+                    <td className="px-4 py-3 font-medium text-[#1A1D1F]">{b.name}</td>
+                    <td className="px-4 py-3 text-[#6F767E]">
+                      {b.description || <span className="text-[#BDBDBD]">—</span>}
+                    </td>
+                    <td className="px-4 py-3 text-[#6F767E]">{formatPeriodSummary(b)}</td>
+                    <td className="px-4 py-3">
+                      <div className="flex items-center justify-end gap-1">
+                        <Link
+                          href={`/special-functions/budgets/${b.guid}`}
+                          className="rounded p-1.5 text-[#3B6B8A] hover:bg-[#3B6B8A]/10"
+                          title="Edit budget"
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </Link>
+                        <button
+                          onClick={() => setDeletingGuid(b.guid)}
+                          className="rounded p-1.5 text-[#C86A6A] hover:bg-[#C86A6A]/10"
+                          title="Delete budget"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </CardContent>
+      </Card>
+
+      {!showNewForm ? (
+        <button
+          onClick={() => setShowNewForm(true)}
+          className="flex items-center gap-2 rounded-lg border border-dashed border-[#6C9B8B]/40 bg-[#6C9B8B]/5 px-4 py-3 text-sm font-medium text-[#6C9B8B] hover:bg-[#6C9B8B]/10"
+        >
+          <Plus className="h-4 w-4" />
+          New budget
+        </button>
+      ) : (
+        <NewBudgetRow
+          onCancel={() => setShowNewForm(false)}
+          onCreated={() => setShowNewForm(false)}
+          onError={setError}
+        />
+      )}
+
+      {deletingGuid && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
+          <Card className="w-full max-w-md">
+            <CardContent className="p-5">
+              <h3 className="text-base font-semibold text-[#1A1D1F]">Delete budget?</h3>
+              <p className="mt-2 text-sm text-[#6F767E]">
+                This removes the budget and every amount row attached to it.
+                Actuals and transactions are unaffected.
+              </p>
+              <div className="mt-4 flex items-center justify-end gap-2">
+                <button
+                  onClick={() => setDeletingGuid(null)}
+                  className="rounded-lg border border-border px-3 py-1.5 text-sm text-[#6F767E] hover:bg-muted"
+                >
+                  Cancel
+                </button>
+                <button
+                  onClick={() => handleDelete(deletingGuid)}
+                  className="rounded-lg bg-[#C86A6A] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#B45555]"
+                >
+                  Delete
+                </button>
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Inline "new budget" entry row. Appears below the list when toggled; hides
+ * itself on successful save and navigates the user into the per-account
+ * editor for the freshly-created budget.
+ */
+function NewBudgetRow({
+  onCancel,
+  onCreated,
+  onError,
+}: {
+  onCancel: () => void;
+  onCreated: () => void;
+  onError: (msg: string) => void;
+}) {
+  const router = useRouter();
+  const { createBudget } = useDashboard();
+  const currentYear = new Date().getFullYear();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [periodType, setPeriodType] = useState<BudgetPeriodType>("month");
+  const [recurrenceMult, setRecurrenceMult] = useState(1);
+  const [numPeriods, setNumPeriods] = useState(12);
+  const [recurrenceStart, setRecurrenceStart] = useState(`${currentYear}-01-01`);
+  const [saving, setSaving] = useState(false);
+
+  async function handleCreate() {
+    if (!name.trim()) {
+      onError("Budget name is required");
+      return;
+    }
+    setSaving(true);
+    try {
+      const budgetGuid = await createBudget({
+        name: name.trim(),
+        description: description.trim(),
+        numPeriods,
+        periodType,
+        recurrenceMult,
+        recurrenceStart,
+      });
+      onCreated();
+      router.push(`/special-functions/budgets/${budgetGuid}`);
+    } catch (err) {
+      onError((err as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <h3 className="mb-3 text-sm font-semibold text-[#1A1D1F]">New budget</h3>
+        <div className="grid gap-3 sm:grid-cols-2">
+          <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+            Name
+            <input
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="2026 Budget"
+              className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+              autoFocus
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+            Description
+            <input
+              type="text"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="Annual household budget"
+              className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+            Period type
+            <select
+              value={periodType}
+              onChange={(e) => setPeriodType(e.target.value as BudgetPeriodType)}
+              className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+            >
+              {PERIOD_TYPE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+            Every N {periodType}s (multiplier)
+            <input
+              type="number"
+              min={1}
+              value={recurrenceMult}
+              onChange={(e) => setRecurrenceMult(Math.max(1, parseInt(e.target.value) || 1))}
+              className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+            Number of periods
+            <input
+              type="number"
+              min={1}
+              value={numPeriods}
+              onChange={(e) => setNumPeriods(Math.max(1, parseInt(e.target.value) || 1))}
+              className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+            />
+          </label>
+          <label className="flex flex-col gap-1 text-xs font-medium text-[#6F767E]">
+            First period starts
+            <input
+              type="date"
+              value={recurrenceStart}
+              onChange={(e) => setRecurrenceStart(e.target.value)}
+              className="rounded-lg border border-border px-2.5 py-1.5 text-sm text-[#1A1D1F]"
+            />
+          </label>
+        </div>
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            onClick={onCancel}
+            disabled={saving}
+            className="rounded-lg border border-border px-3 py-1.5 text-sm text-[#6F767E] hover:bg-muted disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleCreate}
+            disabled={saving}
+            className="rounded-lg bg-[#6C9B8B] px-3 py-1.5 text-sm font-medium text-white hover:bg-[#5A8475] disabled:opacity-50"
+          >
+            {saving ? "Creating…" : "Create and edit"}
+          </button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/app/src/app/(dashboard)/special-functions/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { Card, CardContent } from "@/components/ui/card";
-import { Wand2, Layers } from "lucide-react";
+import { Wand2, Layers, Target } from "lucide-react";
 
 /**
  * Index for the "Special functions" area: a home for experimental or
@@ -41,6 +41,28 @@ export default function SpecialFunctionsPage() {
                     Group simple (2-posting) transactions by description and rename or
                     reassign accounts across the whole group in one step. Useful for
                     cleaning up auto-imported data.
+                  </p>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        </Link>
+
+        <Link href="/special-functions/budgets" className="group">
+          <Card className="h-full transition-shadow hover:shadow-md">
+            <CardContent className="p-5">
+              <div className="flex items-start gap-3">
+                <div className="rounded-lg bg-[#6C9B8B]/10 p-2 text-[#6C9B8B]">
+                  <Target className="h-5 w-5" />
+                </div>
+                <div>
+                  <h2 className="text-base font-semibold text-[#1A1D1F] group-hover:text-[#6C9B8B]">
+                    Budgets
+                  </h2>
+                  <p className="mt-1 text-sm text-[#6F767E]">
+                    Create and edit budgets against your chart of accounts. Any account,
+                    any period. Parent accounts auto-sum from their children, and
+                    imbalances are flagged inline.
                   </p>
                 </div>
               </div>

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { DashboardData } from "@/lib/types/gnucash";
 import { GnuCashWorkerClient } from "@/lib/gnucash/worker/client";
-import type { CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, PostgresConnectionInfo, PostgresDumpPayload } from "@/lib/gnucash/worker/messages";
+import type { CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload } from "@/lib/gnucash/worker/messages";
 import { generateDemoData } from "@/lib/demo-data";
 import { deleteFromOPFS } from "@/lib/gnucash/worker/opfs";
 import {
@@ -110,6 +110,12 @@ interface DashboardContextType {
   addPrice: (payload: AddPricePayload) => Promise<void>;
   editPrice: (payload: EditPricePayload) => Promise<void>;
   deletePrice: (payload: DeletePricePayload) => Promise<void>;
+  /** Create a budget and return its GUID so the UI can navigate into the editor. */
+  createBudget: (payload: CreateBudgetPayload) => Promise<string>;
+  updateBudget: (payload: UpdateBudgetPayload) => Promise<void>;
+  deleteBudget: (payload: DeleteBudgetPayload) => Promise<void>;
+  setBudgetAmount: (payload: SetBudgetAmountPayload) => Promise<void>;
+  clearBudgetAmount: (payload: ClearBudgetAmountPayload) => Promise<void>;
   exportFile: () => Promise<void>;
   setCurrency: (currencyGuid: string) => Promise<void>;
 }
@@ -621,6 +627,43 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     setData(await client.deletePrice(payload));
   }
 
+  /**
+   * Create a budget and return its GUID so the caller can navigate into the
+   * editor. Resolves after the write has been flushed to Postgres (sync
+   * client) or persisted to OPFS (local backend).
+   */
+  async function createBudgetFn(payload: CreateBudgetPayload): Promise<string> {
+    if (!isWritable) throw new Error("Database is not open in read-write mode");
+    const client = getClient();
+    const { budgetGuid, ...dashboardData } = await client.createBudget(payload);
+    setData(dashboardData);
+    return budgetGuid;
+  }
+
+  async function updateBudgetFn(payload: UpdateBudgetPayload) {
+    if (!isWritable) throw new Error("Database is not open in read-write mode");
+    const client = getClient();
+    setData(await client.updateBudget(payload));
+  }
+
+  async function deleteBudgetFn(payload: DeleteBudgetPayload) {
+    if (!isWritable) throw new Error("Database is not open in read-write mode");
+    const client = getClient();
+    setData(await client.deleteBudget(payload));
+  }
+
+  async function setBudgetAmountFn(payload: SetBudgetAmountPayload) {
+    if (!isWritable) throw new Error("Database is not open in read-write mode");
+    const client = getClient();
+    setData(await client.setBudgetAmount(payload));
+  }
+
+  async function clearBudgetAmountFn(payload: ClearBudgetAmountPayload) {
+    if (!isWritable) throw new Error("Database is not open in read-write mode");
+    const client = getClient();
+    setData(await client.clearBudgetAmount(payload));
+  }
+
   async function setCurrencyFn(currencyGuid: string) {
     const client = getClient();
     const dashboardData = await client.setCurrency(currencyGuid);
@@ -641,7 +684,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
   return (
     <DashboardContext.Provider
-      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, postgresSchemaOverride, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, reuploadPostgresBook, openExistingGnuCashBook, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, exportFile, setCurrency: setCurrencyFn }}
+      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, postgresSchemaOverride, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, reuploadPostgresBook, openExistingGnuCashBook, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, createBudget: createBudgetFn, updateBudget: updateBudgetFn, deleteBudget: deleteBudgetFn, setBudgetAmount: setBudgetAmountFn, clearBudgetAmount: clearBudgetAmountFn, exportFile, setCurrency: setCurrencyFn }}
     >
       {children}
     </DashboardContext.Provider>

--- a/app/src/lib/demo-data.ts
+++ b/app/src/lib/demo-data.ts
@@ -727,11 +727,22 @@ function generateBudgetData(
 
   const budgetEntry = { expenseCategories, incomeCategories };
   return {
-    budgets: [{ guid: budgetGuid, name: "2026 Budget", description: "Annual household budget", numPeriods: 12 }],
+    budgets: [
+      {
+        guid: budgetGuid,
+        name: "2026 Budget",
+        description: "Annual household budget",
+        numPeriods: 12,
+        periodType: "month",
+        recurrenceMult: 1,
+        recurrenceStart: `${currentYear}-01-01`,
+      },
+    ],
     categoriesByBudget: { [budgetGuid]: budgetEntry },
     expenseCategories,
     incomeCategories,
     availableYears: [currentYear, currentYear - 1],
+    rawAmountsByBudget: { [budgetGuid]: [] },
   };
 }
 

--- a/app/src/lib/gnucash/__tests__/__snapshots__/index.test.ts.snap
+++ b/app/src/lib/gnucash/__tests__/__snapshots__/index.test.ts.snap
@@ -364,6 +364,9 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
         "guid": "00000034000000340000003400000034",
         "name": "2025 Budget",
         "numPeriods": 12,
+        "periodType": "month",
+        "recurrenceMult": 1,
+        "recurrenceStart": "",
       },
     ],
     "categoriesByBudget": {
@@ -1792,6 +1795,64 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
         "variancePct": 100,
       },
     ],
+    "rawAmountsByBudget": {
+      "00000034000000340000003400000034": [
+        {
+          "accountGuid": "00000012000000120000001200000012",
+          "amountDenom": 100,
+          "amountNum": 25000,
+          "periodNum": 0,
+        },
+        {
+          "accountGuid": "00000012000000120000001200000012",
+          "amountDenom": 100,
+          "amountNum": 25000,
+          "periodNum": 1,
+        },
+        {
+          "accountGuid": "00000012000000120000001200000012",
+          "amountDenom": 100,
+          "amountNum": 25000,
+          "periodNum": 2,
+        },
+        {
+          "accountGuid": "00000015000000150000001500000015",
+          "amountDenom": 100,
+          "amountNum": 10000,
+          "periodNum": 0,
+        },
+        {
+          "accountGuid": "00000015000000150000001500000015",
+          "amountDenom": 100,
+          "amountNum": 10000,
+          "periodNum": 1,
+        },
+        {
+          "accountGuid": "00000015000000150000001500000015",
+          "amountDenom": 100,
+          "amountNum": 10000,
+          "periodNum": 2,
+        },
+        {
+          "accountGuid": "0000000e0000000e0000000e0000000e",
+          "amountDenom": 100,
+          "amountNum": 300000,
+          "periodNum": 0,
+        },
+        {
+          "accountGuid": "0000000e0000000e0000000e0000000e",
+          "amountDenom": 100,
+          "amountNum": 300000,
+          "periodNum": 1,
+        },
+        {
+          "accountGuid": "0000000e0000000e0000000e0000000e",
+          "amountDenom": 100,
+          "amountNum": 300000,
+          "periodNum": 2,
+        },
+      ],
+    },
   },
   "cashFlowBudgetData": {
     "availableYears": [
@@ -1803,6 +1864,9 @@ exports[`parseGnuCashFile > snapshot: full DashboardData 1`] = `
         "guid": "00000034000000340000003400000034",
         "name": "2025 Budget",
         "numPeriods": 12,
+        "periodType": "month",
+        "recurrenceMult": 1,
+        "recurrenceStart": "",
       },
     ],
     "categoriesByBudget": {

--- a/app/src/lib/gnucash/__tests__/domain/__snapshots__/budgets.test.ts.snap
+++ b/app/src/lib/gnucash/__tests__/domain/__snapshots__/budgets.test.ts.snap
@@ -11,6 +11,9 @@ exports[`computeBudgetData > snapshot 1`] = `
       "guid": "00000034000000340000003400000034",
       "name": "2025 Budget",
       "numPeriods": 12,
+      "periodType": "month",
+      "recurrenceMult": 1,
+      "recurrenceStart": "",
     },
   ],
   "categoriesByBudget": {
@@ -1439,5 +1442,63 @@ exports[`computeBudgetData > snapshot 1`] = `
       "variancePct": 100,
     },
   ],
+  "rawAmountsByBudget": {
+    "00000034000000340000003400000034": [
+      {
+        "accountGuid": "00000012000000120000001200000012",
+        "amountDenom": 100,
+        "amountNum": 25000,
+        "periodNum": 0,
+      },
+      {
+        "accountGuid": "00000012000000120000001200000012",
+        "amountDenom": 100,
+        "amountNum": 25000,
+        "periodNum": 1,
+      },
+      {
+        "accountGuid": "00000012000000120000001200000012",
+        "amountDenom": 100,
+        "amountNum": 25000,
+        "periodNum": 2,
+      },
+      {
+        "accountGuid": "00000015000000150000001500000015",
+        "amountDenom": 100,
+        "amountNum": 10000,
+        "periodNum": 0,
+      },
+      {
+        "accountGuid": "00000015000000150000001500000015",
+        "amountDenom": 100,
+        "amountNum": 10000,
+        "periodNum": 1,
+      },
+      {
+        "accountGuid": "00000015000000150000001500000015",
+        "amountDenom": 100,
+        "amountNum": 10000,
+        "periodNum": 2,
+      },
+      {
+        "accountGuid": "0000000e0000000e0000000e0000000e",
+        "amountDenom": 100,
+        "amountNum": 300000,
+        "periodNum": 0,
+      },
+      {
+        "accountGuid": "0000000e0000000e0000000e0000000e",
+        "amountDenom": 100,
+        "amountNum": 300000,
+        "periodNum": 1,
+      },
+      {
+        "accountGuid": "0000000e0000000e0000000e0000000e",
+        "amountDenom": 100,
+        "amountNum": 300000,
+        "periodNum": 2,
+      },
+    ],
+  },
 }
 `;

--- a/app/src/lib/gnucash/__tests__/engine/operations.test.ts
+++ b/app/src/lib/gnucash/__tests__/engine/operations.test.ts
@@ -14,6 +14,14 @@ import {
   deleteAccount,
 } from "../../engine/operations/account-ops";
 import { addPrice, deletePrice } from "../../engine/operations/price-ops";
+import {
+  createBudget,
+  updateBudget,
+  deleteBudget,
+  setBudgetAmount,
+  clearBudgetAmount,
+} from "../../engine/operations/budget-ops";
+import { loadBudgetInfos } from "../../domain/budgets";
 import { bulkEditTransactions } from "../../engine/operations/bulk-ops";
 import {
   createLot,
@@ -621,5 +629,177 @@ describe("bulk-ops", () => {
       if (s.value_num < 0) expect(s.account_guid).toBe(SAVINGS);
       else expect(s.account_guid).toBe(ENTERTAINMENT);
     }
+  });
+});
+
+// ── Budget Operations ───────────────────────────────────────────
+//
+// Exercise the full CRUD shape the special-functions editor depends on:
+// create → set amount → clear amount → update meta → delete. Each test
+// rechecks the backing tables directly so regressions in the SQL layer
+// surface here rather than at the UI.
+
+describe("budget-ops", () => {
+  const EXPENSE = "exp00000000000000000000000000001";
+
+  it("createBudget writes budget + recurrence rows and returns the new GUID", () => {
+    const { budgetGuid } = createBudget(db, {
+      name: "2026",
+      description: "Annual",
+      numPeriods: 12,
+      periodType: "month",
+      recurrenceMult: 1,
+      recurrenceStart: "2026-01-01",
+    });
+
+    const budget = db
+      .prepare(`SELECT guid, name, description, num_periods FROM budgets WHERE guid = ?`)
+      .get(budgetGuid) as { guid: string; name: string; description: string; num_periods: number };
+    expect(budget).toMatchObject({ name: "2026", description: "Annual", num_periods: 12 });
+
+    const rec = db
+      .prepare(
+        `SELECT recurrence_mult, recurrence_period_type, recurrence_period_start
+         FROM recurrences WHERE obj_guid = ?`,
+      )
+      .get(budgetGuid) as {
+        recurrence_mult: number;
+        recurrence_period_type: string;
+        recurrence_period_start: string;
+      };
+    // recurrence_period_start stored in GnuCash compact YYYYMMDD form.
+    expect(rec).toMatchObject({
+      recurrence_mult: 1,
+      recurrence_period_type: "month",
+      recurrence_period_start: "20260101",
+    });
+  });
+
+  it("loadBudgetInfos attaches recurrence fields to BudgetInfo", () => {
+    const { budgetGuid } = createBudget(db, {
+      name: "Quarterly",
+      description: "",
+      numPeriods: 4,
+      periodType: "month",
+      recurrenceMult: 3,
+      recurrenceStart: "2026-01-01",
+    });
+    const infos = loadBudgetInfos(db);
+    const info = infos.find((b) => b.guid === budgetGuid);
+    expect(info).toBeDefined();
+    expect(info).toMatchObject({
+      name: "Quarterly",
+      numPeriods: 4,
+      periodType: "month",
+      recurrenceMult: 3,
+      // Normalised back to ISO for the view layer.
+      recurrenceStart: "2026-01-01",
+    });
+  });
+
+  it("setBudgetAmount upserts idempotently — second call replaces the first row", () => {
+    const { budgetGuid } = createBudget(db, {
+      name: "x", description: "", numPeriods: 12,
+      periodType: "month", recurrenceMult: 1, recurrenceStart: "2026-01-01",
+    });
+    setBudgetAmount(db, budgetGuid, EXPENSE, 0, 50000, 100);
+    setBudgetAmount(db, budgetGuid, EXPENSE, 0, 75000, 100);
+    const rows = db
+      .prepare(
+        `SELECT amount_num, amount_denom FROM budget_amounts
+         WHERE budget_guid = ? AND account_guid = ? AND period_num = ?`,
+      )
+      .all(budgetGuid, EXPENSE, 0) as { amount_num: number; amount_denom: number }[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toEqual({ amount_num: 75000, amount_denom: 100 });
+  });
+
+  it("clearBudgetAmount removes only the targeted cell", () => {
+    const { budgetGuid } = createBudget(db, {
+      name: "x", description: "", numPeriods: 12,
+      periodType: "month", recurrenceMult: 1, recurrenceStart: "2026-01-01",
+    });
+    setBudgetAmount(db, budgetGuid, EXPENSE, 0, 1000, 100);
+    setBudgetAmount(db, budgetGuid, EXPENSE, 1, 2000, 100);
+    clearBudgetAmount(db, budgetGuid, EXPENSE, 0);
+    const rows = db
+      .prepare(`SELECT period_num FROM budget_amounts WHERE budget_guid = ?`)
+      .all(budgetGuid) as { period_num: number }[];
+    expect(rows.map((r) => r.period_num)).toEqual([1]);
+  });
+
+  it("updateBudget shrinks num_periods and drops amounts beyond the new range", () => {
+    const { budgetGuid } = createBudget(db, {
+      name: "x", description: "", numPeriods: 12,
+      periodType: "month", recurrenceMult: 1, recurrenceStart: "2026-01-01",
+    });
+    setBudgetAmount(db, budgetGuid, EXPENSE, 5, 1000, 100);
+    setBudgetAmount(db, budgetGuid, EXPENSE, 10, 2000, 100);
+
+    updateBudget(db, budgetGuid, {
+      name: "half-year",
+      description: "",
+      numPeriods: 6,
+      periodType: "month",
+      recurrenceMult: 1,
+      recurrenceStart: "2026-01-01",
+    });
+
+    const rows = db
+      .prepare(`SELECT period_num FROM budget_amounts WHERE budget_guid = ?`)
+      .all(budgetGuid) as { period_num: number }[];
+    // period 10 is beyond the new 6-period range and should be dropped;
+    // period 5 survives.
+    expect(rows.map((r) => r.period_num)).toEqual([5]);
+
+    const budget = db
+      .prepare(`SELECT name, num_periods FROM budgets WHERE guid = ?`)
+      .get(budgetGuid) as { name: string; num_periods: number };
+    expect(budget).toMatchObject({ name: "half-year", num_periods: 6 });
+  });
+
+  it("updateBudget inserts a recurrence row when one is missing (legacy file)", () => {
+    // Simulate a file written by an older tool that has a budget but no
+    // matching recurrence row — the update path must INSERT rather than silently
+    // ignore, otherwise period shape is lost.
+    db.run(
+      `INSERT INTO budgets (guid, name, description, num_periods) VALUES (?, ?, ?, ?)`,
+      "legacy00000000000000000000000001",
+      "Legacy",
+      "",
+      12,
+    );
+    updateBudget(db, "legacy00000000000000000000000001", {
+      name: "Legacy",
+      description: "",
+      numPeriods: 12,
+      periodType: "year",
+      recurrenceMult: 1,
+      recurrenceStart: "2026-01-01",
+    });
+    const rec = db
+      .prepare(`SELECT recurrence_period_type FROM recurrences WHERE obj_guid = ?`)
+      .get("legacy00000000000000000000000001") as { recurrence_period_type: string };
+    expect(rec.recurrence_period_type).toBe("year");
+  });
+
+  it("deleteBudget cascades to amounts and recurrence rows", () => {
+    const { budgetGuid } = createBudget(db, {
+      name: "x", description: "", numPeriods: 12,
+      periodType: "month", recurrenceMult: 1, recurrenceStart: "2026-01-01",
+    });
+    setBudgetAmount(db, budgetGuid, EXPENSE, 0, 1000, 100);
+
+    deleteBudget(db, budgetGuid);
+
+    expect(
+      db.prepare(`SELECT 1 FROM budgets WHERE guid = ?`).get(budgetGuid),
+    ).toBeUndefined();
+    expect(
+      db.prepare(`SELECT 1 FROM budget_amounts WHERE budget_guid = ?`).get(budgetGuid),
+    ).toBeUndefined();
+    expect(
+      db.prepare(`SELECT 1 FROM recurrences WHERE obj_guid = ?`).get(budgetGuid),
+    ).toBeUndefined();
   });
 });

--- a/app/src/lib/gnucash/domain/budgets.ts
+++ b/app/src/lib/gnucash/domain/budgets.ts
@@ -1,6 +1,86 @@
-import type { BudgetData, BudgetDataForBudget, BudgetInfo, BudgetCategoryRow } from "@/lib/types/gnucash";
+import type { BudgetData, BudgetDataForBudget, BudgetInfo, BudgetCategoryRow, BudgetPeriodType, RawBudgetCell } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { sqlYear, sqlMonthNum } from "../shared/dates";
+
+/**
+ * Normalise a GnuCash `recurrence_period_start` value (stored as compact
+ * `YYYYMMDD` in the SQLite backend and `YYYY-MM-DD` in Postgres) to ISO
+ * `YYYY-MM-DD` for use in the UI.
+ */
+export function normaliseRecurrenceStart(raw: string | null | undefined): string {
+  if (!raw) return "";
+  const trimmed = raw.trim();
+  if (/^\d{8}$/.test(trimmed)) {
+    return `${trimmed.slice(0, 4)}-${trimmed.slice(4, 6)}-${trimmed.slice(6, 8)}`;
+  }
+  // Already ISO or ISO-with-time — take the date portion.
+  return trimmed.slice(0, 10);
+}
+
+const VALID_PERIOD_TYPES: ReadonlySet<BudgetPeriodType> = new Set([
+  "day",
+  "week",
+  "month",
+  "year",
+]);
+
+export function normalisePeriodType(raw: string | null | undefined): BudgetPeriodType {
+  if (raw && VALID_PERIOD_TYPES.has(raw as BudgetPeriodType)) {
+    return raw as BudgetPeriodType;
+  }
+  return "month";
+}
+
+/**
+ * Load the `budgets` table joined with matching `recurrences` rows and return
+ * enriched BudgetInfo[]. Returns an empty array when the `budgets` table does
+ * not exist (older GnuCash files) or when no budgets are defined. Shared
+ * between the cash-flow budget module and the main budget module so the
+ * recurrence attachment logic stays in one place.
+ */
+export function loadBudgetInfos(db: ParseContext["db"]): BudgetInfo[] {
+  const hasBudgets = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='budgets'`)
+    .get() as { name: string } | undefined;
+  if (!hasBudgets) return [];
+
+  const budgetRows = db
+    .prepare(`SELECT guid, name, description, num_periods FROM budgets`)
+    .all() as { guid: string; name: string; description: string; num_periods: number }[];
+  if (budgetRows.length === 0) return [];
+
+  const hasRecurrences = db
+    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='recurrences'`)
+    .get() as { name: string } | undefined;
+  const recurrenceRows = hasRecurrences
+    ? (db
+        .prepare(
+          `SELECT obj_guid, recurrence_mult, recurrence_period_type, recurrence_period_start
+           FROM recurrences`
+        )
+        .all() as {
+          obj_guid: string;
+          recurrence_mult: number | null;
+          recurrence_period_type: string | null;
+          recurrence_period_start: string | null;
+        }[])
+    : [];
+  const recurrenceByBudget = new Map<string, typeof recurrenceRows[number]>();
+  for (const r of recurrenceRows) recurrenceByBudget.set(r.obj_guid, r);
+
+  return budgetRows.map((b) => {
+    const rec = recurrenceByBudget.get(b.guid);
+    return {
+      guid: b.guid,
+      name: b.name,
+      description: b.description,
+      numPeriods: b.num_periods,
+      periodType: normalisePeriodType(rec?.recurrence_period_type ?? null),
+      recurrenceMult: rec?.recurrence_mult ?? 1,
+      recurrenceStart: normaliseRecurrenceStart(rec?.recurrence_period_start ?? null),
+    };
+  });
+}
 
 /**
  * Compute budget vs actual data for all budgets in the GNUCash file.
@@ -18,33 +98,44 @@ import { sqlYear, sqlMonthNum } from "../shared/dates";
 export function computeBudgetData(ctx: ParseContext): BudgetData | null {
   const { db, accounts, accountMap, commodityMap, fxRates, rootAccount, topExpenseGuids, topIncomeGuids } = ctx;
 
-  // Check if budgets table exists
-  const tableCheck = db
-    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='budgets'`)
-    .get() as { name: string } | undefined;
-
-  if (!tableCheck) return null;
-
-  const budgetRows = db
-    .prepare(`SELECT guid, name, description, num_periods FROM budgets`)
-    .all() as { guid: string; name: string; description: string; num_periods: number }[];
-
-  if (budgetRows.length === 0) return null;
-
-  const budgets: BudgetInfo[] = budgetRows.map((b) => ({
-    guid: b.guid,
-    name: b.name,
-    description: b.description,
-    numPeriods: b.num_periods,
-  }));
+  const budgets = loadBudgetInfos(db);
+  if (budgets.length === 0) return null;
 
   const amountRows = db
     .prepare(
       `SELECT ba.budget_guid, ba.account_guid, ba.period_num,
-              CAST(ba.amount_num AS REAL) / ba.amount_denom AS amount
+              CAST(ba.amount_num AS REAL) / ba.amount_denom AS amount,
+              ba.amount_num, ba.amount_denom
        FROM budget_amounts ba`
     )
-    .all() as { budget_guid: string; account_guid: string; period_num: number; amount: number }[];
+    .all() as {
+      budget_guid: string;
+      account_guid: string;
+      period_num: number;
+      amount: number;
+      amount_num: number;
+      amount_denom: number;
+    }[];
+
+  // Bucket the raw rows by budget for the special-functions editor. Kept
+  // separate from `budgetAmountsMap` below because that one is FX-converted
+  // and bucketed per-account-per-period, whereas the editor wants native
+  // num/denom to round-trip edits without precision loss.
+  const rawAmountsByBudget: Record<string, RawBudgetCell[]> = {};
+  for (const row of amountRows) {
+    if (!rawAmountsByBudget[row.budget_guid]) rawAmountsByBudget[row.budget_guid] = [];
+    rawAmountsByBudget[row.budget_guid].push({
+      accountGuid: row.account_guid,
+      periodNum: row.period_num,
+      amountNum: row.amount_num,
+      amountDenom: row.amount_denom,
+    });
+  }
+  // Ensure every known budget has at least an empty bucket so the editor
+  // can distinguish "budget exists with no amounts" from "budget missing".
+  for (const b of budgets) {
+    if (!rawAmountsByBudget[b.guid]) rawAmountsByBudget[b.guid] = [];
+  }
 
   // Fetch actuals for all expense/income leaf accounts (with FX conversion)
   const actualRows = db
@@ -370,6 +461,7 @@ export function computeBudgetData(ctx: ParseContext): BudgetData | null {
     expenseCategories: defaultData.expenseCategories,
     incomeCategories: defaultData.incomeCategories,
     availableYears,
+    rawAmountsByBudget,
   };
 }
 

--- a/app/src/lib/gnucash/domain/cash-flow-budget.ts
+++ b/app/src/lib/gnucash/domain/cash-flow-budget.ts
@@ -1,30 +1,13 @@
-import type { CashFlowBudgetData, CashFlowBudgetForBudget, BudgetInfo, BudgetCategoryRow } from "@/lib/types/gnucash";
+import type { CashFlowBudgetData, CashFlowBudgetForBudget, BudgetCategoryRow } from "@/lib/types/gnucash";
 import type { ParseContext } from "../context";
 import { sqlYear, sqlMonthNum } from "../shared/dates";
-import { addUnbudgetedRows } from "./budgets";
+import { addUnbudgetedRows, loadBudgetInfos } from "./budgets";
 
 export function computeCashFlowBudgetData(ctx: ParseContext): CashFlowBudgetData | null {
   const { db, accounts, accountMap, rootAccount } = ctx;
 
-  // Check if budgets table exists
-  const tableCheck = db
-    .prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='budgets'`)
-    .get() as { name: string } | undefined;
-
-  if (!tableCheck) return null;
-
-  const budgetRows = db
-    .prepare(`SELECT guid, name, description, num_periods FROM budgets`)
-    .all() as { guid: string; name: string; description: string; num_periods: number }[];
-
-  if (budgetRows.length === 0) return null;
-
-  const budgets: BudgetInfo[] = budgetRows.map((b) => ({
-    guid: b.guid,
-    name: b.name,
-    description: b.description,
-    numPeriods: b.num_periods,
-  }));
+  const budgets = loadBudgetInfos(db);
+  if (budgets.length === 0) return null;
 
   const amountRows = db
     .prepare(

--- a/app/src/lib/gnucash/engine/operations/budget-ops.ts
+++ b/app/src/lib/gnucash/engine/operations/budget-ops.ts
@@ -1,0 +1,191 @@
+/**
+ * Budget operations: create, update, delete for `budgets`, `budget_amounts`,
+ * and the attached `recurrences` row.
+ *
+ * GnuCash models a budget as three cooperating rows/tables:
+ *   - `budgets` — guid, name, description, num_periods
+ *   - `recurrences` (`obj_guid = budget.guid`) — period type + multiplier +
+ *     start date, i.e. "12 monthly periods starting 2026-01-01"
+ *   - `budget_amounts` — one row per (budget, account, period) with a
+ *     num/denom rational amount, in the account's own commodity
+ *
+ * These ops keep all three tables in sync. `budget_amounts.id` is assigned
+ * by the DB (AUTOINCREMENT via SQLite's PRIMARY KEY); we never pass it in.
+ */
+
+import type { WritableDbAdapter } from "../db/writable-adapter";
+import type { BudgetPeriodType } from "@/lib/types/gnucash";
+import { generateGuid } from "../guid";
+
+/**
+ * Convert an ISO YYYY-MM-DD date to GnuCash's compact YYYYMMDD form used by
+ * the `recurrences.recurrence_period_start` column. Bare YYYYMMDD inputs are
+ * passed through. Any other shape throws — the caller has typed the form.
+ */
+function toCompactDate(iso: string): string {
+  const trimmed = iso.trim();
+  if (/^\d{8}$/.test(trimmed)) return trimmed;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(trimmed);
+  if (!match) throw new Error(`Invalid recurrence start date: ${iso}`);
+  return `${match[1]}${match[2]}${match[3]}`;
+}
+
+export interface BudgetWriteFields {
+  name: string;
+  description: string;
+  numPeriods: number;
+  periodType: BudgetPeriodType;
+  recurrenceMult: number;
+  /** ISO YYYY-MM-DD. Stored as compact YYYYMMDD in the DB. */
+  recurrenceStart: string;
+}
+
+/**
+ * Create a new budget plus its recurrence row. Returns the new budget's GUID
+ * so the caller can immediately navigate to / populate amounts against it.
+ */
+export function createBudget(
+  db: WritableDbAdapter,
+  fields: BudgetWriteFields,
+): { budgetGuid: string } {
+  const budgetGuid = generateGuid();
+  db.transaction(() => {
+    db.run(
+      `INSERT INTO budgets (guid, name, description, num_periods) VALUES (?, ?, ?, ?)`,
+      budgetGuid,
+      fields.name,
+      fields.description,
+      fields.numPeriods,
+    );
+    db.run(
+      `INSERT INTO recurrences (obj_guid, recurrence_mult, recurrence_period_type, recurrence_period_start)
+       VALUES (?, ?, ?, ?)`,
+      budgetGuid,
+      fields.recurrenceMult,
+      fields.periodType,
+      toCompactDate(fields.recurrenceStart),
+    );
+  });
+  return { budgetGuid };
+}
+
+/**
+ * Replace every field on an existing budget + its recurrence row. If the
+ * recurrence row is missing (older files created outside gnudash), it is
+ * inserted — so after `updateBudget` the budget is guaranteed to have a
+ * recurrence row the read pipeline can attach.
+ *
+ * Shrinking `numPeriods` also drops any `budget_amounts` rows whose
+ * `period_num` is beyond the new range, to keep the periods/amounts
+ * relationship consistent — GnuCash desktop silently hides those on read,
+ * but we prefer to actually remove them so later widens don't resurrect
+ * stale values the user can't see in the editor.
+ */
+export function updateBudget(
+  db: WritableDbAdapter,
+  budgetGuid: string,
+  fields: BudgetWriteFields,
+): void {
+  db.transaction(() => {
+    db.run(
+      `UPDATE budgets SET name = ?, description = ?, num_periods = ? WHERE guid = ?`,
+      fields.name,
+      fields.description,
+      fields.numPeriods,
+      budgetGuid,
+    );
+    const updated = db.run(
+      `UPDATE recurrences
+         SET recurrence_mult = ?, recurrence_period_type = ?, recurrence_period_start = ?
+       WHERE obj_guid = ?`,
+      fields.recurrenceMult,
+      fields.periodType,
+      toCompactDate(fields.recurrenceStart),
+      budgetGuid,
+    );
+    if (updated.changes === 0) {
+      db.run(
+        `INSERT INTO recurrences (obj_guid, recurrence_mult, recurrence_period_type, recurrence_period_start)
+         VALUES (?, ?, ?, ?)`,
+        budgetGuid,
+        fields.recurrenceMult,
+        fields.periodType,
+        toCompactDate(fields.recurrenceStart),
+      );
+    }
+    db.run(
+      `DELETE FROM budget_amounts WHERE budget_guid = ? AND period_num >= ?`,
+      budgetGuid,
+      fields.numPeriods,
+    );
+  });
+}
+
+/**
+ * Remove a budget and everything hanging off it: its recurrence row and all
+ * per-account-per-period amounts. Safe to call for a budget that has no
+ * recurrence or amounts rows.
+ */
+export function deleteBudget(db: WritableDbAdapter, budgetGuid: string): void {
+  db.transaction(() => {
+    db.run(`DELETE FROM budget_amounts WHERE budget_guid = ?`, budgetGuid);
+    db.run(`DELETE FROM recurrences WHERE obj_guid = ?`, budgetGuid);
+    db.run(`DELETE FROM budgets WHERE guid = ?`, budgetGuid);
+  });
+}
+
+/**
+ * Upsert a single `budget_amounts` cell. Implemented as delete-then-insert
+ * because the GnuCash schema has no unique constraint on
+ * (budget_guid, account_guid, period_num); real GnuCash desktop may leave
+ * duplicates in place on edit, which we normalise away to exactly one row.
+ *
+ * `periodNum` is 0-indexed (period 0 = first period).
+ */
+export function setBudgetAmount(
+  db: WritableDbAdapter,
+  budgetGuid: string,
+  accountGuid: string,
+  periodNum: number,
+  amountNum: number,
+  amountDenom: number,
+): void {
+  db.transaction(() => {
+    db.run(
+      `DELETE FROM budget_amounts
+       WHERE budget_guid = ? AND account_guid = ? AND period_num = ?`,
+      budgetGuid,
+      accountGuid,
+      periodNum,
+    );
+    db.run(
+      `INSERT INTO budget_amounts (budget_guid, account_guid, period_num, amount_num, amount_denom)
+       VALUES (?, ?, ?, ?, ?)`,
+      budgetGuid,
+      accountGuid,
+      periodNum,
+      amountNum,
+      amountDenom,
+    );
+  });
+}
+
+/**
+ * Drop any `budget_amounts` rows for this (budget, account, period).
+ * Leaves the parent budget row untouched; the read pipeline will then
+ * synthesise the cell from the account's children (auto-rollup).
+ */
+export function clearBudgetAmount(
+  db: WritableDbAdapter,
+  budgetGuid: string,
+  accountGuid: string,
+  periodNum: number,
+): void {
+  db.run(
+    `DELETE FROM budget_amounts
+     WHERE budget_guid = ? AND account_guid = ? AND period_num = ?`,
+    budgetGuid,
+    accountGuid,
+    periodNum,
+  );
+}

--- a/app/src/lib/gnucash/worker/client.ts
+++ b/app/src/lib/gnucash/worker/client.ts
@@ -17,7 +17,7 @@ import type {
   BudgetData,
   DashboardData,
 } from "@/lib/types/gnucash";
-import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
 import { parseGnuCashXml } from "../xml/parser";
 
 type PendingRequest = {
@@ -378,6 +378,39 @@ export class GnuCashWorkerClient {
   /** Delete a price entry from the prices table. */
   async deletePrice(payload: DeletePricePayload): Promise<DashboardData> {
     return this.mutate("deletePrice", payload);
+  }
+
+  /**
+   * Create a new budget + its recurrence row. Returns the refreshed dashboard
+   * data augmented with the new budget's GUID so callers can navigate into
+   * the editor in one round-trip.
+   */
+  async createBudget(
+    payload: CreateBudgetPayload,
+  ): Promise<DashboardData & { budgetGuid: string }> {
+    return this.mutate("createBudget", payload) as Promise<
+      DashboardData & { budgetGuid: string }
+    >;
+  }
+
+  /** Update a budget's metadata and recurrence row. */
+  async updateBudget(payload: UpdateBudgetPayload): Promise<DashboardData> {
+    return this.mutate("updateBudget", payload);
+  }
+
+  /** Delete a budget and every row hanging off it (amounts + recurrence). */
+  async deleteBudget(payload: DeleteBudgetPayload): Promise<DashboardData> {
+    return this.mutate("deleteBudget", payload);
+  }
+
+  /** Upsert a single budget_amounts cell. */
+  async setBudgetAmount(payload: SetBudgetAmountPayload): Promise<DashboardData> {
+    return this.mutate("setBudgetAmount", payload);
+  }
+
+  /** Remove a single budget_amounts cell (re-enables parent rollup). */
+  async clearBudgetAmount(payload: ClearBudgetAmountPayload): Promise<DashboardData> {
+    return this.mutate("clearBudgetAmount", payload);
   }
 
   // ── Domain queries ─────────────────────────────────────────────

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -32,8 +32,15 @@ import { AccountBuilder } from "../engine/builders/account-builder";
 import { updateAccount, deleteAccountWithReallocation } from "../engine/operations/account-ops";
 import { createCommodity } from "../engine/operations/commodity-ops";
 import { addPrice, deletePrice } from "../engine/operations/price-ops";
+import {
+  createBudget as createBudgetOp,
+  updateBudget as updateBudgetOp,
+  deleteBudget as deleteBudgetOp,
+  setBudgetAmount as setBudgetAmountOp,
+  clearBudgetAmount as clearBudgetAmountOp,
+} from "../engine/operations/budget-ops";
 import type { AccountType } from "../engine/types";
-import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
 import type { GnuCashXmlData } from "../xml/types";
 import { GNUCASH_SCHEMA_DDL } from "../xml/schema";
 import { PostgresSyncClient } from "../db/postgres-sync-client";
@@ -802,6 +809,71 @@ function handleDeletePrice(payload: DeletePricePayload): DashboardData {
   return getFullDashboardData();
 }
 
+/** Handle creating a new budget + its recurrence row. */
+function handleCreateBudget(payload: CreateBudgetPayload): DashboardData & { budgetGuid: string } {
+  if (!ctx) throw new Error("No database loaded");
+  if (!writableAdapter) throw new Error("Database is not open in read-write mode");
+
+  const { budgetGuid } = createBudgetOp(writableAdapter, payload);
+  ctx = buildParseContext(writableAdapter);
+  // Return the new budget's GUID alongside the refreshed dashboard so the UI
+  // can navigate straight into the editor without a second round-trip.
+  return { ...getFullDashboardData(), budgetGuid };
+}
+
+/** Handle updating an existing budget's metadata + recurrence row. */
+function handleUpdateBudget(payload: UpdateBudgetPayload): DashboardData {
+  if (!ctx) throw new Error("No database loaded");
+  if (!writableAdapter) throw new Error("Database is not open in read-write mode");
+
+  const { budgetGuid, ...fields } = payload;
+  updateBudgetOp(writableAdapter, budgetGuid, fields);
+  ctx = buildParseContext(writableAdapter);
+  return getFullDashboardData();
+}
+
+/** Handle deleting a budget + its recurrence row and all amounts. */
+function handleDeleteBudget(payload: DeleteBudgetPayload): DashboardData {
+  if (!ctx) throw new Error("No database loaded");
+  if (!writableAdapter) throw new Error("Database is not open in read-write mode");
+
+  deleteBudgetOp(writableAdapter, payload.budgetGuid);
+  ctx = buildParseContext(writableAdapter);
+  return getFullDashboardData();
+}
+
+/** Handle upserting a single budget_amounts cell. */
+function handleSetBudgetAmount(payload: SetBudgetAmountPayload): DashboardData {
+  if (!ctx) throw new Error("No database loaded");
+  if (!writableAdapter) throw new Error("Database is not open in read-write mode");
+
+  setBudgetAmountOp(
+    writableAdapter,
+    payload.budgetGuid,
+    payload.accountGuid,
+    payload.periodNum,
+    payload.amountNum,
+    payload.amountDenom,
+  );
+  ctx = buildParseContext(writableAdapter);
+  return getFullDashboardData();
+}
+
+/** Handle clearing a budget_amounts cell (re-enables parent rollup for the cell). */
+function handleClearBudgetAmount(payload: ClearBudgetAmountPayload): DashboardData {
+  if (!ctx) throw new Error("No database loaded");
+  if (!writableAdapter) throw new Error("Database is not open in read-write mode");
+
+  clearBudgetAmountOp(
+    writableAdapter,
+    payload.budgetGuid,
+    payload.accountGuid,
+    payload.periodNum,
+  );
+  ctx = buildParseContext(writableAdapter);
+  return getFullDashboardData();
+}
+
 const domainFunctions: Record<DomainFunction, () => unknown> = {
   buildAccountTree: () => buildAccountTree(ctx!),
   computeNetWorthSeries: () => computeNetWorthSeries(ctx!),
@@ -936,6 +1008,21 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
             break;
           case "deletePrice":
             data = handleDeletePrice(msg.payload as DeletePricePayload);
+            break;
+          case "createBudget":
+            data = handleCreateBudget(msg.payload as CreateBudgetPayload);
+            break;
+          case "updateBudget":
+            data = handleUpdateBudget(msg.payload as UpdateBudgetPayload);
+            break;
+          case "deleteBudget":
+            data = handleDeleteBudget(msg.payload as DeleteBudgetPayload);
+            break;
+          case "setBudgetAmount":
+            data = handleSetBudgetAmount(msg.payload as SetBudgetAmountPayload);
+            break;
+          case "clearBudgetAmount":
+            data = handleClearBudgetAmount(msg.payload as ClearBudgetAmountPayload);
             break;
           default:
             throw new Error(`Unknown mutation action: ${msg.action}`);

--- a/app/src/lib/gnucash/worker/messages.ts
+++ b/app/src/lib/gnucash/worker/messages.ts
@@ -66,7 +66,9 @@ export type MutationAction =
   | "bulkEditTransactions"
   | "createAccount" | "updateAccount" | "deleteAccount"
   | "createCommodity"
-  | "addPrice" | "editPrice" | "deletePrice";
+  | "addPrice" | "editPrice" | "deletePrice"
+  | "createBudget" | "updateBudget" | "deleteBudget"
+  | "setBudgetAmount" | "clearBudgetAmount";
 
 /**
  * Payload for creating a transaction via the worker.
@@ -192,6 +194,48 @@ export interface EditPricePayload {
 /** Payload for deleting a price entry. */
 export interface DeletePricePayload {
   priceGuid: string;
+}
+
+/**
+ * Fields on a GnuCash budget + its `recurrences` row. Shared by create and
+ * update payloads so the editor UI can round-trip the same shape.
+ */
+export interface BudgetFieldsPayload {
+  name: string;
+  description: string;
+  numPeriods: number;
+  /** GnuCash recurrence period type — "day" | "week" | "month" | "year". */
+  periodType: "day" | "week" | "month" | "year";
+  /** Recurrence multiplier — e.g. periodType="month" + mult=3 ⇒ quarterly. */
+  recurrenceMult: number;
+  /** First period's start date (ISO YYYY-MM-DD). */
+  recurrenceStart: string;
+}
+
+export type CreateBudgetPayload = BudgetFieldsPayload;
+
+export interface UpdateBudgetPayload extends BudgetFieldsPayload {
+  budgetGuid: string;
+}
+
+export interface DeleteBudgetPayload {
+  budgetGuid: string;
+}
+
+/** Upsert a single budget_amounts cell. `periodNum` is 0-indexed. */
+export interface SetBudgetAmountPayload {
+  budgetGuid: string;
+  accountGuid: string;
+  periodNum: number;
+  /** Amount stored as an exact rational num/denom (e.g. 12345/100 = 123.45). */
+  amountNum: number;
+  amountDenom: number;
+}
+
+export interface ClearBudgetAmountPayload {
+  budgetGuid: string;
+  accountGuid: string;
+  periodNum: number;
 }
 
 export type WorkerResponse =

--- a/app/src/lib/types/gnucash.ts
+++ b/app/src/lib/types/gnucash.ts
@@ -322,6 +322,9 @@ export interface LedgerTransaction {
   splits: LedgerSplit[];
 }
 
+/** GnuCash recurrence period type. Stored on the `recurrences` row attached to a budget. */
+export type BudgetPeriodType = "day" | "week" | "month" | "year";
+
 /** Metadata about a GNUCash budget. */
 export interface BudgetInfo {
   guid: string;
@@ -329,6 +332,24 @@ export interface BudgetInfo {
   description: string;
   /** Number of budget periods (typically 12 for monthly budgets) */
   numPeriods: number;
+  /**
+   * Recurrence period type from the `recurrences` row (`obj_guid = budget.guid`).
+   * Falls back to "month" when no recurrence row is present so the view layer
+   * always has a valid type to render. Writers always emit a recurrence row.
+   */
+  periodType: BudgetPeriodType;
+  /**
+   * Recurrence multiplier — e.g. periodType="month" + mult=3 means quarterly periods.
+   * Defaults to 1 when the recurrence row is missing.
+   */
+  recurrenceMult: number;
+  /**
+   * First period's start date (ISO YYYY-MM-DD). Derived from
+   * `recurrences.recurrence_period_start` (GnuCash stores it as YYYYMMDD or
+   * YYYY-MM-DD HH:MM:SS depending on backend). Empty string when no
+   * recurrence row is present.
+   */
+  recurrenceStart: string;
 }
 
 /** A single row in the budget view, representing one account's budgeted vs actual amounts. */
@@ -369,6 +390,19 @@ export interface BudgetDataForBudget {
   incomeCategories: BudgetCategoryRow[];
 }
 
+/**
+ * One row from the `budget_amounts` table. Amounts are in the account's own
+ * commodity (no FX conversion), stored as an exact rational so the editor
+ * can round-trip values without precision loss.
+ */
+export interface RawBudgetCell {
+  accountGuid: string;
+  /** 0-indexed period (period 0 = first period). */
+  periodNum: number;
+  amountNum: number;
+  amountDenom: number;
+}
+
 /** All budget data across all GNUCash budgets in the file. */
 export interface BudgetData {
   budgets: BudgetInfo[];
@@ -379,6 +413,12 @@ export interface BudgetData {
   incomeCategories: BudgetCategoryRow[];
   /** Years that have actual transaction data, sorted descending (most recent first) */
   availableYears: number[];
+  /**
+   * Raw `budget_amounts` rows keyed by budget guid, in the account's own
+   * commodity (no FX). Feeds the special-functions budget editor, which
+   * needs exact rational amounts to round-trip edits without precision loss.
+   */
+  rawAmountsByBudget: Record<string, RawBudgetCell[]>;
 }
 
 export interface CashFlowBudgetForBudget {


### PR DESCRIPTION
## Summary
- Adds a full create / edit / delete flow for GnuCash budgets under `/special-functions/budgets`, round-tripping through the native `budgets` + `budget_amounts` + `recurrences` schema so budgets authored here open cleanly in GnuCash desktop.
- Editor grid: rows = EXPENSE / INCOME chart-of-accounts (hierarchical, collapsed by default with chevron expanders), columns = periods with labels derived from the recurrence shape ("Jan 2026", "Q1 2026", "2026", …). Cells write through on blur. Parents left blank show greyed rollup from children; explicit parent amounts that disagree with child sums flash an amber imbalance icon, mirroring the existing cash-flow view.
- Supports GnuCash's full period-type flexibility (day / week / month / year with multiplier and num_periods) and multiple named budgets per book.

## Test plan
- [ ] Create a new budget via the inline "New budget" expander — confirm it lands on the editor afterwards.
- [ ] Set an amount on a leaf EXPENSE account, then reload — value persists.
- [ ] Set an explicit amount on a parent that differs from its children's sum — amber imbalance badge appears.
- [ ] Leave a parent blank — greyed rollup placeholder shows the children's sum.
- [ ] Collapse a parent row — children disappear, placeholder still shows on the parent.
- [ ] Change period type from `month` to `month × 3` and save metadata — column labels flip to `Q1 2026`, `Q2 2026`, … .
- [ ] Shrink `numPeriods` on a budget that has amounts past the new end — out-of-range amounts are dropped (engine test covers this; also verify the editor doesn't show stale columns).
- [ ] Delete a budget — confirm dialog appears, budget disappears, amounts are gone.
- [ ] Postgres backend: repeat the full flow connected to a gnudash-managed Postgres book; mutations hit `/api/pg/book/exec`.
- [ ] Interop mode (existing GnuCash PG DB): confirm the Budgets entry in Special Functions and all pages show the read-only message.
- [ ] XML-loaded book: confirm read-only messaging (no SQLite backend to write through).

Closes #90