### PR TITLE
Default next build to webpack to fix Turbopack container panic (closes #103)

### DIFF
--- a/app/scripts/next-build.mjs
+++ b/app/scripts/next-build.mjs
@@ -51,9 +51,21 @@ process.on("SIGTERM", () => {
   process.exit(143);
 });
 
+// Bundler selection: Next.js 16 defaults `next build` to Turbopack, but it
+// panics inside containerised builds (issue #103) — the PostCSS worker spawns
+// a child Node process and times out at the hard-coded 30s connect deadline,
+// most reliably under rootless Podman / fuse-overlayfs and arm64 emulation.
+// Webpack does not have that worker model and finishes cleanly. Default to
+// webpack so `docker build` / `podman build` work out of the box; let power
+// users who want Turbopack's speed opt back in with NEXT_BUILDER=turbopack.
+const buildArgs = ["build"];
+if (process.env.NEXT_BUILDER !== "turbopack") {
+  buildArgs.push("--webpack");
+}
+
 // Invoke next via the local bin. `shell: true` on Windows picks the right
 // extension (.cmd vs .ps1); Unix shells resolve `next` via PATH already.
-const child = spawn("next", ["build"], {
+const child = spawn("next", buildArgs, {
   stdio: "inherit",
   shell: platform() === "win32",
 });

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -96,6 +96,8 @@ NEXT_OUTPUT=export npm run build
 
 The `NEXT_OUTPUT=export` flag is required — without it the build produces the standalone Node.js bundle for the Server version, which static hosts can't serve. The build wrapper (`scripts/next-build.mjs`) also hides the Server tab from the upload screen in this mode so users don't hit a tab whose Connect button would 404.
 
+**Bundler:** the wrapper passes `--webpack` to `next build` by default. Next.js 16's Turbopack builder panics inside container builds (PostCSS worker IPC times out at 30s, most reliably under rootless Podman / fuse-overlayfs and arm64). To opt back in to Turbopack on a host where it works, set `NEXT_BUILDER=turbopack npm run build`.
+
 ## 1.2 Docker (nginx — recommended)
 
 Included `Dockerfile` (repo root) does the build + nginx packaging with COOP/COEP pre-configured. Build from the **repo root**, not `app/` — the Dockerfile pins `NEXT_OUTPUT=export` and expects the whole repo as its build context:


### PR DESCRIPTION
## Summary

- `app/scripts/next-build.mjs` now passes `--webpack` to `next build` by default. Next.js 16 made Turbopack the default builder, but the PostCSS worker it spawns fails to connect within the hard-coded 30s IPC deadline inside container builds — most reliably under rootless Podman / fuse-overlayfs on arm64 (issue #103). Webpack doesn't use that worker model and finishes cleanly.
- `NEXT_BUILDER=turbopack npm run build` opts back in for hosts where Turbopack works (faster local builds on macOS/x86 Linux).
- `docs/deployment.md` §1.1 documents the bundler default + opt-in env var so this isn't surprise behaviour.

The api-park flow, EXDEV fallback (PR #104), and standalone vs. export targeting are all unchanged.

Closes #103.

## Test plan

- [x] `cd app && NEXT_OUTPUT=export npm run build` on macOS — builds via `(webpack)`, completes static export, `app/api` restored, no `.api-parked-for-export` left behind.
- [x] `cd app && npm run build` (standalone, default) on macOS — builds via `(webpack)`, `/api/pg/*` routes show as ƒ (Dynamic) in the route table.
- [ ] `podman build -t gnudash:v5 -f Dockerfile.standalone .` on arm64 Debian 13 — gets past `[1/2] STEP 6/6: RUN npm run build` (the failing step in #103) and produces a runnable image. (Reporter scolbeck to confirm.)
- [ ] `NEXT_BUILDER=turbopack npm run build` on a host where Turbopack works — builds via `(Turbopack)`, confirms the opt-in path.