### PR TITLE
Route budget editor via query param so static export can build

### DIFF
--- a/app/src/app/(dashboard)/special-functions/budgets/edit/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/budgets/edit/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useParams, useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useMemo, useState } from "react";
 import { Card, CardContent } from "@/components/ui/card";
 import { useDashboard } from "@/lib/dashboard-context";
@@ -21,7 +21,12 @@ import { ArrowLeft, AlertTriangle, ChevronDown, ChevronRight, Save, Target, Tras
  * its children's sum is flagged with an imbalance warning, mirroring the
  * existing /cash-flow read-only view.
  *
- * URL: /special-functions/budgets/[guid]
+ * URL: /special-functions/budgets/edit?guid=<budgetGuid>
+ *
+ * Intentionally a search-param route, not a dynamic `[guid]` segment: static
+ * export needs every dynamic route pre-listed by `generateStaticParams`, and
+ * the guids here are only known client-side (they live in the user's OPFS
+ * book). A flat route with a query param sidesteps the issue entirely.
  */
 
 const PERIOD_TYPE_OPTIONS: { value: BudgetPeriodType; label: string }[] = [
@@ -161,8 +166,8 @@ function formatAmount(num: number, denom: number): string {
 
 export default function BudgetEditorPage() {
   const router = useRouter();
-  const params = useParams<{ guid: string }>();
-  const budgetGuid = params.guid;
+  const searchParams = useSearchParams();
+  const budgetGuid = searchParams.get("guid") ?? "";
   const {
     data,
     isWritable,

--- a/app/src/app/(dashboard)/special-functions/budgets/page.tsx
+++ b/app/src/app/(dashboard)/special-functions/budgets/page.tsx
@@ -145,7 +145,7 @@ export default function BudgetsListPage() {
                     <td className="px-4 py-3">
                       <div className="flex items-center justify-end gap-1">
                         <Link
-                          href={`/special-functions/budgets/${b.guid}`}
+                          href={`/special-functions/budgets/edit?guid=${b.guid}`}
                           className="rounded p-1.5 text-[#3B6B8A] hover:bg-[#3B6B8A]/10"
                           title="Edit budget"
                         >
@@ -256,7 +256,7 @@ function NewBudgetRow({
         recurrenceStart,
       });
       onCreated();
-      router.push(`/special-functions/budgets/${budgetGuid}`);
+      router.push(`/special-functions/budgets/edit?guid=${budgetGuid}`);
     } catch (err) {
       onError((err as Error).message);
     } finally {


### PR DESCRIPTION
## Summary
- Next.js `output: export` requires every dynamic route segment be enumerated by `generateStaticParams`, but budget GUIDs live exclusively in the user's client-side OPFS book. `[guid]` can never satisfy that at build time, so static export has been failing since the budget management feature landed.
- Move the editor from `/special-functions/budgets/[guid]` to `/special-functions/budgets/edit?guid=…`. Client behaviour is identical; the build just succeeds now.

## Test plan
- [x] `NEXT_OUTPUT=export npm run build` — green (previously failed with "missing generateStaticParams").
- [x] `npm test` — 239 pass.
- [ ] Navigate to `/special-functions/budgets`, click edit on a budget, confirm the editor loads with the correct guid read from the query param.
- [ ] Create a new budget, confirm it redirects to the editor successfully.