### PR TITLE
Fix RangeError when formatting STOCK/MUTUAL balances on accounts page

### DIFF
--- a/app/src/app/(dashboard)/accounts/page.tsx
+++ b/app/src/app/(dashboard)/accounts/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useCallback, useRef } from "react";
 import { Card, CardContent } from "@/components/ui/card";
-import { formatCurrency } from "@/lib/format";
+import { formatAmount } from "@/lib/format";
 import { useDashboard } from "@/lib/dashboard-context";
 import type { AccountNode } from "@/lib/types/gnucash";
 import { ChevronDown, ChevronRight, Plus, Pencil, Trash2, X, List } from "lucide-react";
@@ -414,7 +414,7 @@ function AccountRow({
             const displayCurrency = account.nativeCurrencyMnemonic;
             return (
               <span className={displayBalance < 0 ? "text-[#E87C6B]" : "text-[#1A1D1F]"}>
-                {displayBalance < 0 ? "−" : ""}{formatCurrency(Math.abs(displayBalance), displayCurrency)}
+                {displayBalance < 0 ? "−" : ""}{formatAmount(Math.abs(displayBalance), displayCurrency)}
               </span>
             );
           })()}

--- a/app/src/lib/__tests__/format.test.ts
+++ b/app/src/lib/__tests__/format.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { formatAmount, formatCurrency } from "../format";
+
+describe("formatCurrency", () => {
+  it("formats known ISO 4217 codes via Intl.NumberFormat", () => {
+    expect(formatCurrency(1234.5, "GBP")).toMatch(/1,234\.50/);
+    expect(formatCurrency(1234.5, "USD")).toMatch(/1,234\.50/);
+  });
+
+  it("does not throw on non-ISO commodity mnemonics (regression: #94 follow-up)", () => {
+    // STOCK/MUTUAL rows pass their ticker mnemonic in as the currency arg;
+    // Intl.NumberFormat would previously throw RangeError. Fall back to the
+    // number + suffix formatting path instead.
+    expect(() => formatCurrency(10, "NEWT")).not.toThrow();
+    expect(formatCurrency(10, "NEWT")).toMatch(/NEWT/);
+  });
+});
+
+describe("formatAmount", () => {
+  it("uses currency formatting for known codes", () => {
+    expect(formatAmount(100, "USD")).toMatch(/\$100\.00/);
+  });
+
+  it("uses ticker suffix for stock/mutual mnemonics", () => {
+    expect(formatAmount(10, "VWRL")).toMatch(/\b10\b.* VWRL/);
+    expect(formatAmount(10.5, "VWRL")).toMatch(/10\.5 VWRL/);
+  });
+});

--- a/app/src/lib/format.ts
+++ b/app/src/lib/format.ts
@@ -13,6 +13,14 @@ export function formatCurrency(
   currency: string,
   options?: { compact?: boolean; decimals?: number }
 ): string {
+  // Intl.NumberFormat's currency mode throws RangeError on anything that isn't
+  // a valid ISO 4217 code, which happens when callers accidentally feed it a
+  // STOCK/MUTUAL ticker mnemonic. Fall back to `formatAmount`, which already
+  // handles the non-currency-commodity path (plain number + suffix).
+  if (!KNOWN_CURRENCIES.has(currency)) {
+    return formatAmount(value, currency, options?.decimals);
+  }
+
   const locale = CURRENCY_LOCALE_MAP[currency] ?? "en-GB";
 
   if (options?.compact) {


### PR DESCRIPTION
## Summary
- `formatCurrency` threw `RangeError: invalid currency code in NumberFormat(): NEWT` because it was called with a ticker mnemonic. `Intl.NumberFormat` in `style: "currency"` mode only accepts ISO 4217 codes.
- The accounts page's account-row balance cell now uses `formatAmount`, which already handles both currency and ticker commodities correctly.
- `formatCurrency` itself now falls back to `formatAmount` for unknown codes so nothing else can regress the same way.
- Added unit tests for both helpers.

## Test plan
- [x] `vitest run` — 239 pass (up from 235).
- [x] Load a book with STOCK/MUTUAL accounts → Accounts page → Expand all → confirm no console error and native balances render as e.g. `100 NEWT`.
- [x] Currency accounts (BANK/CASH) still format with the proper currency symbol.