### PR TITLE
Normalise PG date columns on read-only dump + fix Sankey fonts at HD-ready

### DIFF
--- a/app/src/app/api/pg/__tests__/integration.test.ts
+++ b/app/src/app/api/pg/__tests__/integration.test.ts
@@ -334,3 +334,124 @@ describe.skipIf(!connection)("API routes (integration)", () => {
     expect(statusBody.exists).toBe(false);
   });
 });
+
+/**
+ * Regression coverage for issue #97: when gnudash reads a real GnuCash
+ * Postgres schema (the read-only interop path), `transactions.post_date` etc.
+ * are declared as native TIMESTAMP columns, not the compact YYYYMMDDHHmmss
+ * TEXT format the engine expects. The dump route must normalise those on the
+ * way out so the engine's `substr`-based month extraction keeps working.
+ */
+describe.skipIf(!connection)("dump route: read-only interop date normalisation", () => {
+  const rawSchema = `real_gnucash_${Math.random().toString(36).slice(2, 10)}`;
+
+  function jsonRequest(url: string, body: unknown): Request {
+    return new Request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  async function drop(): Promise<void> {
+    const client = new Client({ ...connection! });
+    await client.connect();
+    try {
+      await client.query(`DROP SCHEMA IF EXISTS ${rawSchema} CASCADE`);
+    } finally {
+      await client.end();
+    }
+  }
+
+  beforeAll(async () => {
+    await drop();
+    const client = new Client({ ...connection! });
+    await client.connect();
+    try {
+      // A minimal slice of GnuCash's real PG schema — only the columns the
+      // dump route needs to touch, with the native timestamp types GnuCash
+      // desktop writes. Enough to prove TO_CHAR normalisation kicks in.
+      await client.query(`CREATE SCHEMA ${rawSchema}`);
+      await client.query(`
+        CREATE TABLE ${rawSchema}.transactions (
+          guid TEXT PRIMARY KEY,
+          currency_guid TEXT NOT NULL,
+          num TEXT,
+          post_date TIMESTAMP,
+          enter_date TIMESTAMP,
+          description TEXT
+        )
+      `);
+      await client.query(`
+        CREATE TABLE ${rawSchema}.prices (
+          guid TEXT PRIMARY KEY,
+          commodity_guid TEXT NOT NULL,
+          currency_guid TEXT NOT NULL,
+          date TIMESTAMP,
+          source TEXT,
+          type TEXT,
+          value_num BIGINT NOT NULL,
+          value_denom BIGINT NOT NULL DEFAULT 100
+        )
+      `);
+      // A future-dated write-off plus a current-year transaction: the exact
+      // shape of data that exposed the bug in issue #97.
+      await client.query(
+        `INSERT INTO ${rawSchema}.transactions
+           (guid, currency_guid, post_date, enter_date, description)
+         VALUES
+           ('tx-now', 'cur', TIMESTAMP '2026-04-15 10:30:00', TIMESTAMP '2026-04-15 10:30:00', 'now'),
+           ('tx-future', 'cur', TIMESTAMP '2029-02-01 00:00:00', TIMESTAMP '2029-02-01 00:00:00', 'writeoff')`,
+      );
+      await client.query(
+        `INSERT INTO ${rawSchema}.prices
+           (guid, commodity_guid, currency_guid, date, value_num, value_denom)
+         VALUES ('p1', 'stk', 'cur', TIMESTAMP '2026-04-15 00:00:00', 100, 1)`,
+      );
+    } finally {
+      await client.end();
+    }
+  });
+
+  afterAll(drop);
+
+  it("wraps TIMESTAMP columns with TO_CHAR so the client sees compact YYYYMMDDHHmmss", async () => {
+    const res = await dumpPOST(
+      jsonRequest("http://local/api/pg/book/dump", {
+        connection,
+        schema: rawSchema,
+      }),
+    );
+    expect(res.status).toBe(200);
+
+    const buf = Buffer.from(await res.arrayBuffer());
+    const decompressed = await new Response(
+      new Blob([new Uint8Array(buf)]).stream().pipeThrough(
+        new DecompressionStream("gzip"),
+      ),
+    ).arrayBuffer();
+    const payload = JSON.parse(new TextDecoder().decode(decompressed)) as {
+      tables: {
+        transactions: { guid: string; post_date: string; enter_date: string }[];
+        prices: { guid: string; date: string }[];
+      };
+    };
+
+    const txns = payload.tables.transactions;
+    const now = txns.find((t) => t.guid === "tx-now");
+    const future = txns.find((t) => t.guid === "tx-future");
+    expect(now?.post_date).toBe("20260415103000");
+    expect(now?.enter_date).toBe("20260415103000");
+    expect(future?.post_date).toBe("20290201000000");
+    expect(future?.enter_date).toBe("20290201000000");
+
+    // Prices.date must also land in compact form — it feeds `sqlMonth` too.
+    expect(payload.tables.prices[0]?.date).toBe("20260415000000");
+
+    // And the shape the chart code would see must round-trip through
+    // `substr(col, 1, 4) || '-' || substr(col, 5, 2)` to produce a valid
+    // YYYY-MM string (not "2026--0").
+    const month = `${now!.post_date.substring(0, 4)}-${now!.post_date.substring(4, 6)}`;
+    expect(month).toBe("2026-04");
+  });
+});

--- a/app/src/app/api/pg/book/dump/route.ts
+++ b/app/src/app/api/pg/book/dump/route.ts
@@ -9,6 +9,32 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
+ * Columns that carry GnuCash-format dates. The gnudash-managed schema stores
+ * these as TEXT in the compact `YYYYMMDDHHmmss` shape the engine expects, but
+ * real GnuCash Postgres schemas (the read-only interop path) declare them as
+ * native TIMESTAMP / DATE columns. When we encounter the latter, we format on
+ * the server via `TO_CHAR(col, 'YYYYMMDDHH24MISS')` so the client cache ends
+ * up with the compact form regardless of source — see issue #97 for the bug
+ * this guards against (corrupted month strings like `2026--0` cascading into
+ * every chart).
+ *
+ * Mirrors the list in `app/api/pg/book/import/route.ts` → `normaliseDatesToCompact`.
+ */
+const DATE_COLUMNS_BY_TABLE: Record<string, readonly string[]> = {
+  transactions: ["post_date", "enter_date"],
+  prices: ["date"],
+  schedxactions: ["start_date", "end_date", "last_occur"],
+  recurrences: ["recurrence_period_start"],
+};
+
+/** Postgres data_type values that need TO_CHAR normalisation. */
+const NATIVE_DATE_TYPES = new Set([
+  "date",
+  "timestamp without time zone",
+  "timestamp with time zone",
+]);
+
+/**
  * Accepts either a gnudash-managed `bookId` (the default flow) or a raw
  * `schema` for the existing-GnuCash-DB read-only interop path. Exactly one
  * must be supplied; see `resolveSchemaName` for validation.
@@ -89,12 +115,30 @@ export async function POST(request: Request) {
       );
       const existingTables = new Set(existing.rows.map((r) => r.table_name));
 
+      // One shot for every column in every table we're about to dump, so we
+      // can detect native TIMESTAMP/DATE columns and format them to compact
+      // form without a round-trip per table.
+      const columnTypes = await client.query<{
+        table_name: string;
+        column_name: string;
+        data_type: string;
+      }>(
+        `SELECT table_name, column_name, data_type FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name = ANY($2::text[])`,
+        [schema, [...GNUCASH_POSTGRES_TABLES]],
+      );
+      const typeByTableCol = new Map<string, string>();
+      for (const row of columnTypes.rows) {
+        typeByTableCol.set(`${row.table_name}.${row.column_name}`, row.data_type);
+      }
+
       const tables: DumpPayload["tables"] = {};
       for (const table of GNUCASH_POSTGRES_TABLES) {
         if (!existingTables.has(table)) continue;
         // Explicit schema-qualified name in case search_path was clobbered.
         const qualified = `${schema}.${table}`;
-        const res = await client.query(`SELECT * FROM ${qualified}`);
+        const selectList = buildSelectList(table, typeByTableCol);
+        const res = await client.query(`SELECT ${selectList} FROM ${qualified}`);
         tables[table] = res.rows;
       }
       return { version: 1 as const, tables };
@@ -117,6 +161,67 @@ export async function POST(request: Request) {
       { status: 502, headers: { "content-type": "application/json" } },
     );
   }
+}
+
+/**
+ * Build the `SELECT` column list for a table. Known date columns that are
+ * declared as a native Postgres date/timestamp type are wrapped with
+ * `TO_CHAR(..., 'YYYYMMDDHH24MISS')` so they arrive at the client in the
+ * compact form the engine parses; everything else is selected with `*` via a
+ * wildcard emitted when no wrapping is required.
+ *
+ * Returns the raw SELECT fragment (either `*` or an explicit column list).
+ */
+function buildSelectList(
+  table: string,
+  typeByTableCol: Map<string, string>,
+): string {
+  const dateCols = DATE_COLUMNS_BY_TABLE[table];
+  if (!dateCols) return "*";
+
+  const nativeDateCols = dateCols.filter((col) => {
+    const type = typeByTableCol.get(`${table}.${col}`);
+    return type !== undefined && NATIVE_DATE_TYPES.has(type);
+  });
+  if (nativeDateCols.length === 0) return "*";
+
+  // Cast to timestamp before TO_CHAR so one formatter handles DATE,
+  // TIMESTAMP, and TIMESTAMPTZ uniformly. For TIMESTAMPTZ the cast uses the
+  // session timezone — matches how GnuCash desktop renders these dates to
+  // the user and how the import route's REPLACE-based normaliser handles
+  // legacy TEXT values. DATE columns get `000000` for the time portion.
+  const wrapped = nativeDateCols.map(
+    (col) => `TO_CHAR(${col}::timestamp, 'YYYYMMDDHH24MISS') AS ${col}`,
+  );
+  // Exclude the raw columns from `*` so we don't emit two rows with the same
+  // key (Postgres tolerates duplicate output column names but node-postgres
+  // would overwrite one with the other in the row object — order-dependent).
+  const excludeCols = new Set(nativeDateCols);
+  const remainingWildcard = buildWildcardExcluding(
+    table,
+    typeByTableCol,
+    excludeCols,
+  );
+  return [...wrapped, remainingWildcard].filter(Boolean).join(", ");
+}
+
+/**
+ * Emit a column list containing every column of `table` except those in
+ * `exclude`. Used when some columns of a table need TO_CHAR wrapping and the
+ * rest should pass through unchanged — we can't use `*` alongside aliased
+ * copies of the excluded columns without producing duplicates.
+ */
+function buildWildcardExcluding(
+  table: string,
+  typeByTableCol: Map<string, string>,
+  exclude: Set<string>,
+): string {
+  const cols: string[] = [];
+  for (const key of typeByTableCol.keys()) {
+    const [t, c] = key.split(".", 2);
+    if (t === table && !exclude.has(c)) cols.push(c);
+  }
+  return cols.join(", ");
 }
 
 async function gzipString(str: string): Promise<Uint8Array> {

--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -179,7 +179,11 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
                     if (typeof label !== "string") return label;
                     const [y, m] = label.split("-");
                     const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
-                    return `${months[parseInt(m) - 1]} ${y}`;
+                    // Fall back to the raw label if the month segment doesn't
+                    // parse (e.g. malformed YYYY-MM from upstream). Avoids
+                    // rendering "undefined YYYY" when the input is garbage.
+                    const name = months[parseInt(m) - 1];
+                    return name ? `${name} ${y}` : label;
                   }}
                   contentStyle={{
                     backgroundColor: "var(--popover)",

--- a/app/src/components/sankey/sankey-echarts.tsx
+++ b/app/src/components/sankey/sankey-echarts.tsx
@@ -74,6 +74,16 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
   const effectiveScale = autoScale * zoom;
   const visibleHeight = idealHeight * effectiveScale;
 
+  // The CSS `transform: scale(effectiveScale)` on the inner container shrinks
+  // every child proportionally — including SVG labels. When autoScale < 1
+  // (common at HD-ready resolutions where containerHeight < idealHeight), a
+  // 12px base label renders at effective ~6px and becomes unreadable. Compute
+  // a pre-inflated base so that after the CSS scale it lands back at ~12px.
+  // Only compensate for autoScale, not user-driven `zoom` — zoom should scale
+  // visibly, which is the whole point of it.
+  const LABEL_BASE_PX = 12;
+  const compensatedLabelFontSize = Math.ceil(LABEL_BASE_PX / autoScale);
+
   const exportImage = useCallback(
     (format: "png" | "svg") => {
       const instance = chartRef.current?.getEchartsInstance();
@@ -115,6 +125,13 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
     tooltip: {
       trigger: "item",
       triggerOn: "mousemove",
+      // Render the tooltip as a body-level element so the parent container's
+      // CSS `transform: scale(...)` doesn't shrink it along with the chart
+      // (issue #97 — tooltip became unreadable at HD-ready where autoScale
+      // drops below ~0.5).
+      appendToBody: true,
+      textStyle: { fontSize: 13 },
+      extraCssText: "font-size: 13px; line-height: 1.4;",
       formatter: (params: Record<string, unknown>) => {
         const d = params.data as Record<string, unknown> | undefined;
         if (!d) return "";
@@ -153,7 +170,7 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
           curveness: 0.5,
         },
         label: {
-          fontSize: 12,
+          fontSize: compensatedLabelFontSize,
           fontFamily: "Inter, system-ui, sans-serif",
           color: "#6F767E",
           formatter: (params: { data?: { label?: string; name?: string }; value?: number }) => {


### PR DESCRIPTION
## Summary
- Detect native TIMESTAMP/DATE columns in the source Postgres schema and wrap them with `TO_CHAR(col::timestamp, 'YYYYMMDDHH24MISS')` in the dump SELECT, so the engine's compact-string SQL helpers (`sqlMonth`, `sqlYear`) keep working against real GnuCash databases on the read-only interop path. TEXT date columns in the gnudash-managed schema pass through unchanged.
- Compensate the Sankey chart's CSS-scale fallback by pre-inflating label font size by `1/autoScale`, and lift the tooltip out of the scaled container via `appendToBody` so it stays readable at HD-ready resolutions where `autoScale` drops to ~0.5.
- Defensive fallback in the Cash Flow tooltip so a malformed YYYY-MM label renders the raw string instead of `undefined YYYY`.

## Root cause (issue #97)
Real GnuCash PG stores `transactions.post_date`, `transactions.enter_date`, `prices.date`, `schedxactions.*_date/last_occur`, and `recurrences.recurrence_period_start` as native `TIMESTAMP`. node-postgres serialises those to ISO strings like `"2026-04-15 10:30:00"`, which the dump route was piping straight into the local SQLite WASM cache. The engine's month extractor uses `substr(col, 1, 4) || '-' || substr(col, 5, 2)` (designed for compact `YYYYMMDDHHmmss`), which on an ISO string returns `"2026--0"`. That cascaded into:
- Net Worth "Last 12 Months" misbehaving — no months in the series matched the relative-period filter.
- "This Year" and spending overview showing zero — `getMonthsForPeriod` generated `["2026-01", ...]` which never matched `"2026--0"` keys.
- Cash Flow tooltip rendering `undefined 2026` — `parseInt("")` → `NaN`, `months[NaN-1]` → `undefined`.
- "Shows nothing unless All Time" on the standalone Sankey tab — same filter mismatch.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `npm test` — 239 passed, 12 skipped (PG integration suite; no local PG).
- [x] `npx eslint` on touched files — clean.
- [ ] Start a local PG (`docker compose up -d postgres`) and run `npm test` — the new "dump route: read-only interop date normalisation" suite creates a schema with native TIMESTAMP columns plus a 2029 future-dated row and asserts the dump emits compact `YYYYMMDDHHmmss`.
- [ ] Manual: reconnect to a real GnuCash PG with future-dated transactions and confirm Net Worth / Income Overview / Spending Overview / Income-Expense Flow all render for relative periods, tooltip shows month name instead of `undefined`.
- [ ] Manual at 1366×768: Sankey labels and tooltip readable without zoom.

Closes #97