### PR TITLE
Add new-book wizard for creating a fresh chart of accounts

### DIFF
--- a/app/src/components/upload/fresh-book-wizard.tsx
+++ b/app/src/components/upload/fresh-book-wizard.tsx
@@ -1,0 +1,550 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { ArrowLeft, ArrowRight, ChevronRight, Loader2, Sparkles } from "lucide-react";
+import { useDashboard } from "@/lib/dashboard-context";
+import type {
+  InitEmptyBookPayload,
+  PostgresConnectionInfo,
+  TemplateAccountNode,
+} from "@/lib/gnucash/worker/messages";
+import {
+  TEMPLATES,
+  getTemplateById,
+  type TemplateAccount,
+} from "@/lib/gnucash/templates";
+import {
+  COMMON_CURRENCIES,
+  findCurrency,
+  isIsoCurrencyCode,
+} from "@/lib/gnucash/templates/currencies";
+
+type BackendTarget =
+  | { kind: "local" }
+  | { kind: "postgres"; connection: PostgresConnectionInfo; bookId: string };
+
+interface FreshBookWizardProps {
+  /** Which backend the resulting book lives on. Set by the launching panel. */
+  target: BackendTarget;
+  /** Called when the user backs out — returns them to the panel that launched the wizard. */
+  onCancel: () => void;
+}
+
+type Step = 1 | 2 | 3 | 4;
+
+/**
+ * Editable mirror of the immutable template tree. `included` lets users drop
+ * branches they don't want, `name` captures in-place renames. Children are
+ * recursively walked into the same node shape.
+ */
+interface EditableNode {
+  /** Stable path string ("Assets/Current Assets/Cash") — used as React key and diff handle. */
+  path: string;
+  name: string;
+  type: TemplateAccount["type"];
+  placeholder: boolean;
+  description?: string;
+  included: boolean;
+  children: EditableNode[];
+}
+
+/**
+ * Stepped inline wizard for creating a fresh book. Rendered in place of the
+ * launching panel (Local or Server) — never a modal — so the flow matches the
+ * "no modals for entry" preference.
+ *
+ * The component is backend-agnostic in its UI: the only difference between
+ * Local and Postgres targets is which context method fires on Create. Until
+ * that moment the user sees the same four steps either way.
+ */
+export function FreshBookWizard({ target, onCancel }: FreshBookWizardProps) {
+  const {
+    createFreshLocalBook,
+    createFreshPostgresBook,
+    isLoading,
+    error,
+  } = useDashboard();
+
+  const [step, setStep] = useState<Step>(1);
+  const [bookName, setBookName] = useState("My Book");
+  const [currencyMnemonic, setCurrencyMnemonic] = useState("USD");
+  const [templateId, setTemplateId] = useState(TEMPLATES[0].id);
+  const [editable, setEditable] = useState<EditableNode[]>(() =>
+    toEditable(TEMPLATES[0].accounts),
+  );
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const selectedTemplate = useMemo(
+    () => getTemplateById(templateId) ?? TEMPLATES[0],
+    [templateId],
+  );
+
+  // Regenerating the editable tree on template change is a straight reset —
+  // we don't try to carry over edits, because template shapes diverge too
+  // much for name/toggle heuristics to feel predictable.
+  const onTemplateChange = useCallback((id: string) => {
+    setTemplateId(id);
+    const tpl = getTemplateById(id);
+    if (tpl) setEditable(toEditable(tpl.accounts));
+  }, []);
+
+  const canAdvanceFromStep1 =
+    bookName.trim().length > 0 && isIsoCurrencyCode(currencyMnemonic);
+
+  const hasAnyIncluded = useMemo(
+    () => editable.some(hasIncludedDescendant),
+    [editable],
+  );
+
+  const handleCreate = useCallback(async () => {
+    setLocalError(null);
+    if (!hasAnyIncluded) {
+      setLocalError("At least one account must be included.");
+      return;
+    }
+
+    const currency = findCurrency(currencyMnemonic) ?? {
+      mnemonic: currencyMnemonic.trim().toUpperCase(),
+      fullname: currencyMnemonic.trim().toUpperCase(),
+    };
+    const spec: InitEmptyBookPayload = {
+      bookName: bookName.trim(),
+      baseCurrencyMnemonic: currency.mnemonic,
+      baseCurrencyFullname: currency.fullname,
+      accounts: editable
+        .filter((n) => n.included || hasIncludedDescendant(n))
+        .map(toPayloadNode)
+        .filter((n): n is TemplateAccountNode => n !== null),
+    };
+
+    if (target.kind === "local") {
+      await createFreshLocalBook(spec);
+    } else {
+      await createFreshPostgresBook(target.connection, target.bookId, spec);
+    }
+  }, [
+    bookName,
+    currencyMnemonic,
+    editable,
+    hasAnyIncluded,
+    target,
+    createFreshLocalBook,
+    createFreshPostgresBook,
+  ]);
+
+  const displayedError = localError ?? error;
+
+  return (
+    <div className="rounded-2xl border border-[#D4DAE0] bg-white p-5">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Sparkles className="h-4 w-4 text-[#6C9B8B]" />
+          <span className="text-sm font-medium text-[#1A1D1F]">
+            Start a fresh book
+          </span>
+        </div>
+        <button
+          onClick={onCancel}
+          className="text-xs text-[#6F767E] hover:text-[#1A1D1F]"
+        >
+          Cancel
+        </button>
+      </div>
+
+      <StepIndicator step={step} />
+
+      {step === 1 && (
+        <Step1BookBasics
+          bookName={bookName}
+          onBookNameChange={setBookName}
+          currencyMnemonic={currencyMnemonic}
+          onCurrencyChange={setCurrencyMnemonic}
+        />
+      )}
+
+      {step === 2 && (
+        <Step2Template
+          selectedId={templateId}
+          onSelect={onTemplateChange}
+        />
+      )}
+
+      {step === 3 && (
+        <Step3Customize
+          template={selectedTemplate.name}
+          nodes={editable}
+          onChange={setEditable}
+        />
+      )}
+
+      {step === 4 && (
+        <Step4Review
+          bookName={bookName}
+          currencyMnemonic={currencyMnemonic}
+          templateName={selectedTemplate.name}
+          includedCount={countIncluded(editable)}
+          target={target}
+        />
+      )}
+
+      {displayedError && (
+        <div className="mt-4 rounded-xl bg-red-50 p-3 text-center text-sm text-red-600">
+          {displayedError}
+        </div>
+      )}
+
+      <div className="mt-5 flex items-center justify-between gap-2">
+        <button
+          onClick={() => {
+            if (step === 1) onCancel();
+            else setStep((step - 1) as Step);
+          }}
+          disabled={isLoading}
+          className="flex items-center gap-1.5 rounded-xl border border-[#D4DAE0] px-3 py-2 text-sm text-[#6F767E] hover:border-[#6C9B8B]/50 hover:bg-[#6C9B8B]/5 hover:text-[#1A1D1F] disabled:opacity-50"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {step === 1 ? "Back" : "Previous"}
+        </button>
+        {step < 4 ? (
+          <button
+            onClick={() => setStep((step + 1) as Step)}
+            disabled={step === 1 && !canAdvanceFromStep1}
+            className="flex items-center gap-1.5 rounded-xl bg-[#6C9B8B] px-3 py-2 text-sm font-medium text-white hover:bg-[#5A8877] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Next
+            <ArrowRight className="h-3.5 w-3.5" />
+          </button>
+        ) : (
+          <button
+            onClick={handleCreate}
+            disabled={isLoading || !hasAnyIncluded}
+            className="flex items-center gap-1.5 rounded-xl bg-[#6C9B8B] px-4 py-2 text-sm font-medium text-white hover:bg-[#5A8877] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                Creating...
+              </>
+            ) : (
+              "Create book"
+            )}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StepIndicator({ step }: { step: Step }) {
+  const labels = ["Basics", "Template", "Customise", "Review"];
+  return (
+    <div className="mb-5 flex items-center gap-2 text-xs">
+      {labels.map((label, i) => {
+        const n = (i + 1) as Step;
+        const active = n === step;
+        const done = n < step;
+        return (
+          <div key={label} className="flex items-center gap-2">
+            <div
+              className={`flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold ${
+                active
+                  ? "bg-[#6C9B8B] text-white"
+                  : done
+                    ? "bg-[#6C9B8B]/20 text-[#6C9B8B]"
+                    : "bg-[#F4F5F7] text-[#9A9FA5]"
+              }`}
+            >
+              {n}
+            </div>
+            <span
+              className={
+                active
+                  ? "font-medium text-[#1A1D1F]"
+                  : done
+                    ? "text-[#6C9B8B]"
+                    : "text-[#9A9FA5]"
+              }
+            >
+              {label}
+            </span>
+            {i < labels.length - 1 && (
+              <ChevronRight className="h-3 w-3 text-[#D4DAE0]" />
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+interface Step1Props {
+  bookName: string;
+  onBookNameChange: (v: string) => void;
+  currencyMnemonic: string;
+  onCurrencyChange: (v: string) => void;
+}
+
+function Step1BookBasics({
+  bookName,
+  onBookNameChange,
+  currencyMnemonic,
+  onCurrencyChange,
+}: Step1Props) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="mb-1 block text-xs font-medium text-[#6F767E]">
+          Book name
+        </label>
+        <input
+          type="text"
+          value={bookName}
+          onChange={(e) => onBookNameChange(e.target.value)}
+          className="w-full rounded-lg border border-[#D4DAE0] bg-white px-3 py-2 text-sm text-[#1A1D1F] focus:border-[#6C9B8B] focus:outline-none focus:ring-2 focus:ring-[#6C9B8B]/20"
+          placeholder="My Book"
+        />
+      </div>
+
+      <div>
+        <label className="mb-1 block text-xs font-medium text-[#6F767E]">
+          Base currency
+        </label>
+        <select
+          value={currencyMnemonic}
+          onChange={(e) => onCurrencyChange(e.target.value)}
+          className="w-full rounded-lg border border-[#D4DAE0] bg-white px-3 py-2 text-sm text-[#1A1D1F] focus:border-[#6C9B8B] focus:outline-none focus:ring-2 focus:ring-[#6C9B8B]/20"
+        >
+          {COMMON_CURRENCIES.map((c) => (
+            <option key={c.mnemonic} value={c.mnemonic}>
+              {c.mnemonic} — {c.fullname}
+            </option>
+          ))}
+        </select>
+        <p className="mt-1 text-xs text-[#9A9FA5]">
+          This is the currency every account will use by default. You can add
+          other currencies afterwards.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+interface Step2Props {
+  selectedId: string;
+  onSelect: (id: string) => void;
+}
+
+function Step2Template({ selectedId, onSelect }: Step2Props) {
+  return (
+    <div className="space-y-2">
+      {TEMPLATES.map((tpl) => {
+        const active = tpl.id === selectedId;
+        return (
+          <button
+            key={tpl.id}
+            onClick={() => onSelect(tpl.id)}
+            className={`w-full rounded-xl border p-3 text-left transition-colors ${
+              active
+                ? "border-[#6C9B8B] bg-[#6C9B8B]/5"
+                : "border-[#D4DAE0] hover:border-[#6C9B8B]/50"
+            }`}
+          >
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-[#1A1D1F]">
+                {tpl.name}
+              </span>
+              <span className="text-xs text-[#9A9FA5]">
+                {countTemplateAccounts(tpl.accounts)} accounts
+              </span>
+            </div>
+            <p className="mt-1 text-xs text-[#6F767E]">{tpl.description}</p>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface Step3Props {
+  template: string;
+  nodes: EditableNode[];
+  onChange: (next: EditableNode[]) => void;
+}
+
+function Step3Customize({ template, nodes, onChange }: Step3Props) {
+  return (
+    <div>
+      <p className="mb-3 text-xs text-[#6F767E]">
+        Preview of the <span className="font-medium">{template}</span> template.
+        Uncheck any account to skip it, or rename inline. Parent accounts stay
+        in the tree as long as any descendant is included.
+      </p>
+      <div className="max-h-[300px] overflow-y-auto rounded-xl border border-[#D4DAE0] bg-[#F4F5F7]/30 p-2">
+        {nodes.map((n, i) => (
+          <TreeRow
+            key={n.path}
+            node={n}
+            depth={0}
+            onChange={(next) => {
+              const copy = [...nodes];
+              copy[i] = next;
+              onChange(copy);
+            }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+interface TreeRowProps {
+  node: EditableNode;
+  depth: number;
+  onChange: (next: EditableNode) => void;
+}
+
+function TreeRow({ node, depth, onChange }: TreeRowProps) {
+  return (
+    <div>
+      <div
+        className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-white"
+        style={{ paddingLeft: `${8 + depth * 16}px` }}
+      >
+        <input
+          type="checkbox"
+          checked={node.included}
+          onChange={(e) =>
+            onChange({ ...node, included: e.target.checked })
+          }
+          className="h-3.5 w-3.5 rounded border-[#D4DAE0] text-[#6C9B8B] accent-[#6C9B8B]"
+        />
+        <input
+          type="text"
+          value={node.name}
+          onChange={(e) => onChange({ ...node, name: e.target.value })}
+          className={`flex-1 rounded border border-transparent bg-transparent px-1.5 py-0.5 text-sm focus:border-[#D4DAE0] focus:bg-white focus:outline-none ${
+            node.included ? "text-[#1A1D1F]" : "text-[#9A9FA5] line-through"
+          }`}
+        />
+        <span className="shrink-0 rounded bg-[#F4F5F7] px-1.5 py-0.5 font-mono text-[10px] text-[#6F767E]">
+          {node.type}
+        </span>
+      </div>
+      {node.children.map((child, i) => (
+        <TreeRow
+          key={child.path}
+          node={child}
+          depth={depth + 1}
+          onChange={(next) => {
+            const copy = [...node.children];
+            copy[i] = next;
+            onChange({ ...node, children: copy });
+          }}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface Step4Props {
+  bookName: string;
+  currencyMnemonic: string;
+  templateName: string;
+  includedCount: number;
+  target: BackendTarget;
+}
+
+function Step4Review({
+  bookName,
+  currencyMnemonic,
+  templateName,
+  includedCount,
+  target,
+}: Step4Props) {
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-[#6F767E]">
+        Ready to create. This will {target.kind === "local"
+          ? "seed a new book in your browser's local storage"
+          : `push a new empty book schema to your Postgres server at ${target.connection.host} (book id: ${target.bookId})`}.
+      </p>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 rounded-xl bg-[#F4F5F7]/60 p-3 text-sm">
+        <dt className="text-xs text-[#6F767E]">Book name</dt>
+        <dd className="text-[#1A1D1F]">{bookName}</dd>
+        <dt className="text-xs text-[#6F767E]">Base currency</dt>
+        <dd className="text-[#1A1D1F]">{currencyMnemonic.toUpperCase()}</dd>
+        <dt className="text-xs text-[#6F767E]">Template</dt>
+        <dd className="text-[#1A1D1F]">{templateName}</dd>
+        <dt className="text-xs text-[#6F767E]">Accounts</dt>
+        <dd className="text-[#1A1D1F]">{includedCount}</dd>
+        <dt className="text-xs text-[#6F767E]">Backend</dt>
+        <dd className="text-[#1A1D1F]">
+          {target.kind === "local" ? "Local (OPFS)" : "Postgres"}
+        </dd>
+      </dl>
+    </div>
+  );
+}
+
+// ── Tree helpers ───────────────────────────────────────────────────
+
+function toEditable(
+  accounts: TemplateAccount[],
+  prefix = "",
+): EditableNode[] {
+  return accounts.map((a) => {
+    const path = prefix ? `${prefix}/${a.name}` : a.name;
+    return {
+      path,
+      name: a.name,
+      type: a.type,
+      placeholder: a.placeholder ?? false,
+      description: a.description,
+      included: true,
+      children: a.children ? toEditable(a.children, path) : [],
+    };
+  });
+}
+
+/**
+ * Convert an editable node back to the serialisable payload shape the worker
+ * consumes. A node survives the transform if it is itself included OR any of
+ * its descendants is — this keeps placeholder parents around when the user
+ * unchecks only the parent but keeps children.
+ */
+function toPayloadNode(node: EditableNode): TemplateAccountNode | null {
+  const kids = node.children
+    .map(toPayloadNode)
+    .filter((c): c is TemplateAccountNode => c !== null);
+  if (!node.included && kids.length === 0) return null;
+  return {
+    name: node.name,
+    type: node.type,
+    placeholder: !node.included || node.placeholder,
+    description: node.description,
+    children: kids.length > 0 ? kids : undefined,
+  };
+}
+
+function hasIncludedDescendant(node: EditableNode): boolean {
+  if (node.included) return true;
+  return node.children.some(hasIncludedDescendant);
+}
+
+function countIncluded(nodes: EditableNode[]): number {
+  let n = 0;
+  for (const node of nodes) {
+    if (node.included) n++;
+    n += countIncluded(node.children);
+  }
+  return n;
+}
+
+function countTemplateAccounts(accounts: TemplateAccount[]): number {
+  let n = 0;
+  for (const a of accounts) {
+    n++;
+    if (a.children) n += countTemplateAccounts(a.children);
+  }
+  return n;
+}

--- a/app/src/components/upload/local-upload-panel.tsx
+++ b/app/src/components/upload/local-upload-panel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useCallback, useState } from "react";
-import { Loader2, Play, Upload } from "lucide-react";
+import { Loader2, Play, Sparkles, Upload } from "lucide-react";
 import { useDashboard } from "@/lib/dashboard-context";
+import { FreshBookWizard } from "./fresh-book-wizard";
 
 const MAX_FILE_SIZE_BYTES = 200 * 1024 * 1024;
 
@@ -21,6 +22,7 @@ export function LocalUploadPanel() {
   const [isDragging, setIsDragging] = useState(false);
   const [readOnly, setReadOnly] = useState(false);
   const [fileSizeError, setFileSizeError] = useState<string | null>(null);
+  const [showWizard, setShowWizard] = useState(false);
 
   const handleFile = useCallback(
     (file: File) => {
@@ -69,6 +71,15 @@ export function LocalUploadPanel() {
     };
     input.click();
   }, [handleFile]);
+
+  if (showWizard) {
+    return (
+      <FreshBookWizard
+        target={{ kind: "local" }}
+        onCancel={() => setShowWizard(false)}
+      />
+    );
+  }
 
   return (
     <div>
@@ -126,14 +137,24 @@ export function LocalUploadPanel() {
         <div className="h-px flex-1 bg-[#D4DAE0]" />
       </div>
 
-      <button
-        onClick={loadDemo}
-        disabled={isLoading}
-        className="mt-4 flex w-full items-center justify-center gap-2 rounded-xl border-2 border-[#D4DAE0] bg-white px-4 py-3 text-sm font-medium text-[#6F767E] transition-all hover:border-[#6C9B8B]/50 hover:bg-[#6C9B8B]/5 hover:text-[#6C9B8B] disabled:opacity-50"
-      >
-        <Play className="h-4 w-4" />
-        Try with demo data
-      </button>
+      <div className="mt-4 grid grid-cols-2 gap-3">
+        <button
+          onClick={() => setShowWizard(true)}
+          disabled={isLoading}
+          className="flex items-center justify-center gap-2 rounded-xl border-2 border-[#D4DAE0] bg-white px-4 py-3 text-sm font-medium text-[#6F767E] transition-all hover:border-[#6C9B8B]/50 hover:bg-[#6C9B8B]/5 hover:text-[#6C9B8B] disabled:opacity-50"
+        >
+          <Sparkles className="h-4 w-4" />
+          Start fresh
+        </button>
+        <button
+          onClick={loadDemo}
+          disabled={isLoading}
+          className="flex items-center justify-center gap-2 rounded-xl border-2 border-[#D4DAE0] bg-white px-4 py-3 text-sm font-medium text-[#6F767E] transition-all hover:border-[#6C9B8B]/50 hover:bg-[#6C9B8B]/5 hover:text-[#6C9B8B] disabled:opacity-50"
+        >
+          <Play className="h-4 w-4" />
+          Try demo
+        </button>
+      </div>
 
       {(error || fileSizeError) && (
         <div className="mt-4 rounded-xl bg-red-50 p-4 text-center">

--- a/app/src/components/upload/server-connect-panel.tsx
+++ b/app/src/components/upload/server-connect-panel.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
-import { AlertTriangle, Loader2, Server, Upload } from "lucide-react";
+import { AlertTriangle, Loader2, Server, Sparkles, Upload } from "lucide-react";
 import { useDashboard } from "@/lib/dashboard-context";
 import type { PostgresConnectionInfo } from "@/lib/gnucash/worker/messages";
 import { loadServerConfig } from "@/lib/storage/server-config";
+import { FreshBookWizard } from "./fresh-book-wizard";
 
 /**
  * Server (Postgres) backend panel of the upload screen.
@@ -69,6 +70,7 @@ export function ServerConnectPanel() {
   const [localError, setLocalError] = useState<string | null>(null);
   const [fileSizeError, setFileSizeError] = useState<string | null>(null);
   const [isDragging, setIsDragging] = useState(false);
+  const [showWizard, setShowWizard] = useState(false);
 
   // Prefill from OPFS-persisted server-config when the panel mounts so users
   // who land here after a failed auto-reconnect don't have to retype every
@@ -253,6 +255,15 @@ export function ServerConnectPanel() {
   const displayedError = error ?? localError ?? fileSizeError;
   const busy = isLoading || stage.kind === "testing" || stage.kind === "loading";
 
+  if (showWizard) {
+    return (
+      <FreshBookWizard
+        target={{ kind: "postgres", connection, bookId }}
+        onCancel={() => setShowWizard(false)}
+      />
+    );
+  }
+
   return (
     <div>
       <div className="rounded-2xl border border-[#D4DAE0] bg-white p-5">
@@ -411,6 +422,19 @@ export function ServerConnectPanel() {
               </div>
             </div>
           </div>
+          <div className="flex items-center gap-3">
+            <div className="h-px flex-1 bg-[#D4DAE0]" />
+            <span className="text-xs text-[#9A9FA5]">or</span>
+            <div className="h-px flex-1 bg-[#D4DAE0]" />
+          </div>
+          <button
+            onClick={() => setShowWizard(true)}
+            disabled={busy}
+            className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-[#D4DAE0] bg-white px-4 py-3 text-sm font-medium text-[#6F767E] transition-all hover:border-[#6C9B8B]/50 hover:bg-[#6C9B8B]/5 hover:text-[#6C9B8B] disabled:opacity-50"
+          >
+            <Sparkles className="h-4 w-4" />
+            Start fresh from a template
+          </button>
         </div>
       )}
 

--- a/app/src/lib/dashboard-context.tsx
+++ b/app/src/lib/dashboard-context.tsx
@@ -10,7 +10,7 @@ import {
 } from "react";
 import type { DashboardData } from "@/lib/types/gnucash";
 import { GnuCashWorkerClient } from "@/lib/gnucash/worker/client";
-import type { CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload } from "@/lib/gnucash/worker/messages";
+import type { CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload, InitEmptyBookPayload } from "@/lib/gnucash/worker/messages";
 import { generateDemoData } from "@/lib/demo-data";
 import { deleteFromOPFS } from "@/lib/gnucash/worker/opfs";
 import {
@@ -97,6 +97,23 @@ interface DashboardContextType {
     connection: PostgresConnectionInfo,
     schema: string,
   ) => Promise<boolean>;
+  /**
+   * Create a brand-new book from a wizard-chosen template and open it in the
+   * local (OPFS) backend. Mirrors `uploadFile` but skips the .gnucash parse
+   * step — the worker seeds a fresh SQLite DB from the template directly.
+   */
+  createFreshLocalBook: (spec: InitEmptyBookPayload) => Promise<void>;
+  /**
+   * Create a brand-new book from a wizard-chosen template, push it to
+   * Postgres via the existing import pipeline, and then open it. Reuses
+   * `/api/pg/book/import` so the server never learns about templates — it
+   * just sees a SQLite buffer like any other upload.
+   */
+  createFreshPostgresBook: (
+    connection: PostgresConnectionInfo,
+    bookId: string,
+    spec: InitEmptyBookPayload,
+  ) => Promise<void>;
   loadDemo: () => Promise<void>;
   clearData: () => void;
   createTransaction: (payload: CreateTransactionPayload) => Promise<void>;
@@ -517,6 +534,91 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  /**
+   * Local-backend entry point for the "Start fresh" wizard. Seeds an empty
+   * OPFS book from the chosen template and flips the UI straight into the
+   * loaded-book state — no .gnucash file ever involved.
+   */
+  async function createFreshLocalBook(spec: InitEmptyBookPayload) {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const client = getClient();
+      await client.waitForReady();
+      await client.initEmptyBook(spec, true);
+      const dashboardData = await client.getFullDashboardData();
+      const now = new Date();
+      setData(dashboardData);
+      setUploadedAt(now);
+      setIsXmlSource(false);
+      setIsWritable(true);
+      setBackend("local");
+      setPostgresBookId(null);
+      setPostgresSchemaOverride(null);
+      sessionStorage.setItem(UPLOADED_AT_KEY, now.toISOString());
+      sessionStorage.setItem(WRITABLE_KEY, "true");
+      sessionStorage.setItem(BACKEND_KEY, "local");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Fresh book creation failed");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  /**
+   * Postgres-backend entry point for the "Start fresh" wizard.
+   *
+   * The server-side import route is schema-agnostic — it accepts a SQLite
+   * buffer and drops/recreates the target schema from it. So the fresh-book
+   * flow builds the empty book in the worker, exports it, and uploads that
+   * buffer using the exact same code path as `importFileToPostgres`. This
+   * avoids a new API route *and* inherits the transactional rollback
+   * behaviour the existing import already has.
+   */
+  async function createFreshPostgresBook(
+    connection: PostgresConnectionInfo,
+    bookId: string,
+    spec: InitEmptyBookPayload,
+  ) {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const client = getClient();
+      await client.waitForReady();
+
+      // Seed the worker's in-memory DB (no OPFS write — Postgres is the
+      // source of truth), then grab the SQLite bytes for upload.
+      await client.initEmptyBook(spec, false);
+      const sqliteBuffer = await client.exportDatabase();
+
+      const form = new FormData();
+      form.append("file", new Blob([sqliteBuffer]), "fresh.gnucash");
+      form.append("connection", JSON.stringify(connection));
+      form.append("bookId", bookId);
+
+      const importRes = await fetch("/api/pg/book/import", {
+        method: "POST",
+        body: form,
+      });
+      if (!importRes.ok) {
+        const body = (await importRes.json().catch(() => ({}))) as {
+          error?: string;
+        };
+        throw new Error(
+          body.error ?? `Import failed: HTTP ${importRes.status}`,
+        );
+      }
+
+      await openPostgresBook(connection, bookId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Fresh book creation failed");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
   async function loadDemo() {
     setIsLoading(true);
     setError(null);
@@ -684,7 +786,7 @@ export function DashboardProvider({ children }: { children: ReactNode }) {
 
   return (
     <DashboardContext.Provider
-      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, postgresSchemaOverride, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, reuploadPostgresBook, openExistingGnuCashBook, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, createBudget: createBudgetFn, updateBudget: updateBudgetFn, deleteBudget: deleteBudgetFn, setBudgetAmount: setBudgetAmountFn, clearBudgetAmount: clearBudgetAmountFn, exportFile, setCurrency: setCurrencyFn }}
+      value={{ data, isLoading, error, uploadedAt, isWritable, isXmlSource, backend, postgresBookId, postgresSchemaOverride, toggleWritable, uploadFile, openPostgresBook, importFileToPostgres, reuploadPostgresBook, openExistingGnuCashBook, createFreshLocalBook, createFreshPostgresBook, loadDemo, clearData, createTransaction, deleteTransaction: deleteTransactionFn, editTransaction, bulkEditTransactions: bulkEditTransactionsFn, createAccount: createAccountFn, updateAccount: updateAccountFn, deleteAccountWithReallocation: deleteAccountWithReallocationFn, createCommodity: createCommodityFn, addPrice: addPriceFn, editPrice: editPriceFn, deletePrice: deletePriceFn, createBudget: createBudgetFn, updateBudget: updateBudgetFn, deleteBudget: deleteBudgetFn, setBudgetAmount: setBudgetAmountFn, clearBudgetAmount: clearBudgetAmountFn, exportFile, setCurrency: setCurrencyFn }}
     >
       {children}
     </DashboardContext.Provider>

--- a/app/src/lib/gnucash/templates/currencies.ts
+++ b/app/src/lib/gnucash/templates/currencies.ts
@@ -1,0 +1,49 @@
+/**
+ * Currency picker catalog for the new-book wizard.
+ *
+ * Intentionally not exhaustive — GnuCash recognises every ISO-4217 code, but
+ * presenting 180 options in a dropdown is worse UX than offering a shortlist
+ * and a "custom" escape hatch. The list below covers the common majors plus
+ * a few regional currencies; users can type any ISO code and it's accepted
+ * as-is (validated against /^[A-Z]{3}$/).
+ *
+ * The fullname is cosmetic (stored in `commodities.fullname`) — GnuCash
+ * engines key off mnemonic + namespace "CURRENCY", so a typo in the fullname
+ * won't break anything.
+ */
+export interface CurrencyOption {
+  mnemonic: string;
+  fullname: string;
+}
+
+export const COMMON_CURRENCIES: readonly CurrencyOption[] = [
+  { mnemonic: "USD", fullname: "US Dollar" },
+  { mnemonic: "EUR", fullname: "Euro" },
+  { mnemonic: "GBP", fullname: "Pound Sterling" },
+  { mnemonic: "JPY", fullname: "Japanese Yen" },
+  { mnemonic: "CAD", fullname: "Canadian Dollar" },
+  { mnemonic: "AUD", fullname: "Australian Dollar" },
+  { mnemonic: "CHF", fullname: "Swiss Franc" },
+  { mnemonic: "NZD", fullname: "New Zealand Dollar" },
+  { mnemonic: "CNY", fullname: "Chinese Yuan" },
+  { mnemonic: "HKD", fullname: "Hong Kong Dollar" },
+  { mnemonic: "SGD", fullname: "Singapore Dollar" },
+  { mnemonic: "INR", fullname: "Indian Rupee" },
+  { mnemonic: "SEK", fullname: "Swedish Krona" },
+  { mnemonic: "NOK", fullname: "Norwegian Krone" },
+  { mnemonic: "DKK", fullname: "Danish Krone" },
+  { mnemonic: "ZAR", fullname: "South African Rand" },
+  { mnemonic: "MXN", fullname: "Mexican Peso" },
+  { mnemonic: "BRL", fullname: "Brazilian Real" },
+];
+
+/** Lookup helper — returns the catalog entry for a mnemonic or null. */
+export function findCurrency(mnemonic: string): CurrencyOption | null {
+  const m = mnemonic.trim().toUpperCase();
+  return COMMON_CURRENCIES.find((c) => c.mnemonic === m) ?? null;
+}
+
+/** True if `s` looks like a valid ISO 4217 currency code. */
+export function isIsoCurrencyCode(s: string): boolean {
+  return /^[A-Z]{3}$/.test(s.trim().toUpperCase());
+}

--- a/app/src/lib/gnucash/templates/index.ts
+++ b/app/src/lib/gnucash/templates/index.ts
@@ -1,0 +1,288 @@
+/**
+ * Built-in chart-of-accounts templates for the "Start fresh" book wizard.
+ *
+ * Structured as plain data so adding a template is a matter of appending a
+ * new `AccountTemplate` here — no wiring changes required. The wizard picker
+ * iterates `TEMPLATES` in order, so this file's ordering doubles as the
+ * display order.
+ */
+import type { AccountTemplate } from "./types";
+
+/**
+ * Bare minimum GnuCash top-level tree. Gives the user the five canonical
+ * roots and nothing more — a sensible starting point for people who want to
+ * build their own chart without deleting a bunch of pre-seeded accounts.
+ */
+const MINIMAL: AccountTemplate = {
+  id: "minimal",
+  name: "Minimal",
+  description: "Just the five top-level accounts — build the rest yourself.",
+  accounts: [
+    { name: "Assets", type: "ASSET", placeholder: true },
+    { name: "Liabilities", type: "LIABILITY", placeholder: true },
+    { name: "Income", type: "INCOME", placeholder: true },
+    { name: "Expenses", type: "EXPENSE", placeholder: true },
+    { name: "Equity", type: "EQUITY", placeholder: true },
+  ],
+};
+
+/**
+ * Everyday personal-finance chart. Covers current/savings/cash, common
+ * expense categories, and standard income sources. Mirrors what GnuCash
+ * desktop's "Common Accounts" template ships with.
+ */
+const PERSONAL: AccountTemplate = {
+  id: "personal",
+  name: "Personal Finance",
+  description:
+    "Bank accounts, cards, everyday income and expenses — ideal for tracking household finances.",
+  accounts: [
+    {
+      name: "Assets",
+      type: "ASSET",
+      placeholder: true,
+      children: [
+        {
+          name: "Current Assets",
+          type: "ASSET",
+          placeholder: true,
+          children: [
+            { name: "Cash in Wallet", type: "CASH" },
+            { name: "Current Account", type: "BANK" },
+            { name: "Savings Account", type: "BANK" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "Liabilities",
+      type: "LIABILITY",
+      placeholder: true,
+      children: [
+        { name: "Credit Card", type: "CREDIT" },
+      ],
+    },
+    {
+      name: "Income",
+      type: "INCOME",
+      placeholder: true,
+      children: [
+        { name: "Salary", type: "INCOME" },
+        { name: "Interest", type: "INCOME" },
+        { name: "Other Income", type: "INCOME" },
+      ],
+    },
+    {
+      name: "Expenses",
+      type: "EXPENSE",
+      placeholder: true,
+      children: [
+        { name: "Groceries", type: "EXPENSE" },
+        { name: "Dining", type: "EXPENSE" },
+        { name: "Transport", type: "EXPENSE" },
+        {
+          name: "Housing",
+          type: "EXPENSE",
+          placeholder: true,
+          children: [
+            { name: "Rent/Mortgage", type: "EXPENSE" },
+            { name: "Utilities", type: "EXPENSE" },
+            { name: "Internet", type: "EXPENSE" },
+          ],
+        },
+        { name: "Entertainment", type: "EXPENSE" },
+        { name: "Healthcare", type: "EXPENSE" },
+        { name: "Shopping", type: "EXPENSE" },
+      ],
+    },
+    {
+      name: "Equity",
+      type: "EQUITY",
+      placeholder: true,
+      children: [{ name: "Opening Balances", type: "EQUITY" }],
+    },
+  ],
+};
+
+/**
+ * Small-business chart with AR/AP, revenue vs COGS vs operating expenses,
+ * and payroll taxes. Designed for sole traders or small LLCs — not a
+ * substitute for a proper accountant's chart, but a reasonable starting
+ * point for bookkeeping in GnuDash.
+ */
+const SMALL_BUSINESS: AccountTemplate = {
+  id: "small-business",
+  name: "Small Business",
+  description:
+    "Revenue, COGS, AR/AP, payroll — a starting chart for sole traders and small LLCs.",
+  accounts: [
+    {
+      name: "Assets",
+      type: "ASSET",
+      placeholder: true,
+      children: [
+        {
+          name: "Current Assets",
+          type: "ASSET",
+          placeholder: true,
+          children: [
+            { name: "Business Checking", type: "BANK" },
+            { name: "Petty Cash", type: "CASH" },
+            { name: "Accounts Receivable", type: "RECEIVABLE" },
+          ],
+        },
+        {
+          name: "Fixed Assets",
+          type: "ASSET",
+          placeholder: true,
+          children: [{ name: "Equipment", type: "ASSET" }],
+        },
+      ],
+    },
+    {
+      name: "Liabilities",
+      type: "LIABILITY",
+      placeholder: true,
+      children: [
+        { name: "Accounts Payable", type: "PAYABLE" },
+        { name: "Sales Tax Payable", type: "LIABILITY" },
+        { name: "Payroll Tax Payable", type: "LIABILITY" },
+      ],
+    },
+    {
+      name: "Income",
+      type: "INCOME",
+      placeholder: true,
+      children: [
+        { name: "Sales", type: "INCOME" },
+        { name: "Service Revenue", type: "INCOME" },
+      ],
+    },
+    {
+      name: "Expenses",
+      type: "EXPENSE",
+      placeholder: true,
+      children: [
+        {
+          name: "Cost of Goods Sold",
+          type: "EXPENSE",
+          placeholder: true,
+          children: [
+            { name: "Materials", type: "EXPENSE" },
+            { name: "Subcontractors", type: "EXPENSE" },
+          ],
+        },
+        {
+          name: "Operating Expenses",
+          type: "EXPENSE",
+          placeholder: true,
+          children: [
+            { name: "Rent", type: "EXPENSE" },
+            { name: "Utilities", type: "EXPENSE" },
+            { name: "Office Supplies", type: "EXPENSE" },
+            { name: "Software Subscriptions", type: "EXPENSE" },
+            { name: "Professional Fees", type: "EXPENSE" },
+            { name: "Travel", type: "EXPENSE" },
+          ],
+        },
+        {
+          name: "Payroll",
+          type: "EXPENSE",
+          placeholder: true,
+          children: [
+            { name: "Wages", type: "EXPENSE" },
+            { name: "Payroll Taxes", type: "EXPENSE" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "Equity",
+      type: "EQUITY",
+      placeholder: true,
+      children: [
+        { name: "Opening Balances", type: "EQUITY" },
+        { name: "Owner's Draw", type: "EQUITY" },
+      ],
+    },
+  ],
+};
+
+/**
+ * Brokerage-focused template. Provides placeholders for holdings, dividend
+ * income, realised/unrealised gains, and brokerage fees. STOCK accounts are
+ * intentionally *not* pre-seeded because each one needs a matching
+ * commodity (ticker) the user hasn't declared yet — the user adds securities
+ * through the account editor after creation.
+ */
+const INVESTMENT: AccountTemplate = {
+  id: "investment",
+  name: "Investment / Brokerage",
+  description:
+    "Brokerage cash, dividend income, gains/losses — placeholders for adding securities later.",
+  accounts: [
+    {
+      name: "Assets",
+      type: "ASSET",
+      placeholder: true,
+      children: [
+        { name: "Brokerage Cash", type: "BANK" },
+        {
+          name: "Investments",
+          type: "ASSET",
+          placeholder: true,
+          description: "Add STOCK/MUTUAL sub-accounts per holding.",
+        },
+      ],
+    },
+    {
+      name: "Liabilities",
+      type: "LIABILITY",
+      placeholder: true,
+    },
+    {
+      name: "Income",
+      type: "INCOME",
+      placeholder: true,
+      children: [
+        { name: "Dividends", type: "INCOME" },
+        { name: "Interest", type: "INCOME" },
+        { name: "Realised Gains", type: "INCOME" },
+      ],
+    },
+    {
+      name: "Expenses",
+      type: "EXPENSE",
+      placeholder: true,
+      children: [
+        { name: "Brokerage Fees", type: "EXPENSE" },
+        { name: "Realised Losses", type: "EXPENSE" },
+      ],
+    },
+    {
+      name: "Equity",
+      type: "EQUITY",
+      placeholder: true,
+      children: [
+        { name: "Opening Balances", type: "EQUITY" },
+        { name: "Unrealised Gains", type: "EQUITY" },
+      ],
+    },
+  ],
+};
+
+/**
+ * Ordered registry used by the wizard picker. Order is display order.
+ */
+export const TEMPLATES: readonly AccountTemplate[] = [
+  PERSONAL,
+  SMALL_BUSINESS,
+  INVESTMENT,
+  MINIMAL,
+];
+
+export function getTemplateById(id: string): AccountTemplate | undefined {
+  return TEMPLATES.find((t) => t.id === id);
+}
+
+export type { AccountTemplate, TemplateAccount } from "./types";

--- a/app/src/lib/gnucash/templates/types.ts
+++ b/app/src/lib/gnucash/templates/types.ts
@@ -1,0 +1,33 @@
+/**
+ * Types for the "Start fresh" book templates surfaced in the new-book wizard.
+ *
+ * A template describes a chart-of-accounts skeleton — names, types, and
+ * placeholder flags — in a tree form. The wizard turns a chosen template
+ * into real `accounts` rows by walking the tree depth-first and assigning
+ * parents as it recurses.
+ */
+import type { AccountType } from "../engine/types";
+
+export interface TemplateAccount {
+  /** Display name for the account. Must be unique within its parent. */
+  name: string;
+  /** GnuCash account type. Placeholders use a concrete type (e.g. ASSET). */
+  type: AccountType;
+  /** Grouping account — cannot have transactions. Default false. */
+  placeholder?: boolean;
+  /** Optional long-form description copied into the `description` column. */
+  description?: string;
+  /** Child accounts, recursive. */
+  children?: TemplateAccount[];
+}
+
+export interface AccountTemplate {
+  /** Stable identifier used by the wizard UI to pick a template. */
+  id: string;
+  /** Human-readable name shown in the picker. */
+  name: string;
+  /** One-line summary shown under the name in the picker. */
+  description: string;
+  /** Top-level accounts — typically Assets, Liabilities, Income, Expenses, Equity. */
+  accounts: TemplateAccount[];
+}

--- a/app/src/lib/gnucash/worker/client.ts
+++ b/app/src/lib/gnucash/worker/client.ts
@@ -17,7 +17,7 @@ import type {
   BudgetData,
   DashboardData,
 } from "@/lib/types/gnucash";
-import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, MutationAction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload, InitEmptyBookPayload } from "./messages";
 import { parseGnuCashXml } from "../xml/parser";
 
 type PendingRequest = {
@@ -258,6 +258,38 @@ export class GnuCashWorkerClient {
       };
 
       this.send({ type: "init-pg-dump-readonly", dump });
+    });
+  }
+
+  /**
+   * Build a brand-new book from a wizard-supplied template — no file upload.
+   * When `persistToOpfs` is true the worker writes the seeded DB to OPFS and
+   * re-opens it from there, matching the post-upload state exactly. For the
+   * Postgres handoff path the caller passes `false` and exports a SQLite
+   * buffer immediately afterwards.
+   */
+  async initEmptyBook(
+    spec: InitEmptyBookPayload,
+    persistToOpfs: boolean,
+  ): Promise<void> {
+    await this.wasmReady;
+
+    return new Promise<void>((resolve, reject) => {
+      const prevHandler = this.worker.onmessage;
+      this.worker.onmessage = (e: MessageEvent<WorkerResponse>) => {
+        const msg = e.data;
+        if (msg.type === "ready") {
+          this.worker.onmessage = prevHandler;
+          resolve();
+        } else if (msg.type === "init-error") {
+          this.worker.onmessage = prevHandler;
+          reject(new Error(msg.message));
+        } else {
+          this.handleMessage(msg);
+        }
+      };
+
+      this.send({ type: "init-empty-book", spec, persistToOpfs });
     });
   }
 

--- a/app/src/lib/gnucash/worker/db-worker.ts
+++ b/app/src/lib/gnucash/worker/db-worker.ts
@@ -40,7 +40,8 @@ import {
   clearBudgetAmount as clearBudgetAmountOp,
 } from "../engine/operations/budget-ops";
 import type { AccountType } from "../engine/types";
-import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload } from "./messages";
+import type { WorkerRequest, WorkerResponse, DomainFunction, CreateTransactionPayload, DeleteTransactionPayload, EditTransactionPayload, BulkEditTransactionsPayload, CreateAccountPayload, UpdateAccountPayload, DeleteAccountPayload, CreateCommodityPayload, AddPricePayload, EditPricePayload, DeletePricePayload, CreateBudgetPayload, UpdateBudgetPayload, DeleteBudgetPayload, SetBudgetAmountPayload, ClearBudgetAmountPayload, PostgresConnectionInfo, PostgresDumpPayload, InitEmptyBookPayload, TemplateAccountNode } from "./messages";
+import { generateGuid } from "../engine/guid";
 import type { GnuCashXmlData } from "../xml/types";
 import { GNUCASH_SCHEMA_DDL } from "../xml/schema";
 import { PostgresSyncClient } from "../db/postgres-sync-client";
@@ -302,6 +303,150 @@ function initFromXmlData(data: GnuCashXmlData): void {
   const adapter = createWasmAdapter(db);
   validateSchema(adapter);
   ctx = buildParseContext(adapter);
+}
+
+/**
+ * Seed the open `db` with a minimal viable GnuCash book:
+ *   - one `books` row
+ *   - one ROOT account owning the tree
+ *   - one CURRENCY commodity (the user-chosen base currency)
+ *   - a ROOT template account that budgets/recurrences reference
+ *   - the template's account tree, walked depth-first
+ *
+ * Shared between the in-memory (init-empty-book) path and anywhere else
+ * that needs to materialise a blank book against an already-open DB.
+ */
+function seedEmptyBook(database: WasmDatabase, spec: InitEmptyBookPayload): void {
+  const mnemonic = spec.baseCurrencyMnemonic.trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(mnemonic)) {
+    throw new Error(
+      `Base currency "${spec.baseCurrencyMnemonic}" must be a 3-letter ISO code.`,
+    );
+  }
+
+  const bookGuid = generateGuid();
+  const rootAccountGuid = generateGuid();
+  const rootTemplateGuid = generateGuid();
+  const commodityGuid = generateGuid();
+
+  // Commodity first so the ROOT account can reference it via FK.
+  database.exec({
+    sql: `INSERT INTO commodities (guid, namespace, mnemonic, fullname, cusip, fraction) VALUES (?, ?, ?, ?, ?, ?)`,
+    bind: [commodityGuid, "CURRENCY", mnemonic, spec.baseCurrencyFullname || mnemonic, "", 100],
+  });
+
+  // ROOT account — the hidden top of the tree every real account hangs off.
+  // commodity_guid on ROOT doubles as the book's base currency marker
+  // (buildParseContext reads it via `WHERE account_type = 'ROOT'`).
+  database.exec({
+    sql: `INSERT INTO accounts (guid, name, account_type, commodity_guid, commodity_scu,
+                                non_std_scu, parent_guid, code, description, hidden, placeholder)
+          VALUES (?, ?, 'ROOT', ?, 100, 0, NULL, '', '', 0, 0)`,
+    bind: [rootAccountGuid, "Root Account", commodityGuid],
+  });
+
+  // Template Root — GnuCash desktop creates this even in books without
+  // scheduled transactions. Harmless to include; matches the shape the
+  // desktop app produces so round-tripping through .gnucash export works.
+  database.exec({
+    sql: `INSERT INTO accounts (guid, name, account_type, commodity_guid, commodity_scu,
+                                non_std_scu, parent_guid, code, description, hidden, placeholder)
+          VALUES (?, ?, 'ROOT', ?, 100, 0, NULL, '', '', 0, 0)`,
+    bind: [rootTemplateGuid, "Template Root", commodityGuid],
+  });
+
+  database.exec({
+    sql: `INSERT INTO books (guid, root_account_guid, root_template_guid, num_periods) VALUES (?, ?, ?, 0)`,
+    bind: [bookGuid, rootAccountGuid, rootTemplateGuid],
+  });
+
+  // Walk the template tree. Each node becomes an `accounts` row; children
+  // recurse with their parent's freshly-generated GUID.
+  const insertNode = (node: TemplateAccountNode, parentGuid: string): void => {
+    const guid = generateGuid();
+    database.exec({
+      sql: `INSERT INTO accounts (guid, name, account_type, commodity_guid, commodity_scu,
+                                  non_std_scu, parent_guid, code, description, hidden, placeholder)
+            VALUES (?, ?, ?, ?, 100, 0, ?, '', ?, 0, ?)`,
+      bind: [
+        guid,
+        node.name,
+        node.type,
+        commodityGuid,
+        parentGuid,
+        node.description ?? "",
+        node.placeholder ? 1 : 0,
+      ],
+    });
+    if (node.children) {
+      for (const child of node.children) {
+        insertNode(child, guid);
+      }
+    }
+  };
+
+  for (const top of spec.accounts) {
+    insertNode(top, rootAccountGuid);
+  }
+}
+
+/**
+ * Create a brand-new empty book — no source file, just a user-picked
+ * template + base currency — and open it through the standard adapter
+ * plumbing so the rest of the engine treats it identically to an imported
+ * book.
+ *
+ * When `persistToOpfs` is set and OPFS is available, the freshly seeded DB
+ * is dumped to OPFS and re-opened from there so reloads restore the book.
+ * For the Postgres path the caller flips this off, uses `exportDatabase`
+ * to grab a SQLite buffer, and uploads it via the existing import route —
+ * the local copy is transient and gets cleared right after.
+ */
+async function initEmptyBook(
+  spec: InitEmptyBookPayload,
+  persistToOpfs: boolean,
+): Promise<void> {
+  closeDb();
+  isWritable = true;
+
+  const hasOpfs = !!sqlite3.oo1.OpfsDb;
+  const shouldPersist = persistToOpfs && hasOpfs;
+
+  // Build the fresh book in an in-memory scratch DB first. Going straight to
+  // OPFS would commit every partial INSERT to disk even on failure; keeping
+  // the build in-memory means a crash leaves no half-written file behind.
+  const scratch = new sqlite3.oo1.DB();
+  try {
+    scratch.exec({ sql: GNUCASH_SCHEMA_DDL });
+    scratch.exec({ sql: EXTRA_ENGINE_TABLES_SQL });
+    seedEmptyBook(scratch, spec);
+
+    if (shouldPersist) {
+      // Export the scratch DB to a buffer, import it into OPFS, then re-open
+      // from OPFS so the engine sees the on-disk file as the source of truth.
+      const exported = sqlite3.capi.sqlite3_js_db_export(scratch.pointer!);
+      const buffer = exported.buffer.slice(
+        exported.byteOffset,
+        exported.byteOffset + exported.byteLength,
+      );
+      await sqlite3.oo1.OpfsDb.importDb(OPFS_DB_NAME, buffer);
+      scratch.close();
+      db = new sqlite3.oo1.OpfsDb(OPFS_DB_NAME, "rw");
+    } else {
+      // Non-persistent path (Postgres upload, or OPFS unavailable). Keep the
+      // scratch DB as the live handle so `exportDatabase` works.
+      db = scratch;
+    }
+  } catch (err) {
+    // Only close scratch if we didn't already hand it off as `db`.
+    if (db !== scratch) scratch.close();
+    throw err;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  writableAdapter = createWritableWasmAdapter(db as any);
+  validateSchema(writableAdapter);
+  ctx = buildParseContext(writableAdapter);
 }
 
 function closeDb(): void {
@@ -923,6 +1068,20 @@ self.onmessage = async (e: MessageEvent<WorkerRequest>) => {
       try {
         initFromOpfs(msg.writable ?? false);
         console.log("[db-worker] DB restored from OPFS", isWritable ? "(read-write)" : "(read-only)");
+        post({ type: "ready" });
+      } catch (err) {
+        post({ type: "init-error", message: (err as Error).message });
+      }
+      break;
+    }
+
+    case "init-empty-book": {
+      try {
+        await initEmptyBook(msg.spec, msg.persistToOpfs);
+        console.log(
+          "[db-worker] DB created from fresh-book template",
+          msg.persistToOpfs ? "(persisted to OPFS)" : "(in-memory)",
+        );
         post({ type: "ready" });
       } catch (err) {
         post({ type: "init-error", message: (err as Error).message });

--- a/app/src/lib/gnucash/worker/messages.ts
+++ b/app/src/lib/gnucash/worker/messages.ts
@@ -4,6 +4,7 @@
  */
 
 import type { GnuCashXmlData } from "../xml/types";
+import type { AccountType } from "../engine/types";
 
 /** Connection params for the Postgres backend (#48). Mirrors `PgConnection`
  *  in `lib/pg/connect.ts` but lives here so worker modules never need to
@@ -28,6 +29,11 @@ export type WorkerRequest =
   | { type: "init-xml"; xmlData: GnuCashXmlData }
   | { type: "init-opfs"; fileName: string; writable?: boolean }
   | {
+      type: "init-empty-book";
+      spec: InitEmptyBookPayload;
+      persistToOpfs: boolean;
+    }
+  | {
       type: "init-pg-dump";
       dump: PostgresDumpPayload;
       connection: PostgresConnectionInfo;
@@ -42,6 +48,33 @@ export type WorkerRequest =
   | { type: "set-currency"; id: string; currencyGuid: string }
   | { type: "export"; id: string }
   | { type: "close" };
+
+/**
+ * Serialisable payload describing a fresh chart of accounts. Built on the
+ * main thread from the wizard's template + user edits, then posted to the
+ * worker via `init-empty-book`. The worker walks the tree depth-first,
+ * assigning generated GUIDs as it goes, so the caller never has to
+ * pre-compute parent relationships.
+ */
+export interface InitEmptyBookPayload {
+  /** Cosmetic book name — currently only stored for future use. */
+  bookName: string;
+  /** ISO 4217 code for the base currency commodity. Uppercased before use. */
+  baseCurrencyMnemonic: string;
+  /** Human-readable name for the base currency (e.g. "US Dollar"). */
+  baseCurrencyFullname: string;
+  /** Top-level accounts under ROOT — walked recursively. */
+  accounts: TemplateAccountNode[];
+}
+
+/** Tree node mirroring `TemplateAccount` from the templates module. */
+export interface TemplateAccountNode {
+  name: string;
+  type: AccountType;
+  placeholder?: boolean;
+  description?: string;
+  children?: TemplateAccountNode[];
+}
 
 export type DomainFunction =
   | "buildAccountTree"


### PR DESCRIPTION
## Summary
- Adds a "Start fresh" entry point on both the Local (OPFS) and Server (Postgres) upload tabs that launches a stepped inline wizard (basics → template → customise → review → create).
- Ships four built-in chart-of-accounts templates (Personal, Small Business, Investment, Minimal) with an ISO currency picker.
- Worker grows an `init-empty-book` message that seeds schema + ROOT + base currency + template accounts; Postgres path reuses the existing `/api/pg/book/import` route (no new server surface).

Closes #47.

## Test plan
- [x] Local: Start fresh → Personal template → Create → verify dashboard loads, accounts tree matches template, book persists across reload (OPFS).
- [x] Local: Minimal template creates only the 5 top-level accounts.
- [x] Local: Customise step can uncheck leaves, rename accounts, and the resulting tree reflects the edits.
- [x] Postgres: Connect → needs-import → Start fresh from a template → Create → book opens and every mutation still flushes to the server.
- [x] Reload after a fresh Postgres book to confirm auto-reconnect still works.