### PR TITLE
Coerce BigInts in the writable WASM adapter (closes #102)

### DIFF
--- a/app/src/lib/gnucash/db/bigint-coerce.ts
+++ b/app/src/lib/gnucash/db/bigint-coerce.ts
@@ -1,0 +1,22 @@
+/**
+ * SQLite WASM returns int64 column values as JavaScript `BigInt` whenever the
+ * underlying value exceeds Number.MAX_SAFE_INTEGER, which causes downstream
+ * arithmetic (Number * BigInt, Number + BigInt, …) to throw "can't convert
+ * BigInt to number". The whole engine treats integer columns as `number`, so
+ * coerce at the adapter boundary instead of audit-trailing every caller.
+ *
+ * Both the read-only (`wasm-adapter.ts`) and writable (`engine/db/
+ * writable-wasm-adapter.ts`) WASM adapters import this helper — keep it as
+ * the single source of truth so a future adapter can't silently miss the
+ * conversion (see issue #102, which regressed exactly that way).
+ */
+export function coerceBigInts(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
+  for (const key in obj) {
+    if (typeof obj[key] === "bigint") {
+      obj[key] = Number(obj[key]);
+    }
+  }
+  return obj;
+}

--- a/app/src/lib/gnucash/db/wasm-adapter.ts
+++ b/app/src/lib/gnucash/db/wasm-adapter.ts
@@ -4,15 +4,7 @@
  */
 import type { Database as WasmDatabase, BindingSpec } from "@sqlite.org/sqlite-wasm";
 import type { DbAdapter, PreparedQuery } from "./adapter";
-
-function coerceBigInts(obj: Record<string, unknown>): Record<string, unknown> {
-  for (const key in obj) {
-    if (typeof obj[key] === "bigint") {
-      obj[key] = Number(obj[key]);
-    }
-  }
-  return obj;
-}
+import { coerceBigInts } from "./bigint-coerce";
 
 export function createWasmAdapter(db: WasmDatabase): DbAdapter {
   return {

--- a/app/src/lib/gnucash/engine/db/writable-wasm-adapter.ts
+++ b/app/src/lib/gnucash/engine/db/writable-wasm-adapter.ts
@@ -1,4 +1,5 @@
 import type { PreparedQuery } from "../../db/adapter";
+import { coerceBigInts } from "../../db/bigint-coerce";
 import type { WritableDbAdapter, RunResult } from "./writable-adapter";
 
 /**
@@ -52,11 +53,14 @@ export function createWritableWasmAdapter(
       return {
         all(...params: unknown[]): unknown[] {
           const bind = params.length > 0 ? (params as unknown[]) : undefined;
-          return db.selectObjects(sql, bind);
+          return db
+            .selectObjects(sql, bind)
+            .map((row) => coerceBigInts(row as Record<string, unknown>));
         },
         get(...params: unknown[]): unknown | undefined {
           const bind = params.length > 0 ? (params as unknown[]) : undefined;
-          return db.selectObject(sql, bind);
+          const row = db.selectObject(sql, bind);
+          return row ? coerceBigInts(row as Record<string, unknown>) : undefined;
         },
       };
     },


### PR DESCRIPTION
## Summary

The BigInt-to-Number coercion from #18 lives on the read-only WASM adapter only (`app/src/lib/gnucash/db/wasm-adapter.ts`). The v4 engine's parallel writable adapter (`app/src/lib/gnucash/engine/db/writable-wasm-adapter.ts`, added two days earlier in commit 5883d68) calls `selectObjects` / `selectObject` directly with no coercion. After the OPFS migration, the worker opens OPFS-backed sessions in writable mode by default so inline edits work — so the unpatched path is now what large-file imports go through, and the "can't convert BigInt to number" error is back.

This PR:

- Extracts `coerceBigInts` into `app/src/lib/gnucash/db/bigint-coerce.ts` as the single source of truth.
- Wires it into both the read-only adapter (preserving existing behaviour) and the writable adapter (fixing the regression).

The shared helper exists specifically so the next adapter we add can't silently miss the conversion the same way.

Closes #102.

## Test plan

- [x] `npx tsc --noEmit` clean.
- [x] `npm test` — 239 passed / 12 skipped, including the 102 engine tests that exercise the writable adapter.
- [ ] Reporter (wrd2093) to re-pull and confirm a large `.gnucash` file now loads end-to-end without the BigInt error.