### PR TITLE
Fix EXDEV on container builds + document Podman parity (closes #101)

### DIFF
--- a/app/scripts/next-build.mjs
+++ b/app/scripts/next-build.mjs
@@ -10,9 +10,23 @@
  * using the same `NEXT_OUTPUT=export npm run build` command from PR 1 / the
  * deployment guide without having to know about this script.
  */
-import { existsSync, renameSync } from "node:fs";
+import { existsSync, renameSync, cpSync, rmSync } from "node:fs";
 import { spawn } from "node:child_process";
 import { platform } from "node:os";
+
+// Docker overlayfs returns EXDEV when renaming a path that lives in a lower
+// (read-only) layer to a destination that has to be created in the upper
+// layer — see issue #101. Fall back to copy-then-remove on EXDEV; keep the
+// atomic rename on host filesystems where it works.
+const moveDir = (src, dest) => {
+  try {
+    renameSync(src, dest);
+  } catch (err) {
+    if (err.code !== "EXDEV") throw err;
+    cpSync(src, dest, { recursive: true });
+    rmSync(src, { recursive: true, force: true });
+  }
+};
 
 // Park OUTSIDE src/app/ — Next scans every descendant for route handlers
 // regardless of folder name, so hiding under src/app/ is not enough.
@@ -28,13 +42,13 @@ process.env.NEXT_PUBLIC_HAS_SERVER_BACKEND = shouldPark ? "false" : "true";
 
 let parked = false;
 if (shouldPark && existsSync(API_DIR)) {
-  renameSync(API_DIR, PARKED_DIR);
+  moveDir(API_DIR, PARKED_DIR);
   parked = true;
 }
 
 const restore = () => {
   if (parked && existsSync(PARKED_DIR)) {
-    renameSync(PARKED_DIR, API_DIR);
+    moveDir(PARKED_DIR, API_DIR);
     parked = false;
   }
 };

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,6 +108,8 @@ docker run -p 8080:80 --restart unless-stopped gnudash
 
 Open [http://localhost:8080](http://localhost:8080). Change `-p 8080:80` to remap the host port; `80` inside the container is fixed.
 
+**Podman / Buildah / Kaniko:** drop-in. Substitute `podman build .` / `podman run …` for the docker commands above; the same `Dockerfile` is used. The build script tolerates overlay filesystems that return `EXDEV` on cross-layer renames (common under rootless Podman with `fuse-overlayfs`), so no extra flags are needed.
+
 ### Docker Compose
 
 Minimal compose for just the Local-mode nginx container (distinct from the `docker-compose.yml` at the repo root, which is for Server mode):


### PR DESCRIPTION
## Summary

- `app/scripts/next-build.mjs` now falls back to `cpSync` + `rmSync` when `renameSync` fails with `EXDEV`, so the api-dir park step survives container builds where overlayfs (Docker overlay2 in some configs, rootless Podman with `fuse-overlayfs`, Kaniko, etc.) refuses cross-layer renames. Host builds keep the atomic-rename fast path — the copy fallback only kicks in when the kernel forces it.
- `docs/deployment.md` §1.2 picks up a one-line note that Podman / Buildah / Kaniko are drop-in replacements for the docker commands and that the EXDEV case is already handled, so users on non-Docker engines don't have to guess.

Closes #101.

## Test plan

- [ ] `cd app && NEXT_OUTPUT=export npm run build` on macOS host — atomic rename path, exit 0, `app/api` restored.
- [ ] `docker build -t gnudash .` from repo root on a Linux host — build completes through `[build 6/6]` and the final nginx image runs.
- [ ] `podman build -t gnudash .` (rootless, default `fuse-overlayfs`) — same, confirms the EXDEV fallback fires without breaking the build.
- [ ] Sanity-check that `src/app/api` is restored after a failed build (Ctrl-C during `next build`).