### PR TITLE
Improve Sankey zoom and labels

### DIFF
--- a/app/src/components/sankey/sankey-echarts.tsx
+++ b/app/src/components/sankey/sankey-echarts.tsx
@@ -6,6 +6,7 @@ import * as echarts from "echarts/core";
 import { SankeyChart } from "echarts/charts";
 import { TooltipComponent } from "echarts/components";
 import { SVGRenderer, CanvasRenderer } from "echarts/renderers";
+import { Maximize2, Minimize2, Minus, Plus, RotateCcw } from "lucide-react";
 import type { EChartsSankeyData } from "@/lib/sankey-utils";
 import { formatCurrencyShort } from "@/lib/format";
 
@@ -15,6 +16,11 @@ const NODE_MIN_HEIGHT = 30;
 const NODE_GAP = 12;
 const PX_PER_NODE = NODE_MIN_HEIGHT + NODE_GAP + 16;
 const CHART_PADDING = 40;
+const ZOOM_MIN = 0.5;
+const ZOOM_MAX = 3;
+const ZOOM_STEP = 0.1;
+const MINOR_NODE_SHARE = 0.02;
+const MINOR_NODE_LIMIT = 10;
 
 function computeIdealHeight(data: EChartsSankeyData): number {
   const targetOf = new Set<string>();
@@ -43,6 +49,37 @@ function computeIdealHeight(data: EChartsSankeyData): number {
   return Math.max(400, maxNodesInColumn * PX_PER_NODE + CHART_PADDING);
 }
 
+function clampZoom(value: number): number {
+  return Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, value));
+}
+
+function computeNodeValues(data: EChartsSankeyData): Map<string, number> {
+  const incoming = new Map<string, number>();
+  const outgoing = new Map<string, number>();
+
+  for (const link of data.links) {
+    outgoing.set(link.source, (outgoing.get(link.source) ?? 0) + link.value);
+    incoming.set(link.target, (incoming.get(link.target) ?? 0) + link.value);
+  }
+
+  const values = new Map<string, number>();
+  for (const node of data.nodes) {
+    values.set(node.name, Math.max(incoming.get(node.name) ?? 0, outgoing.get(node.name) ?? 0));
+  }
+
+  return values;
+}
+
+function isAggregateNode(name: string): boolean {
+  return (
+    name === "total-income" ||
+    name === "total-expenses" ||
+    name === "total-inflow" ||
+    name === "total-outflow" ||
+    name === "net-cashflow"
+  );
+}
+
 interface SankeyEChartsProps {
   data: EChartsSankeyData;
   currency: string;
@@ -53,10 +90,29 @@ interface SankeyEChartsProps {
 export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsProps) {
   const chartRef = useRef<ReactEChartsCore>(null);
   const containerRef = useRef<HTMLDivElement>(null);
+  const previousScaleRef = useRef(1);
   const [containerHeight, setContainerHeight] = useState(600);
+  const [containerWidth, setContainerWidth] = useState(800);
   const [zoom, setZoom] = useState(1);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   const idealHeight = useMemo(() => computeIdealHeight(data), [data]);
+  const nodeValues = useMemo(() => computeNodeValues(data), [data]);
+  const minorNodes = useMemo(() => {
+    const largestNodeValue = Math.max(...Array.from(nodeValues.values()), 0);
+    if (largestNodeValue <= 0) return [];
+
+    return data.nodes
+      .map((node) => ({
+        name: node.name,
+        label: node.displayLabel,
+        value: nodeValues.get(node.name) ?? 0,
+        color: node.itemStyle.color,
+      }))
+      .filter((node) => !isAggregateNode(node.name) && node.value > 0 && node.value / largestNodeValue <= MINOR_NODE_SHARE)
+      .sort((a, b) => b.value - a.value)
+      .slice(0, MINOR_NODE_LIMIT);
+  }, [data.nodes, nodeValues]);
 
   useEffect(() => {
     function measure() {
@@ -64,15 +120,27 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
       const rect = containerRef.current.getBoundingClientRect();
       const available = window.innerHeight - rect.top - 80;
       setContainerHeight(Math.max(300, available));
+      setContainerWidth(Math.max(300, rect.width));
     }
+
     measure();
+    const resizeObserver = new ResizeObserver(measure);
+    if (containerRef.current) {
+      resizeObserver.observe(containerRef.current);
+    }
+
     window.addEventListener("resize", measure);
-    return () => window.removeEventListener("resize", measure);
-  }, []);
+    return () => {
+      resizeObserver.disconnect();
+      window.removeEventListener("resize", measure);
+    };
+  }, [isExpanded]);
 
   const autoScale = Math.min(1, containerHeight / idealHeight);
   const effectiveScale = autoScale * zoom;
-  const visibleHeight = idealHeight * effectiveScale;
+  const chartBaseWidth = containerWidth / autoScale;
+  const scaledChartWidth = chartBaseWidth * effectiveScale;
+  const scaledChartHeight = idealHeight * effectiveScale;
 
   // The CSS `transform: scale(effectiveScale)` on the inner container shrinks
   // every child proportionally — including SVG labels. When autoScale < 1
@@ -83,6 +151,8 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
   // visibly, which is the whole point of it.
   const LABEL_BASE_PX = 12;
   const compensatedLabelFontSize = Math.ceil(LABEL_BASE_PX / autoScale);
+  const compensatedLabelLineHeight = Math.ceil(15 / autoScale);
+  const compensatedLabelWidth = Math.ceil(160 / autoScale);
 
   const exportImage = useCallback(
     (format: "png" | "svg") => {
@@ -103,23 +173,70 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
     [],
   );
 
+  useEffect(() => {
+    if (!isExpanded) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === "Escape") {
+        setIsExpanded(false);
+      }
+    }
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [isExpanded]);
+
   // Zoom on Shift+scroll only — normal scroll passes through to the page
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return;
+
     function onWheel(e: WheelEvent) {
       if (!e.shiftKey) return; // let normal scroll pass through
       e.preventDefault();
       setZoom((prev) => {
-        const delta = e.deltaY > 0 ? -0.005 : 0.005;
-        return Math.min(3, Math.max(0.5, prev + delta));
+        const delta = e.deltaY > 0 ? -ZOOM_STEP / 2 : ZOOM_STEP / 2;
+        return clampZoom(prev + delta);
       });
     }
     el.addEventListener("wheel", onWheel, { passive: false });
     return () => el.removeEventListener("wheel", onWheel);
   }, []);
 
+  useEffect(() => {
+    const el = containerRef.current;
+    const previousScale = previousScaleRef.current;
+    if (!el || previousScale === effectiveScale) {
+      previousScaleRef.current = effectiveScale;
+      return;
+    }
+
+    const ratio = effectiveScale / previousScale;
+    const centerX = el.scrollLeft + el.clientWidth / 2;
+    const centerY = el.scrollTop + el.clientHeight / 2;
+    el.scrollLeft = centerX * ratio - el.clientWidth / 2;
+    el.scrollTop = centerY * ratio - el.clientHeight / 2;
+    previousScaleRef.current = effectiveScale;
+  }, [effectiveScale]);
+
   const resetZoom = useCallback(() => setZoom(1), []);
+
+  useEffect(() => {
+    const instance = chartRef.current?.getEchartsInstance();
+    if (!instance) return;
+
+    const frameId = window.requestAnimationFrame(() => {
+      instance.resize();
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [containerHeight, containerWidth, isExpanded]);
 
   const option: echarts.EChartsCoreOption = {
     tooltip: {
@@ -137,13 +254,13 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
         if (!d) return "";
 
         if (d.source && d.target) {
-          const sourceLabel = data.nodes.find((n) => n.name === d.source)?.label ?? d.source;
-          const targetLabel = data.nodes.find((n) => n.name === d.target)?.label ?? d.target;
+          const sourceLabel = data.nodes.find((n) => n.name === d.source)?.displayLabel ?? d.source;
+          const targetLabel = data.nodes.find((n) => n.name === d.target)?.displayLabel ?? d.target;
           return `<strong>${sourceLabel} → ${targetLabel}</strong><br/>Amount: ${Number(d.value).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
         }
 
         if (d.name) {
-          const label = (d as Record<string, unknown>).label ?? d.name;
+          const label = (d as Record<string, unknown>).displayLabel ?? d.name;
           const value = (params.value as number) ?? 0;
           return `<strong>${label}</strong><br/>Total: ${value.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} ${currency}`;
         }
@@ -169,12 +286,19 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
         lineStyle: {
           curveness: 0.5,
         },
+        labelLayout: {
+          moveOverlap: "shiftY",
+          hideOverlap: true,
+        },
         label: {
           fontSize: compensatedLabelFontSize,
+          lineHeight: compensatedLabelLineHeight,
           fontFamily: "Inter, system-ui, sans-serif",
           color: "#6F767E",
-          formatter: (params: { data?: { label?: string; name?: string }; value?: number }) => {
-            const label = params.data?.label ?? params.data?.name ?? "";
+          width: compensatedLabelWidth,
+          overflow: "truncate",
+          formatter: (params: { data?: { displayLabel?: string; name?: string }; value?: number }) => {
+            const label = params.data?.displayLabel ?? params.data?.name ?? "";
             const value = params.value ?? 0;
             return `${label}\n${formatCurrencyShort(value, currency)}`;
           },
@@ -184,44 +308,87 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
   };
 
   return (
-    <div>
+    <div className={isExpanded ? "fixed inset-0 z-50 flex flex-col bg-white p-4" : "relative"}>
       <div
         ref={containerRef}
-        className="overflow-hidden rounded-lg"
-        style={{ height: `${visibleHeight}px` }}
+        className="overflow-auto rounded-lg border border-[#EFEFEF] bg-white"
+        style={{ height: `${containerHeight}px` }}
       >
         <div
           style={{
-            width: `${100 / effectiveScale}%`,
-            height: `${idealHeight}px`,
-            transform: `scale(${effectiveScale})`,
-            transformOrigin: "top left",
+            width: `${scaledChartWidth}px`,
+            height: `${scaledChartHeight}px`,
+            position: "relative",
           }}
         >
-          <ReactEChartsCore
-            ref={chartRef}
-            echarts={echarts}
-            option={option}
-            style={{ height: "100%", width: "100%" }}
-            opts={{ renderer: "svg" }}
-          />
+          <div
+            style={{
+              width: `${chartBaseWidth}px`,
+              height: `${idealHeight}px`,
+              transform: `scale(${effectiveScale})`,
+              transformOrigin: "top left",
+            }}
+          >
+            <ReactEChartsCore
+              ref={chartRef}
+              echarts={echarts}
+              option={option}
+              style={{ height: "100%", width: "100%" }}
+              opts={{ renderer: "svg" }}
+            />
+          </div>
         </div>
       </div>
 
-      <div className="mt-3 flex items-center justify-between">
-        <div className="flex items-center gap-3">
-          <span className="text-xs text-[#9A9FA5]">
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="min-w-12 whitespace-nowrap text-xs text-[#9A9FA5]">
             {zoom !== 1
               ? `${Math.round(effectiveScale * 100)}%`
               : autoScale < 1
                 ? `Fit ${Math.round(autoScale * 100)}% · Shift + scroll to zoom`
                 : "Shift + scroll to zoom"}
           </span>
+          <div className="flex items-center gap-1.5">
+            <button
+              type="button"
+              onClick={() => setZoom((prev) => clampZoom(prev - ZOOM_STEP))}
+              disabled={zoom <= ZOOM_MIN}
+              title="Zoom out"
+              aria-label="Zoom out"
+              className="flex h-7 w-7 items-center justify-center rounded border border-[#EFEFEF] text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:cursor-default disabled:opacity-30"
+            >
+              <Minus className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+            <input
+              aria-label="Sankey zoom"
+              type="range"
+              min={ZOOM_MIN * 100}
+              max={ZOOM_MAX * 100}
+              step={ZOOM_STEP * 100}
+              value={Math.round(zoom * 100)}
+              onChange={(event) => setZoom(clampZoom(Number(event.target.value) / 100))}
+              className="h-7 w-28 accent-[#6C9B8B] sm:w-32"
+            />
+            <button
+              type="button"
+              onClick={() => setZoom((prev) => clampZoom(prev + ZOOM_STEP))}
+              disabled={zoom >= ZOOM_MAX}
+              title="Zoom in"
+              aria-label="Zoom in"
+              className="flex h-7 w-7 items-center justify-center rounded border border-[#EFEFEF] text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:cursor-default disabled:opacity-30"
+            >
+              <Plus className="h-3.5 w-3.5" aria-hidden="true" />
+            </button>
+          </div>
           {zoom !== 1 && (
             <button
+              type="button"
               onClick={resetZoom}
-              className="rounded-lg border border-[#EFEFEF] px-2 py-1 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7]"
+              title="Reset zoom"
+              className="flex h-7 items-center gap-1 rounded border border-[#EFEFEF] px-2 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7]"
             >
+              <RotateCcw className="h-3 w-3" aria-hidden="true" />
               Reset
             </button>
           )}
@@ -233,6 +400,19 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
           )}
         </div>
         <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((current) => !current)}
+            title={isExpanded ? "Minimize Sankey" : "Expand Sankey"}
+            aria-label={isExpanded ? "Minimize Sankey" : "Expand Sankey"}
+            className="flex h-8 w-8 items-center justify-center rounded-lg border border-[#EFEFEF] text-[#6F767E] transition-colors hover:bg-[#F4F5F7]"
+          >
+            {isExpanded ? (
+              <Minimize2 className="h-3.5 w-3.5" aria-hidden="true" />
+            ) : (
+              <Maximize2 className="h-3.5 w-3.5" aria-hidden="true" />
+            )}
+          </button>
           <button
             onClick={() => exportImage("png")}
             className="rounded-lg border border-[#EFEFEF] px-3 py-1.5 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7]"
@@ -247,6 +427,23 @@ export function SankeyECharts({ data, currency, bottomBarLeft }: SankeyEChartsPr
           </button>
         </div>
       </div>
+
+      {minorNodes.length > 0 && (
+        <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1.5 border-t border-[#EFEFEF] pt-3">
+          <span className="text-xs font-medium text-[#6F767E]">Small items</span>
+          {minorNodes.map((node) => (
+            <span key={node.name} className="inline-flex items-center gap-1.5 text-xs text-[#6F767E]">
+              <span
+                className="h-2 w-2 rounded-sm"
+                style={{ backgroundColor: node.color }}
+                aria-hidden="true"
+              />
+              <span>{node.label}</span>
+              <span className="text-[#9A9FA5]">{formatCurrencyShort(node.value, currency)}</span>
+            </span>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/lib/sankey-utils.ts
+++ b/app/src/lib/sankey-utils.ts
@@ -1,5 +1,4 @@
 import type { MonthlyExpenseByCategory, MonthlyCashFlow } from "@/lib/types/gnucash";
-import { formatCurrencyShort } from "@/lib/format";
 import { type CustomRange, dateToMonth } from "@/lib/period-utils";
 
 // ── Library-agnostic intermediate format ──────────────────────────────
@@ -290,7 +289,7 @@ export function buildSankeyData(opts: BuildOptions): SankeyData {
 
 export interface EChartsSankeyNode {
   name: string;
-  label: string;
+  displayLabel: string;
   itemStyle: { color: string };
   depth?: number;
 }
@@ -308,7 +307,7 @@ export function toEChartsFormat(
   return {
     nodes: data.nodes.map((n) => ({
       name: n.id,
-      label: n.label,
+      displayLabel: n.label,
       itemStyle: { color: n.color },
       ...(n.depth !== undefined ? { depth: n.depth } : {}),
     })),


### PR DESCRIPTION
## Summary
- Add explicit Sankey zoom controls with a scrollable map-style viewport
- Add fullscreen expand/minimize mode for Sankey diagrams
- Reduce label collisions with ECharts label layout, truncation, and a small-items summary
- Move custom node labels to displayLabel to avoid colliding with ECharts label options

Closes #110
Closes #111

## Verification
- ./node_modules/.bin/eslint src/components/sankey/sankey-echarts.tsx src/lib/sankey-utils.ts
- ./node_modules/.bin/tsc --noEmit
- npm run build