### PR TITLE
Fix dark mode chart account styling

### DIFF
--- a/app/src/app/(dashboard)/accounts/page.tsx
+++ b/app/src/app/(dashboard)/accounts/page.tsx
@@ -38,19 +38,19 @@ const ACCOUNT_TYPE_LABELS: Record<string, string> = {
 };
 
 const TYPE_COLORS: Record<string, string> = {
-  ASSET: "bg-emerald-50 text-emerald-700",
-  BANK: "bg-emerald-50 text-emerald-700",
-  CASH: "bg-emerald-50 text-emerald-700",
-  STOCK: "bg-blue-50 text-blue-700",
-  MUTUAL: "bg-blue-50 text-blue-700",
-  INCOME: "bg-teal-50 text-teal-700",
-  EXPENSE: "bg-amber-50 text-amber-700",
-  LIABILITY: "bg-red-50 text-red-700",
-  CREDIT: "bg-red-50 text-red-700",
-  PAYABLE: "bg-red-50 text-red-700",
-  EQUITY: "bg-purple-50 text-purple-700",
-  RECEIVABLE: "bg-cyan-50 text-cyan-700",
-  TRADING: "bg-gray-50 text-gray-700",
+  ASSET: "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200",
+  BANK: "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200",
+  CASH: "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/15 dark:text-emerald-200",
+  STOCK: "bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-200",
+  MUTUAL: "bg-blue-50 text-blue-700 dark:bg-blue-500/15 dark:text-blue-200",
+  INCOME: "bg-teal-50 text-teal-700 dark:bg-teal-500/15 dark:text-teal-200",
+  EXPENSE: "bg-amber-50 text-amber-700 dark:bg-amber-500/15 dark:text-amber-200",
+  LIABILITY: "bg-red-50 text-red-700 dark:bg-red-500/15 dark:text-red-200",
+  CREDIT: "bg-red-50 text-red-700 dark:bg-red-500/15 dark:text-red-200",
+  PAYABLE: "bg-red-50 text-red-700 dark:bg-red-500/15 dark:text-red-200",
+  EQUITY: "bg-purple-50 text-purple-700 dark:bg-purple-500/15 dark:text-purple-200",
+  RECEIVABLE: "bg-cyan-50 text-cyan-700 dark:bg-cyan-500/15 dark:text-cyan-200",
+  TRADING: "bg-gray-50 text-gray-700 dark:bg-gray-500/15 dark:text-gray-200",
 };
 
 // ── Helpers ──────────────────────────────────────────────────────
@@ -362,7 +362,7 @@ function AccountRow({
   return (
     <>
       <tr
-        className={`group border-b border-[#EFEFEF] transition-colors cursor-pointer hover:bg-[#F9FAFB] ${isTopLevel ? "bg-[#FAFBFC]" : ""}`}
+        className={`group border-b border-[#EFEFEF] transition-colors cursor-pointer hover:bg-[#F9FAFB] ${isTopLevel ? "bg-[#FAFBFC] dark:bg-muted" : ""}`}
         onClick={() => {
           if (hasChildren) {
             onToggle(account.guid);

--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -244,7 +244,7 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
             <span className="text-xs text-[#6F767E]">Outflow</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <div className="h-0.5 w-4 border-t-2 border-dashed border-[#1A1D1F]" />
+            <div className="h-0.5 w-4 border-t-2 border-dashed" style={{ borderColor: "var(--chart-net-line)" }} />
             <span className="text-xs text-[#6F767E]">Net</span>
           </div>
         </div>
@@ -253,17 +253,17 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
           <div className="h-[220px]">
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
                 <XAxis
                   dataKey="month"
                   tickFormatter={formatMonthLabel}
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <YAxis
                   tickFormatter={(v) => formatCurrencyShort(v, currency)}
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   axisLine={false}
                   tickLine={false}
                   width={50}
@@ -280,15 +280,16 @@ function CashFlowBarChart({ filters }: { filters: SankeyFilterState }) {
                     return `${months[parseInt(m) - 1]} ${y}`;
                   }}
                   contentStyle={{
-                    backgroundColor: "white",
-                    border: "1px solid #EFEFEF",
+                    backgroundColor: "var(--popover)",
+                    color: "var(--popover-foreground)",
+                    border: "1px solid var(--border)",
                     borderRadius: "10px",
                     fontSize: "13px",
                   }}
                 />
                 <Bar dataKey="inflow" fill="#3B6B8A" radius={[3, 3, 0, 0]} barSize={14} />
                 <Bar dataKey="outflow" fill="#F87171" radius={[3, 3, 0, 0]} barSize={14} />
-                <Line type="monotone" dataKey="net" stroke="#1A1D1F" strokeWidth={2} strokeDasharray="6 4" dot={false} />
+                <Line type="monotone" dataKey="net" stroke="var(--chart-net-line)" strokeWidth={2} strokeDasharray="6 4" dot={false} />
               </ComposedChart>
             </ResponsiveContainer>
           </div>

--- a/app/src/app/(dashboard)/income-expenses/page.tsx
+++ b/app/src/app/(dashboard)/income-expenses/page.tsx
@@ -614,7 +614,7 @@ function IncomeExpenseBarChart({
             <span className="text-xs text-[#6F767E]">Expense</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <div className="h-0.5 w-4 border-t-2 border-dashed border-[#1A1D1F]" />
+            <div className="h-0.5 w-4 border-t-2 border-dashed" style={{ borderColor: "var(--chart-net-line)" }} />
             <span className="text-xs text-[#6F767E]">Net</span>
           </div>
           <div className="flex items-center gap-1.5">
@@ -627,18 +627,18 @@ function IncomeExpenseBarChart({
           <div className="h-[220px]">
             <ResponsiveContainer width="100%" height="100%">
               <ComposedChart data={chartData} margin={{ top: 5, right: 5, bottom: 0, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
                 <XAxis
                   dataKey="month"
                   tickFormatter={formatMonthLabel}
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   axisLine={false}
                   tickLine={false}
                 />
                 <YAxis
                   yAxisId="amount"
                   tickFormatter={(v) => formatCurrencyShort(v, currency)}
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   axisLine={false}
                   tickLine={false}
                   width={50}
@@ -647,7 +647,7 @@ function IncomeExpenseBarChart({
                   yAxisId="rate"
                   orientation="right"
                   tickFormatter={(v: number) => `${v.toFixed(0)}%`}
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   axisLine={false}
                   tickLine={false}
                   width={42}
@@ -667,15 +667,16 @@ function IncomeExpenseBarChart({
                     return `${months[parseInt(m) - 1]} ${y}`;
                   }}
                   contentStyle={{
-                    backgroundColor: "white",
-                    border: "1px solid #EFEFEF",
+                    backgroundColor: "var(--popover)",
+                    color: "var(--popover-foreground)",
+                    border: "1px solid var(--border)",
                     borderRadius: "10px",
                     fontSize: "13px",
                   }}
                 />
                 <Bar yAxisId="amount" dataKey="income" fill="#3B6B8A" radius={[3, 3, 0, 0]} barSize={14} />
                 <Bar yAxisId="amount" dataKey="expense" fill="#F87171" radius={[3, 3, 0, 0]} barSize={14} />
-                <Line yAxisId="amount" type="monotone" dataKey="net" stroke="#1A1D1F" strokeWidth={2} strokeDasharray="6 4" dot={false} />
+                <Line yAxisId="amount" type="monotone" dataKey="net" stroke="var(--chart-net-line)" strokeWidth={2} strokeDasharray="6 4" dot={false} />
                 <Line yAxisId="rate" type="monotone" dataKey="savingsRate" stroke={rateColor} strokeWidth={2} dot={false} connectNulls />
               </ComposedChart>
             </ResponsiveContainer>

--- a/app/src/app/globals.css
+++ b/app/src/app/globals.css
@@ -56,6 +56,8 @@
   --chart-grid: #EFEFEF;
   --chart-axis-tick: #9A9FA5;
   --chart-axis-line: rgba(26, 29, 31, 0.3);
+  --chart-net-line: #1A1D1F;
+  --chart-cost-basis: #D4DAE0;
   --card: oklch(1 0 0);
   --card-foreground: oklch(0.145 0 0);
   --popover: oklch(1 0 0);
@@ -94,6 +96,8 @@
   --chart-grid: rgba(255, 255, 255, 0.08);
   --chart-axis-tick: rgba(255, 255, 255, 0.55);
   --chart-axis-line: rgba(255, 255, 255, 0.4);
+  --chart-net-line: rgba(255, 255, 255, 0.78);
+  --chart-cost-basis: rgba(255, 255, 255, 0.3);
   --card: oklch(0.205 0 0);
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
@@ -146,6 +150,7 @@
 .dark .hover\:bg-\[\#F4F5F7\]:hover                                  { background-color: var(--muted); }
 .dark .bg-\[\#F9FAFB\]                                               { background-color: var(--muted); }
 .dark .hover\:bg-\[\#F9FAFB\]:hover                                  { background-color: var(--muted); }
+.dark .bg-\[\#FAFBFC\]                                               { background-color: color-mix(in oklch, var(--muted), white 4%); }
 .dark .bg-\[\#EFEFEF\]                                               { background-color: var(--muted); }
 .dark .hover\:bg-\[\#EFEFEF\]:hover                                  { background-color: color-mix(in oklch, var(--muted), white 10%); }
 .dark .bg-\[\#EBF5EC\]                                               { background-color: color-mix(in oklch, var(--muted), #6C9B8B 12%); }
@@ -160,6 +165,7 @@
 
 /* Neutral borders */
 .dark .border-\[\#EFEFEF\]                                           { border-color: var(--border); }
+.dark .border-\[\#1A1D1F\]                                           { border-color: var(--chart-net-line); }
 .dark .border-\[\#D4DAE0\]                                           { border-color: var(--border); }
 .dark .border-\[\#D1D5DB\]                                           { border-color: var(--border); }
 

--- a/app/src/components/dashboard/charts/cash-flow-chart.tsx
+++ b/app/src/components/dashboard/charts/cash-flow-chart.tsx
@@ -146,7 +146,7 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
             <span className="text-xs text-[#6F767E]">Expense</span>
           </div>
           <div className="flex items-center gap-1.5">
-            <div className="h-0.5 w-4 border-t-2 border-dashed border-[#1A1D1F]" />
+            <div className="h-0.5 w-4 border-t-2 border-dashed" style={{ borderColor: "var(--chart-net-line)" }} />
             <span className="text-xs text-[#6F767E]">Net</span>
           </div>
         </div>
@@ -198,7 +198,7 @@ export function CashFlowChart({ series, currency, externalPeriod, externalCustom
                 <Line
                   type="monotone"
                   dataKey="net"
-                  stroke="currentColor"
+                  stroke="var(--chart-net-line)"
                   strokeWidth={2}
                   strokeDasharray="6 4"
                   dot={false}

--- a/app/src/components/dashboard/charts/investment-performance.tsx
+++ b/app/src/components/dashboard/charts/investment-performance.tsx
@@ -144,7 +144,7 @@ export function InvestmentPerformance({ investments, currency }: InvestmentPerfo
                   </span>
                 )}
               />
-              <Bar dataKey="costBasis" fill="#D4DAE0" radius={[3, 3, 0, 0]} barSize={16} />
+              <Bar dataKey="costBasis" fill="var(--chart-cost-basis)" radius={[3, 3, 0, 0]} barSize={16} />
               <Bar dataKey="marketValue" radius={[3, 3, 0, 0]} barSize={16}>
                 {chartData.map((entry, index) => (
                   <Cell

--- a/app/src/components/investment/value-over-time-chart.tsx
+++ b/app/src/components/investment/value-over-time-chart.tsx
@@ -78,16 +78,16 @@ export function ValueOverTimeChart({ series, currency, selectedTicker }: ValueOv
           <div className="h-[260px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={chartData} margin={{ top: 4, right: 4, bottom: 0, left: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" stroke="#EFEFEF" vertical={false} />
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--chart-grid)" vertical={false} />
                 <XAxis
                   dataKey="label"
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   tickLine={false}
-                  axisLine={{ stroke: "#EFEFEF" }}
+                  axisLine={{ stroke: "var(--chart-grid)" }}
                   interval="preserveStartEnd"
                 />
                 <YAxis
-                  tick={{ fontSize: 11, fill: "#9A9FA5" }}
+                  tick={{ fontSize: 11, fill: "var(--chart-axis-tick)" }}
                   tickLine={false}
                   axisLine={false}
                   tickFormatter={(v) =>
@@ -104,8 +104,9 @@ export function ValueOverTimeChart({ series, currency, selectedTicker }: ValueOv
                   ]}
                   labelFormatter={(label) => String(label)}
                   contentStyle={{
-                    backgroundColor: "white",
-                    border: "1px solid #EFEFEF",
+                    backgroundColor: "var(--popover)",
+                    color: "var(--popover-foreground)",
+                    border: "1px solid var(--border)",
                     borderRadius: "10px",
                     fontSize: "13px",
                     boxShadow: "0 2px 8px rgba(0,0,0,0.08)",
@@ -129,7 +130,7 @@ export function ValueOverTimeChart({ series, currency, selectedTicker }: ValueOv
                 <Line
                   type="monotone"
                   dataKey="costBasis"
-                  stroke="#9A9FA5"
+                  stroke="var(--chart-axis-tick)"
                   strokeWidth={1.5}
                   strokeDasharray="6 4"
                   dot={false}


### PR DESCRIPTION
## Summary
- Fix top-level Chart of Accounts rows in dark mode
- Soften account type badges in dark mode
- Use theme-aware colors for the net line, chart grid/ticks, chart tooltips, and investment cost-basis series

Closes #112

## Verification
- ./node_modules/.bin/tsc --noEmit
- npm run build

Note: targeted ESLint still reports existing React hook errors in dashboard page files unrelated to this styling change.