### PR TITLE
Saving rate Adding

### DIFF
--- a/app/next.config.ts
+++ b/app/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import path from "path";
 
 // Default build target is the standalone Node.js server, which the Postgres
 // backend (issue #48) needs for its API routes. Set `NEXT_OUTPUT=export` at
@@ -25,6 +26,14 @@ const nextConfig: NextConfig = {
   // "Too many open files" with Turbopack, increase your OS file descriptor
   // limit instead (see docs/deployment.md).
   webpack: (config) => {
+    // Ensure module resolution always includes this app's dependencies,
+    // even when tooling is started from the repository root.
+    config.resolve = config.resolve ?? {};
+    config.resolve.modules = [
+      ...(config.resolve.modules ?? []),
+      path.resolve(__dirname, "node_modules"),
+    ];
+
     config.watchOptions = {
       ...config.watchOptions,
       ignored: ["**/__tests__/**", "**/__snapshots__/**", "**/fixtures/**"],

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -184,55 +184,52 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
     [activeCashFlow, period, customRange],
   );
 
-  const netWorthMap = useMemo(() => {
-    const map = new Map<string, number>();
-    for (const row of data?.netWorthSeries ?? []) map.set(row.month, row.netWorth);
+  // Outflows to asset/investment accounts are savings, not spending
+  const topLevelTypeMap = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const acc of data?.accounts ?? []) map.set(acc.name, acc.type);
     return map;
   }, [data]);
 
+  const SAVINGS_TYPES = new Set(["ASSET", "STOCK", "MUTUAL"]);
+
   const chartData = useMemo(() => {
-    // Aggregate inflow/outflow by month
-    const monthMap = new Map<string, { inflow: number; outflow: number }>();
+    const monthMap = new Map<string, { inflow: number; outflow: number; spendingOutflow: number }>();
     for (const row of activeInflow) {
       if (!validMonths.has(row.month)) continue;
-      const entry = monthMap.get(row.month) ?? { inflow: 0, outflow: 0 };
+      const entry = monthMap.get(row.month) ?? { inflow: 0, outflow: 0, spendingOutflow: 0 };
       entry.inflow += row.amount;
       monthMap.set(row.month, entry);
     }
     for (const row of activeOutflow) {
       if (!validMonths.has(row.month)) continue;
-      const entry = monthMap.get(row.month) ?? { inflow: 0, outflow: 0 };
+      const entry = monthMap.get(row.month) ?? { inflow: 0, outflow: 0, spendingOutflow: 0 };
       entry.outflow += row.amount;
+      if (!SAVINGS_TYPES.has(topLevelTypeMap.get(row.pathParts[0]) ?? ""))
+        entry.spendingOutflow += row.amount;
       monthMap.set(row.month, entry);
     }
     return [...monthMap.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([month, { inflow, outflow }]) => {
-        const prevMonth = prevCalMonth(month);
-        const nw = netWorthMap.get(month);
-        const nwPrev = netWorthMap.get(prevMonth);
-        const savingsRate =
-          inflow > 0 && nw !== undefined && nwPrev !== undefined
-            ? Math.max(-100, Math.min(100, ((nw - nwPrev) / inflow) * 100))
-            : null;
-        return { month, inflow, outflow, net: inflow - outflow, savingsRate };
-      });
-  }, [activeInflow, activeOutflow, validMonths, netWorthMap]);
+      .map(([month, { inflow, outflow, spendingOutflow }]) => ({
+        month,
+        inflow,
+        outflow,
+        spendingOutflow,
+        net: inflow - outflow,
+        savingsRate: inflow > 0 ? Math.max(-100, Math.min(100, ((inflow - spendingOutflow) / inflow) * 100)) : null,
+      }));
+  }, [activeInflow, activeOutflow, validMonths, topLevelTypeMap]);
 
   if (!data || chartData.length === 0) return null;
 
   const currency = data.currency;
   const totalNet = chartData.reduce((s, d) => s + d.net, 0);
   const totalInflow = chartData.reduce((s, d) => s + d.inflow, 0);
-  const totalSavingsRate = (() => {
-    const months = chartData.map((d) => d.month).sort();
-    const firstMonth = months[0];
-    const lastMonth = months[months.length - 1];
-    const nwEnd = netWorthMap.get(lastMonth);
-    const nwStart = netWorthMap.get(prevCalMonth(firstMonth));
-    if (totalInflow <= 0 || nwEnd === undefined || nwStart === undefined) return null;
-    return Math.max(-100, Math.min(100, ((nwEnd - nwStart) / totalInflow) * 100));
-  })();
+  const totalSpendingOutflow = chartData.reduce((s, d) => s + d.spendingOutflow, 0);
+  const totalSavingsRate = totalInflow > 0
+    ? Math.max(-100, Math.min(100, ((totalInflow - totalSpendingOutflow) / totalInflow) * 100))
+    : null;
 
   return (
     <Card className="shadow-sm border-[#EFEFEF]">

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -237,12 +237,9 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
   return (
     <Card className="shadow-sm border-[#EFEFEF]">
       <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <div>
-          <CardTitle className="text-lg font-semibold text-[#1A1D1F]">
-            Monthly Cash Flow
-          </CardTitle>
-          <p className="text-xs text-[#9A9FA5]">Net cash flow</p>
-        </div>
+        <CardTitle className="text-lg font-semibold text-[#1A1D1F]">
+          Monthly Cash Flow
+        </CardTitle>
         <PeriodSelector
           period={period}
           labels={SANKEY_PERIOD_LABELS}

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -151,6 +151,11 @@ function CashFlowSankeySection({ filters }: { filters: SankeyFilterState }) {
 
 // ── Monthly Cash Flow Bar Chart ─────────────────────────────────────
 
+function prevCalMonth(month: string): string {
+  const [y, m] = month.split("-").map(Number);
+  return m === 1 ? `${y - 1}-12` : `${y}-${String(m - 1).padStart(2, "0")}`;
+}
+
 function formatMonthLabel(month: string): string {
   const [year, m] = month.split("-");
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -250,8 +250,8 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
         </div>
 
         {chartData.length > 1 ? (
-          <div className="h-[220px]">
-            <ResponsiveContainer width="100%" height="100%">
+          <div className="h-[220px] w-full min-w-0">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
               <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
                 <XAxis

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -253,11 +253,19 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
         />
       </CardHeader>
       <CardContent>
-        <div className="mb-1">
+        <div className="mb-1 flex items-baseline gap-3">
           <span className="text-3xl font-bold tracking-tight text-[#1A1D1F]" data-v>
             {formatCurrency(totalNet, currency)}
           </span>
+          {totalSavingsRate !== null && (
+            <span className={`text-lg font-semibold ${totalSavingsRate >= 0 ? "text-[#6C9B8B]" : "text-[#F87171]"}`}>
+              {totalSavingsRate >= 0 ? "+" : ""}{totalSavingsRate.toFixed(1)}%
+            </span>
+          )}
         </div>
+        {totalSavingsRate !== null && (
+          <p className="mb-1 text-xs text-[#9A9FA5]">savings rate</p>
+        )}
 
         <div className="mb-4 flex items-center gap-5">
           <div className="flex items-center gap-1.5">

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -250,19 +250,22 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
         />
       </CardHeader>
       <CardContent>
-        <div className="mb-1 flex items-baseline gap-3">
-          <span className="text-3xl font-bold tracking-tight text-[#1A1D1F]" data-v>
-            {formatCurrency(totalNet, currency)}
-          </span>
-          {totalSavingsRate !== null && (
-            <span className={`text-lg font-semibold ${totalSavingsRate >= 0 ? "text-[#6C9B8B]" : "text-[#F87171]"}`}>
-              {totalSavingsRate >= 0 ? "+" : ""}{totalSavingsRate.toFixed(1)}%
+        <div className="mb-4 flex gap-8">
+          <div>
+            <p className="text-xs text-[#9A9FA5]">Net cash flow</p>
+            <span className="text-3xl font-bold tracking-tight text-[#1A1D1F]" data-v>
+              {formatCurrency(totalNet, currency)}
             </span>
+          </div>
+          {totalSavingsRate !== null && (
+            <div>
+              <p className="text-xs text-[#9A9FA5]">Savings rate</p>
+              <span className={`text-3xl font-bold tracking-tight ${totalSavingsRate >= 0 ? "text-[#6C9B8B]" : "text-[#F87171]"}`} data-v>
+                {totalSavingsRate >= 0 ? "+" : ""}{totalSavingsRate.toFixed(1)}%
+              </span>
+            </div>
           )}
         </div>
-        {totalSavingsRate !== null && (
-          <p className="mb-1 text-xs text-[#9A9FA5]">savings rate</p>
-        )}
 
         <div className="mb-4 flex items-center gap-5">
           <div className="flex items-center gap-1.5">

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -184,6 +184,12 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
     [activeCashFlow, period, customRange],
   );
 
+  const netWorthMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const row of data?.netWorthSeries ?? []) map.set(row.month, row.netWorth);
+    return map;
+  }, [data]);
+
   const chartData = useMemo(() => {
     // Aggregate inflow/outflow by month
     const monthMap = new Map<string, { inflow: number; outflow: number }>();

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -280,6 +280,10 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
             <div className="h-0.5 w-4 border-t-2 border-dashed border-[#1A1D1F]" />
             <span className="text-xs text-[#6F767E]">Net</span>
           </div>
+          <div className="flex items-center gap-1.5">
+            <div className="h-0.5 w-4 border-t-2 border-solid border-[#6C9B8B]" />
+            <span className="text-xs text-[#6F767E]">Savings rate</span>
+          </div>
         </div>
 
         {chartData.length > 1 ? (

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -223,6 +223,16 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
 
   const currency = data.currency;
   const totalNet = chartData.reduce((s, d) => s + d.net, 0);
+  const totalInflow = chartData.reduce((s, d) => s + d.inflow, 0);
+  const totalSavingsRate = (() => {
+    const months = chartData.map((d) => d.month).sort();
+    const firstMonth = months[0];
+    const lastMonth = months[months.length - 1];
+    const nwEnd = netWorthMap.get(lastMonth);
+    const nwStart = netWorthMap.get(prevCalMonth(firstMonth));
+    if (totalInflow <= 0 || nwEnd === undefined || nwStart === undefined) return null;
+    return Math.max(-100, Math.min(100, ((nwEnd - nwStart) / totalInflow) * 100));
+  })();
 
   return (
     <Card className="shadow-sm border-[#EFEFEF]">

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -207,13 +207,17 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
     }
     return [...monthMap.entries()]
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([month, { inflow, outflow }]) => ({
-        month,
-        inflow,
-        outflow,
-        net: inflow - outflow,
-      }));
-  }, [activeInflow, activeOutflow, validMonths]);
+      .map(([month, { inflow, outflow }]) => {
+        const prevMonth = prevCalMonth(month);
+        const nw = netWorthMap.get(month);
+        const nwPrev = netWorthMap.get(prevMonth);
+        const savingsRate =
+          inflow > 0 && nw !== undefined && nwPrev !== undefined
+            ? Math.max(-100, Math.min(100, ((nw - nwPrev) / inflow) * 100))
+            : null;
+        return { month, inflow, outflow, net: inflow - outflow, savingsRate };
+      });
+  }, [activeInflow, activeOutflow, validMonths, netWorthMap]);
 
   if (!data || chartData.length === 0) return null;
 

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -287,7 +287,7 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
         </div>
 
         {chartData.length > 1 ? (
-          <div className="h-[220px] w-full min-w-0">
+          <div className="h-55 w-full min-w-0">
             <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
               <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
@@ -299,17 +299,31 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
                   tickLine={false}
                 />
                 <YAxis
+                  yAxisId="amount"
                   tickFormatter={(v) => formatCurrencyShort(v, currency)}
                   tick={{ fontSize: 11, fill: "#9A9FA5" }}
                   axisLine={false}
                   tickLine={false}
                   width={50}
                 />
+                <YAxis
+                  yAxisId="rate"
+                  orientation="right"
+                  domain={[-100, 100]}
+                  tickFormatter={(v: number) => `${v.toFixed(0)}%`}
+                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  axisLine={false}
+                  tickLine={false}
+                  width={36}
+                />
                 <Tooltip
-                  formatter={(value, name) => [
-                    formatCurrency(Number(value), currency),
-                    String(name).charAt(0).toUpperCase() + String(name).slice(1),
-                  ]}
+                  formatter={(value, name) => {
+                    if (name === "savingsRate") return [`${Number(value).toFixed(1)}%`, "Savings rate"];
+                    return [
+                      formatCurrency(Number(value), currency),
+                      String(name).charAt(0).toUpperCase() + String(name).slice(1),
+                    ];
+                  }}
                   labelFormatter={(label) => {
                     if (typeof label !== "string") return label;
                     const [y, m] = label.split("-");
@@ -323,9 +337,10 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
                     fontSize: "13px",
                   }}
                 />
-                <Bar dataKey="inflow" fill="#3B6B8A" radius={[3, 3, 0, 0]} barSize={14} />
-                <Bar dataKey="outflow" fill="#F87171" radius={[3, 3, 0, 0]} barSize={14} />
-                <Line type="monotone" dataKey="net" stroke="#1A1D1F" strokeWidth={2} strokeDasharray="6 4" dot={false} />
+                <Bar yAxisId="amount" dataKey="inflow" fill="#3B6B8A" radius={[3, 3, 0, 0]} barSize={14} />
+                <Bar yAxisId="amount" dataKey="outflow" fill="#F87171" radius={[3, 3, 0, 0]} barSize={14} />
+                <Line yAxisId="amount" type="monotone" dataKey="net" stroke="#1A1D1F" strokeWidth={2} strokeDasharray="6 4" dot={false} />
+                <Line yAxisId="rate" type="monotone" dataKey="savingsRate" stroke="#6C9B8B" strokeWidth={2} dot={false} connectNulls />
               </ComposedChart>
             </ResponsiveContainer>
           </div>

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -364,6 +364,14 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
                 {formatCurrency(chartData[0]?.net ?? 0, currency)}
               </p>
             </div>
+            {totalSavingsRate !== null && (
+              <div className="flex-1 rounded-xl bg-[#F4F5F7] p-4">
+                <p className="text-xs text-[#9A9FA5]">Savings rate</p>
+                <p className={`mt-1 text-xl font-bold ${totalSavingsRate >= 0 ? "text-[#6C9B8B]" : "text-[#F87171]"}`} data-v>
+                  {totalSavingsRate >= 0 ? "+" : ""}{totalSavingsRate.toFixed(1)}%
+                </p>
+              </div>
+            )}
           </div>
         )}
       </CardContent>

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -151,11 +151,6 @@ function CashFlowSankeySection({ filters }: { filters: SankeyFilterState }) {
 
 // ── Monthly Cash Flow Bar Chart ─────────────────────────────────────
 
-function prevCalMonth(month: string): string {
-  const [y, m] = month.split("-").map(Number);
-  return m === 1 ? `${y - 1}-12` : `${y}-${String(m - 1).padStart(2, "0")}`;
-}
-
 function formatMonthLabel(month: string): string {
   const [year, m] = month.split("-");
   const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];

--- a/app/src/components/dashboard/charts/balance-pie.tsx
+++ b/app/src/components/dashboard/charts/balance-pie.tsx
@@ -128,7 +128,7 @@ export function BalancePie({
                 <p className="text-[11px] text-[#9A9FA5]">Total</p>
               </div>
               <div className="relative h-[180px] w-[180px]">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
                   <PieChart>
                     <Pie
                       data={pieData}

--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -152,8 +152,8 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
         </div>
 
         {showChart ? (
-          <div className="h-[220px]">
-            <ResponsiveContainer width="100%" height="100%">
+          <div className="h-[220px] w-full min-w-0">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
               <ComposedChart data={filtered} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
                 <XAxis

--- a/app/src/components/dashboard/charts/income-overview.tsx
+++ b/app/src/components/dashboard/charts/income-overview.tsx
@@ -229,7 +229,7 @@ export function IncomeOverview({ monthlyIncome, categoryColors, currency, linkTo
                 </p>
               </div>
               <div className="relative h-[180px] w-[180px]">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
                   <PieChart>
                     <Pie
                       data={pieData}

--- a/app/src/components/dashboard/charts/investment-performance.tsx
+++ b/app/src/components/dashboard/charts/investment-performance.tsx
@@ -107,8 +107,8 @@ export function InvestmentPerformance({ investments, currency }: InvestmentPerfo
         </div>
 
         {/* Chart */}
-        <div className="h-[280px]">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-[280px] w-full min-w-0">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
             <BarChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
               <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
               <XAxis

--- a/app/src/components/dashboard/charts/net-worth-chart.tsx
+++ b/app/src/components/dashboard/charts/net-worth-chart.tsx
@@ -204,8 +204,8 @@ export function NetWorthChart({ series, currentNetWorth, currency, externalPerio
           </div>
         )}
 
-        <div className="h-[200px]">
-          <ResponsiveContainer width="100%" height="100%">
+        <div className="h-[200px] w-full min-w-0">
+          <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
             <AreaChart data={filtered} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
               <defs>
                 <linearGradient id="netWorthGradient" x1="0" y1="0" x2="0" y2="1">

--- a/app/src/components/dashboard/charts/spending-overview.tsx
+++ b/app/src/components/dashboard/charts/spending-overview.tsx
@@ -314,7 +314,7 @@ export function SpendingOverview({ monthlyExpenses, categoryColors, currency, li
                 </p>
               </div>
               <div className="relative h-[180px] w-[180px]">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
                   <PieChart>
                     <Pie
                       data={pieData}

--- a/app/src/components/investment/allocation-pie.tsx
+++ b/app/src/components/investment/allocation-pie.tsx
@@ -104,7 +104,7 @@ export function AllocationPie({ items, currency, selectedTicker, onSelect, group
                 <p className="text-[11px] text-[#9A9FA5]">Total value</p>
               </div>
               <div className="relative h-[170px] w-[170px]">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
                   <PieChart>
                     <Pie
                       data={pieData}

--- a/app/src/components/investment/value-over-time-chart.tsx
+++ b/app/src/components/investment/value-over-time-chart.tsx
@@ -75,8 +75,8 @@ export function ValueOverTimeChart({ series, currency, selectedTicker }: ValueOv
         {chartData.length === 0 ? (
           <p className="py-8 text-center text-sm text-[#9A9FA5]">No data available</p>
         ) : (
-          <div className="h-[260px]">
-            <ResponsiveContainer width="100%" height="100%">
+          <div className="h-[260px] w-full min-w-0">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
               <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
                 <XAxis

--- a/app/src/components/spending/monthly-expense-bar-card.tsx
+++ b/app/src/components/spending/monthly-expense-bar-card.tsx
@@ -128,8 +128,8 @@ export function MonthlyExpenseBarCard({
         {barData.length === 0 ? (
           <p className="py-8 text-center text-sm text-[#9A9FA5]">No data for this period</p>
         ) : (
-          <div className="h-[260px]">
-            <ResponsiveContainer width="100%" height="100%">
+          <div className="h-[260px] w-full min-w-0">
+            <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
               <BarChart data={barData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
                 <XAxis

--- a/app/src/components/spending/spending-pie-card.tsx
+++ b/app/src/components/spending/spending-pie-card.tsx
@@ -173,7 +173,7 @@ export function SpendingPieCard({ monthlyExpenses, categoryColors, currency, tit
                 </p>
               </div>
               <div className="relative h-[180px] w-[180px]">
-                <ResponsiveContainer width="100%" height="100%">
+                <ResponsiveContainer width="100%" height="100%" minWidth={0} minHeight={1}>
                   <PieChart>
                     <Pie
                       data={pieData}


### PR DESCRIPTION
### Add savings rate to the Monthly Cash Flow card

Adds a savings rate metric to the Monthly Cash Flow card, both as a period summary and as a per-month line on the chart.
$Savings rate = (inflow − spending outflow) / inflow$

Outflows to `ASSET`, `STOCK`, and `MUTUAL` accounts are excluded from spending — money directed to investments is savings, not a cost. Only outflows to expense and liability accounts count as spending. The rate is clamped to [−100%, +100%].

#### UI changes
- Header: "Net cash flow" and "Savings rate" displayed side by side, each with its label above the value
- Chart (multi-month): green savings rate line on a dedicated right y-axis (−100% to +100%), with a matching legend entry
- Tooltip: savings rate shown as a percentage alongside the existing currency values
- Single-month fallback: a fourth summary card showing the savings rate
