### PR TITLE
Fix React lint errors

### DIFF
--- a/app/src/app/(dashboard)/cash-flow/page.tsx
+++ b/app/src/app/(dashboard)/cash-flow/page.tsx
@@ -333,7 +333,7 @@ const TX_PAGE_SIZE = 25;
 function CashFlowTransactions({ filters }: { filters: SankeyFilterState }) {
   const { data } = useDashboard();
   const { excludeClosing } = useClosing();
-  const [page, setPage] = useState(0);
+  const [pageState, setPageState] = useState({ key: "", page: 0 });
 
   const { period, customRange, selectedInflow, selectedOutflow } = filters;
 
@@ -375,7 +375,7 @@ function CashFlowTransactions({ filters }: { filters: SankeyFilterState }) {
 
   // Reset page when filters change
   const filterKey = `${period}-${customRange?.start}-${customRange?.end}-${Array.from(allSelected).sort().join(",")}`;
-  useMemo(() => setPage(0), [filterKey]);
+  const page = pageState.key === filterKey ? pageState.page : 0;
 
   if (!data || filtered.length === 0) return null;
 
@@ -439,14 +439,14 @@ function CashFlowTransactions({ filters }: { filters: SankeyFilterState }) {
             </span>
             <div className="flex gap-1">
               <button
-                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                onClick={() => setPageState({ key: filterKey, page: Math.max(0, page - 1) })}
                 disabled={page === 0}
                 className="rounded-md border border-[#EFEFEF] px-2.5 py-1 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30"
               >
                 Prev
               </button>
               <button
-                onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                onClick={() => setPageState({ key: filterKey, page: Math.min(totalPages - 1, page + 1) })}
                 disabled={page >= totalPages - 1}
                 className="rounded-md border border-[#EFEFEF] px-2.5 py-1 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30"
               >
@@ -563,15 +563,6 @@ function CashFlowBudgetContent({ data }: { data: NonNullable<ReturnType<typeof u
     }
   }, []);
 
-  if (!cashFlowData || cashFlowData.budgets.length === 0) {
-    return (
-      <div className="flex flex-col gap-4 sm:gap-6">
-        <h2 className="text-lg font-semibold text-[#1A1D1F] sm:text-xl">Cash Flow Budget</h2>
-        <NoBudgetState message="Create a budget in GNUCash to see your cash flow vs budget here. Go to Actions > Budget > New Budget in GNUCash." />
-      </div>
-    );
-  }
-
   const ytdVarianceMap = useMemo(() => {
     if (!activeBudgetData || viewMode !== "monthly") return new Map<string, number>();
     const source = isInflow ? activeBudgetData.inflowCategories : activeBudgetData.outflowCategories;
@@ -589,6 +580,15 @@ function CashFlowBudgetContent({ data }: { data: NonNullable<ReturnType<typeof u
     }
     return map;
   }, [activeBudgetData, viewMode, selectedMonth, yearStr, isInflow]);
+
+  if (!cashFlowData || cashFlowData.budgets.length === 0) {
+    return (
+      <div className="flex flex-col gap-4 sm:gap-6">
+        <h2 className="text-lg font-semibold text-[#1A1D1F] sm:text-xl">Cash Flow Budget</h2>
+        <NoBudgetState message="Create a budget in GNUCash to see your cash flow vs budget here. Go to Actions > Budget > New Budget in GNUCash." />
+      </div>
+    );
+  }
 
   const c = data.currency;
   const hasInflows = allInflowCategories.length > 0;

--- a/app/src/app/(dashboard)/investment/page.tsx
+++ b/app/src/app/(dashboard)/investment/page.tsx
@@ -82,10 +82,7 @@ export default function InvestmentPage() {
   const [selectedTicker, setSelectedTicker] = useState<string | null>(null);
   const [grouped, setGrouped] = useState(true);
 
-  if (!data) return null;
-
-  const c = data.currency;
-  const allHoldings = data.investments ?? [];
+  const allHoldings = data?.investments ?? [];
   const activeHoldings = useMemo(
     () => allHoldings.filter((h) => Math.abs(h.marketValue) >= 0.01 || Math.abs(h.sharesHeld) >= 0.0001),
     [allHoldings]
@@ -93,6 +90,10 @@ export default function InvestmentPage() {
 
   const allItems = useMemo(() => (grouped ? toGrouped(allHoldings) : toUngrouped(allHoldings)), [allHoldings, grouped]);
   const activeItems = useMemo(() => (grouped ? filterActive(toGrouped(allHoldings)) : filterActive(toUngrouped(allHoldings))), [allHoldings, grouped]);
+
+  if (!data) return null;
+
+  const c = data.currency;
 
   return (
     <div className="flex flex-col gap-4 sm:gap-6">

--- a/app/src/components/account-editor-sheet.tsx
+++ b/app/src/components/account-editor-sheet.tsx
@@ -71,13 +71,11 @@ function SimpleCombobox({
   placeholder: string;
 }) {
   const selected = items.find((i) => i.guid === value);
-  const [query, setQuery] = useState(selected?.label ?? "");
+  const selectedLabel = selected?.label ?? "";
+  const [draftQuery, setDraftQuery] = useState(selectedLabel);
   const [open, setOpen] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    setQuery(selected?.label ?? "");
-  }, [selected]);
+  const query = open ? draftQuery : selectedLabel;
 
   const filtered = useMemo(() => {
     if (!query.trim()) return items.slice(0, 50);
@@ -94,8 +92,8 @@ function SimpleCombobox({
         <input
           type="text"
           value={query}
-          onChange={(e) => { setQuery(e.target.value); setOpen(true); if (!e.target.value) onChange("", ""); }}
-          onFocus={() => setOpen(true)}
+          onChange={(e) => { setDraftQuery(e.target.value); setOpen(true); if (!e.target.value) onChange("", ""); }}
+          onFocus={() => { setDraftQuery(selectedLabel); setOpen(true); }}
           onBlur={() => setTimeout(() => setOpen(false), 200)}
           placeholder={placeholder}
           className="h-8 w-full rounded-md border border-[#EFEFEF] bg-white pl-7 pr-2 text-xs text-[#1A1D1F] placeholder:text-[#9A9FA5] focus:border-[#3B6B8A] focus:outline-none focus:ring-1 focus:ring-[#3B6B8A]"
@@ -107,7 +105,7 @@ function SimpleCombobox({
             <div
               key={item.guid}
               onMouseDown={(e) => e.preventDefault()}
-              onClick={() => { onChange(item.guid, item.label); setQuery(item.label); setOpen(false); }}
+              onClick={() => { onChange(item.guid, item.label); setDraftQuery(item.label); setOpen(false); }}
               className={`cursor-pointer px-2.5 py-1.5 text-xs hover:bg-[#3B6B8A]/10 ${item.guid === value ? "font-medium text-[#3B6B8A]" : "text-[#1A1D1F]"}`}
             >
               <div>{item.label}</div>
@@ -258,7 +256,7 @@ export function AccountEditorSheet({
     setSaveError(null);
 
     try {
-      let finalCommodityGuid = commodityGuid;
+      const finalCommodityGuid = commodityGuid;
 
       // Create new commodity if needed
       if (showNewCommodity && isInvestment) {

--- a/app/src/components/account-ledger.tsx
+++ b/app/src/components/account-ledger.tsx
@@ -55,7 +55,7 @@ export function AccountLedger({
   const [duplicateError, setDuplicateError] = useState<string | null>(null);
   const entryRef = useRef<InlineEntryHandle | null>(null);
   const [search, setSearch] = useState("");
-  const [page, setPage] = useState(0);
+  const [pageState, setPageState] = useState({ key: "", page: 0 });
   const [sortField, setSortField] = useState<SortField>("date");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
   const [expandedTx, setExpandedTx] = useState<Set<string>>(new Set());
@@ -80,7 +80,6 @@ export function AccountLedger({
       setSortField(field);
       setSortDir(field === "date" ? "asc" : "desc");
     }
-    setPage(0);
   }
 
   // Filter transactions to those involving this account, and compute running balance
@@ -151,9 +150,8 @@ export function AccountLedger({
     return { rows: sorted, runningBalance: balance };
   }, [data, account.guid, search, sortField, sortDir, isCredit]);
 
-  // Reset page on search change
-  const filterKey = search;
-  useMemo(() => setPage(0), [filterKey]);
+  const filterKey = `${search}-${sortField}-${sortDir}`;
+  const page = pageState.key === filterKey ? pageState.page : 0;
 
   if (!data) return null;
 
@@ -305,14 +303,14 @@ export function AccountLedger({
               </span>
               <div className="flex gap-1">
                 <button
-                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  onClick={() => setPageState({ key: filterKey, page: Math.max(0, page - 1) })}
                   disabled={page === 0}
                   className="rounded-md border border-[#EFEFEF] px-2.5 py-1 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:hover:bg-transparent"
                 >
                   Prev
                 </button>
                 <button
-                  onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                  onClick={() => setPageState({ key: filterKey, page: Math.min(totalPages - 1, page + 1) })}
                   disabled={page >= totalPages - 1}
                   className="rounded-md border border-[#EFEFEF] px-2.5 py-1 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:hover:bg-transparent"
                 >

--- a/app/src/components/add-transaction-sheet.tsx
+++ b/app/src/components/add-transaction-sheet.tsx
@@ -53,12 +53,11 @@ function AccountCombobox({
   value: { guid: string; path: string };
   onChange: (account: FlatAccount | null) => void;
 }) {
-  const [query, setQuery] = useState(value.path);
+  const [draftQuery, setDraftQuery] = useState(value.path);
   const [open, setOpen] = useState(false);
   const [highlightIndex, setHighlightIndex] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => { setQuery(value.path); }, [value.path]);
+  const query = open ? draftQuery : value.path;
 
   const filtered = useMemo(() => {
     if (!query.trim()) return accounts.slice(0, 50);
@@ -84,7 +83,7 @@ function AccountCombobox({
   const selectItem = useCallback(
     (item: FlatAccount) => {
       onChange(item);
-      setQuery(item.fullPath);
+      setDraftQuery(item.fullPath);
       setOpen(false);
     },
     [onChange]
@@ -92,7 +91,7 @@ function AccountCombobox({
 
   function handleKeyDown(e: React.KeyboardEvent) {
     if (!open) {
-      if (e.key === "ArrowDown" || e.key === "Enter") { setOpen(true); e.preventDefault(); }
+      if (e.key === "ArrowDown" || e.key === "Enter") { setDraftQuery(value.path); setOpen(true); e.preventDefault(); }
       return;
     }
     switch (e.key) {
@@ -117,12 +116,12 @@ function AccountCombobox({
           type="text"
           value={query}
           onChange={(e) => {
-            setQuery(e.target.value);
+            setDraftQuery(e.target.value);
             setOpen(true);
             setHighlightIndex(0);
             if (!e.target.value) onChange(null);
           }}
-          onFocus={() => setOpen(true)}
+          onFocus={() => { setDraftQuery(value.path); setOpen(true); }}
           onBlur={() => setTimeout(() => setOpen(false), 200)}
           onKeyDown={handleKeyDown}
           placeholder="Search accounts..."

--- a/app/src/components/budget/variance-table.tsx
+++ b/app/src/components/budget/variance-table.tsx
@@ -5,6 +5,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/format";
 import type { BudgetCategoryRow } from "@/lib/types/gnucash";
 
+function SortIcon({ active, sortAsc }: { active: boolean; sortAsc: boolean }) {
+  return (
+    <svg className={`ml-1 inline h-3 w-3 ${active ? "text-[#6C9B8B]" : "text-[#9A9FA5]"}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={sortAsc ? "M5 15l7-7 7 7" : "M19 9l-7 7-7-7"} />
+    </svg>
+  );
+}
+
 export function VarianceTable({
   categories,
   currency,
@@ -53,12 +61,6 @@ export function VarianceTable({
     }
   }
 
-  const SortIcon = ({ active }: { active: boolean }) => (
-    <svg className={`ml-1 inline h-3 w-3 ${active ? "text-[#6C9B8B]" : "text-[#9A9FA5]"}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
-      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={sortAsc ? "M5 15l7-7 7 7" : "M19 9l-7 7-7-7"} />
-    </svg>
-  );
-
   return (
     <Card>
       <CardHeader>
@@ -69,16 +71,16 @@ export function VarianceTable({
           <thead>
             <tr className="border-b border-[#EFEFEF] text-left text-xs text-[#9A9FA5]">
               <th className="cursor-pointer pb-2 pr-4 font-medium" onClick={() => toggleSort("name")}>
-                Category<SortIcon active={sortKey === "name"} />
+                Category<SortIcon active={sortKey === "name"} sortAsc={sortAsc} />
               </th>
               <th className="cursor-pointer pb-2 pr-4 text-right font-medium" onClick={() => toggleSort("budgeted")}>
-                {isIncome ? "Target" : "Budgeted"}<SortIcon active={sortKey === "budgeted"} />
+                {isIncome ? "Target" : "Budgeted"}<SortIcon active={sortKey === "budgeted"} sortAsc={sortAsc} />
               </th>
               <th className="cursor-pointer pb-2 pr-4 text-right font-medium" onClick={() => toggleSort("actual")}>
-                Actual<SortIcon active={sortKey === "actual"} />
+                Actual<SortIcon active={sortKey === "actual"} sortAsc={sortAsc} />
               </th>
               <th className="cursor-pointer pb-2 pr-4 text-right font-medium" onClick={() => toggleSort("variance")}>
-                Variance<SortIcon active={sortKey === "variance"} />
+                Variance<SortIcon active={sortKey === "variance"} sortAsc={sortAsc} />
               </th>
               <th className="pb-2 text-right font-medium">%</th>
             </tr>

--- a/app/src/components/inline-entry/account-autocomplete.tsx
+++ b/app/src/components/inline-entry/account-autocomplete.tsx
@@ -37,26 +37,27 @@ export function AccountAutocomplete({
   placeholder = "Transfer account",
 }: Props) {
   const [highlightIndex, setHighlightIndex] = useState(-1);
-  const [showDropdown, setShowDropdown] = useState(false);
+  const [dropdownDismissed, setDropdownDismissed] = useState(false);
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number; width: number } | null>(null);
   // Tracks confirmed hierarchy prefix, e.g. "Expenses:" or "Expenses:Fun:"
   const [hierarchyPrefix, setHierarchyPrefix] = useState("");
   const dropdownRef = useRef<HTMLDivElement>(null);
+  const activeHierarchyPrefix = value ? hierarchyPrefix : "";
 
   // The text the user is currently typing (after the hierarchy prefix)
-  const typedText = value.startsWith(hierarchyPrefix) ? value.slice(hierarchyPrefix.length) : value;
+  const typedText = value.startsWith(activeHierarchyPrefix) ? value.slice(activeHierarchyPrefix.length) : value;
 
   // Build filtered account list
   const suggestions = useMemo(() => {
-    if (!value.trim() && !hierarchyPrefix) return [];
+    if (!value.trim() && !activeHierarchyPrefix) return [];
 
     const query = typedText.toLowerCase();
 
     // If we have a hierarchy prefix, show children at that level
-    if (hierarchyPrefix) {
+    if (activeHierarchyPrefix) {
       const atLevel = accounts.filter((a) => {
-        if (!a.fullPath.startsWith(hierarchyPrefix)) return false;
-        const remaining = a.fullPath.slice(hierarchyPrefix.length);
+        if (!a.fullPath.startsWith(activeHierarchyPrefix)) return false;
+        const remaining = a.fullPath.slice(activeHierarchyPrefix.length);
         // Get the next segment name
         const nextSegment = remaining.split(":")[0];
         if (!query) return true;
@@ -66,11 +67,11 @@ export function AccountAutocomplete({
       // Deduplicate by next segment (show parent levels as well as leaves)
       const seen = new Map<string, FlatAccount>();
       for (const a of atLevel) {
-        const remaining = a.fullPath.slice(hierarchyPrefix.length);
+        const remaining = a.fullPath.slice(activeHierarchyPrefix.length);
         const nextSegment = remaining.split(":")[0];
         // Prefer exact level match (the account whose path ends at this segment)
         const key = nextSegment.toLowerCase();
-        if (!seen.has(key) || a.fullPath === hierarchyPrefix + nextSegment) {
+        if (!seen.has(key) || a.fullPath === activeHierarchyPrefix + nextSegment) {
           seen.set(key, a);
         }
       }
@@ -88,26 +89,22 @@ export function AccountAutocomplete({
       .slice(0, 15);
 
     return scored.map((s) => s.account);
-  }, [value, typedText, hierarchyPrefix, accounts]);
+  }, [value, typedText, activeHierarchyPrefix, accounts]);
 
   // Check if the current value already exactly matches a known account
   const isAlreadySelected = useMemo(() => {
     return accounts.some((a) => a.fullPath === value);
   }, [accounts, value]);
 
-  // Show/hide dropdown - don't show if value already exactly matches an account
-  useEffect(() => {
-    if (isAlreadySelected) {
-      setShowDropdown(false);
-      setHighlightIndex(-1);
-    } else if (suggestions.length > 0 && (value.trim() || hierarchyPrefix)) {
-      setShowDropdown(true);
-      setHighlightIndex(0);
-    } else {
-      setShowDropdown(false);
-      setHighlightIndex(-1);
-    }
-  }, [suggestions, value, hierarchyPrefix, isAlreadySelected]);
+  const showDropdown =
+    !dropdownDismissed &&
+    !isAlreadySelected &&
+    suggestions.length > 0 &&
+    Boolean(value.trim() || activeHierarchyPrefix);
+  const activeHighlightIndex =
+    showDropdown && suggestions.length > 0
+      ? Math.min(Math.max(highlightIndex, 0), suggestions.length - 1)
+      : -1;
 
   // Update dropdown position
   useEffect(() => {
@@ -129,7 +126,7 @@ export function AccountAutocomplete({
         dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
         inputRef.current && !inputRef.current.contains(e.target as Node)
       ) {
-        setShowDropdown(false);
+        setDropdownDismissed(true);
       }
     }
     document.addEventListener("mousedown", handleClick);
@@ -139,7 +136,7 @@ export function AccountAutocomplete({
   const selectAccount = useCallback((account: FlatAccount) => {
     onChange(account.fullPath);
     onSelect(account);
-    setShowDropdown(false);
+    setDropdownDismissed(true);
     setHierarchyPrefix("");
   }, [onChange, onSelect]);
 
@@ -155,6 +152,7 @@ export function AccountAutocomplete({
     if (hasChildren) {
       setHierarchyPrefix(newPrefix);
       onChange(newPrefix);
+      setDropdownDismissed(false);
       setHighlightIndex(0);
     } else {
       // This is a leaf node, select it
@@ -166,7 +164,7 @@ export function AccountAutocomplete({
   function handleKeyDown(e: React.KeyboardEvent) {
     // If the value already matches a complete account, Tab/Enter should just pass through
     if (isAlreadySelected && (e.key === "Tab" || e.key === "Enter")) {
-      setShowDropdown(false);
+      setDropdownDismissed(true);
       onKeyDown(e);
       return;
     }
@@ -185,9 +183,9 @@ export function AccountAutocomplete({
 
       // ":" key descends into hierarchy
       if (e.key === ":") {
-        if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
+        if (activeHighlightIndex >= 0) {
           e.preventDefault();
-          descendInto(suggestions[highlightIndex]);
+          descendInto(suggestions[activeHighlightIndex]);
           return;
         }
       }
@@ -197,8 +195,8 @@ export function AccountAutocomplete({
         // next cell. Hierarchy drill-down is handled by the ":" key instead, so
         // typing "hob" + Down + Tab correctly commits Expenses:Fun:Hobbies
         // rather than collapsing to the highest-order parent.
-        if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
-          selectAccount(suggestions[highlightIndex]);
+        if (activeHighlightIndex >= 0) {
+          selectAccount(suggestions[activeHighlightIndex]);
         }
         onKeyDown(e);
         return;
@@ -206,15 +204,15 @@ export function AccountAutocomplete({
 
       if (e.key === "Enter") {
         e.preventDefault();
-        if (highlightIndex >= 0 && highlightIndex < suggestions.length) {
-          selectAccount(suggestions[highlightIndex]);
+        if (activeHighlightIndex >= 0) {
+          selectAccount(suggestions[activeHighlightIndex]);
         }
         return;
       }
 
       if (e.key === "Escape") {
         e.preventDefault();
-        setShowDropdown(false);
+        setDropdownDismissed(true);
         return;
       }
 
@@ -225,6 +223,7 @@ export function AccountAutocomplete({
         parts.pop();
         const newPrefix = parts.length > 0 ? parts.join(":") + ":" : "";
         setHierarchyPrefix(newPrefix);
+        setDropdownDismissed(false);
         onChange(newPrefix);
         return;
       }
@@ -234,29 +233,34 @@ export function AccountAutocomplete({
   }
 
   function handleChange(newValue: string) {
+    const basePrefix = value ? hierarchyPrefix : "";
+
     // If user types ":" manually, try to confirm hierarchy
     if (newValue.endsWith(":") && !newValue.endsWith("::")) {
-      const segment = newValue.slice(hierarchyPrefix.length, -1);
+      const segment = newValue.slice(basePrefix.length, -1);
       if (segment) {
         const match = accounts.find((a) => {
-          if (!a.fullPath.startsWith(hierarchyPrefix)) return false;
-          const remaining = a.fullPath.slice(hierarchyPrefix.length);
+          if (!a.fullPath.startsWith(basePrefix)) return false;
+          const remaining = a.fullPath.slice(basePrefix.length);
           const nextSeg = remaining.split(":")[0];
           return nextSeg.toLowerCase() === segment.toLowerCase();
         });
         if (match) {
-          const remaining = match.fullPath.slice(hierarchyPrefix.length);
+          const remaining = match.fullPath.slice(basePrefix.length);
           const nextSegment = remaining.split(":")[0];
-          const newPrefix = hierarchyPrefix + nextSegment + ":";
-          const hasChildren = accounts.some((a) => a.fullPath.startsWith(newPrefix) && a.fullPath !== hierarchyPrefix + nextSegment);
+          const newPrefix = basePrefix + nextSegment + ":";
+          const hasChildren = accounts.some((a) => a.fullPath.startsWith(newPrefix) && a.fullPath !== basePrefix + nextSegment);
           if (hasChildren) {
             setHierarchyPrefix(newPrefix);
+            setDropdownDismissed(false);
             onChange(newPrefix);
             return;
           }
         }
       }
     }
+    setDropdownDismissed(false);
+    setHighlightIndex(0);
     onChange(newValue);
   }
 
@@ -266,11 +270,6 @@ export function AccountAutocomplete({
     const el = dropdownRef.current?.children[highlightIndex] as HTMLElement | undefined;
     el?.scrollIntoView({ block: "nearest" });
   }, [highlightIndex, showDropdown]);
-
-  // Reset hierarchy when value is cleared externally
-  useEffect(() => {
-    if (!value) setHierarchyPrefix("");
-  }, [value]);
 
   return (
     <>
@@ -282,8 +281,8 @@ export function AccountAutocomplete({
         onKeyDown={handleKeyDown}
         onFocus={(e) => {
           e.target.select();
-          if (!isAlreadySelected && (value.trim() || hierarchyPrefix)) {
-            if (suggestions.length > 0) setShowDropdown(true);
+          if (!isAlreadySelected && (value.trim() || activeHierarchyPrefix)) {
+            if (suggestions.length > 0) setDropdownDismissed(false);
           }
         }}
         placeholder={placeholder}
@@ -303,16 +302,16 @@ export function AccountAutocomplete({
               width: dropdownPos.width,
             }}
           >
-            {hierarchyPrefix && (
+            {activeHierarchyPrefix && (
               <div className="px-3 py-1 text-[10px] text-[#9A9FA5] border-b border-[#EFEFEF]">
-                {hierarchyPrefix}
+                {activeHierarchyPrefix}
               </div>
             )}
             {suggestions.map((account, i) => {
-              const remaining = account.fullPath.slice(hierarchyPrefix.length);
+              const remaining = account.fullPath.slice(activeHierarchyPrefix.length);
               const nextSegment = remaining.split(":")[0];
               const hasChildren = accounts.some((a) =>
-                a.fullPath.startsWith(hierarchyPrefix + nextSegment + ":") &&
+                a.fullPath.startsWith(activeHierarchyPrefix + nextSegment + ":") &&
                 a.fullPath !== account.fullPath
               );
               const dotColor = TYPE_DOT_COLORS[account.type] ?? "#6b7280";
@@ -321,7 +320,7 @@ export function AccountAutocomplete({
                 <button
                   key={account.guid + "-" + i}
                   className={`flex w-full items-center gap-2 px-3 py-1.5 text-left text-xs transition-colors ${
-                    i === highlightIndex ? "bg-[#3B6B8A]/10 text-[#1A1D1F]" : "text-[#6F767E] hover:bg-[#F4F5F7]"
+                    i === activeHighlightIndex ? "bg-[#3B6B8A]/10 text-[#1A1D1F]" : "text-[#6F767E] hover:bg-[#F4F5F7]"
                   }`}
                   onMouseDown={(e) => {
                     e.preventDefault();
@@ -338,7 +337,7 @@ export function AccountAutocomplete({
                     style={{ backgroundColor: dotColor }}
                   />
                   <span className="truncate">
-                    {hierarchyPrefix ? (
+                    {activeHierarchyPrefix ? (
                       <>
                         <span className="font-medium">{nextSegment}</span>
                         {hasChildren && <span className="text-[#9A9FA5]"> :</span>}

--- a/app/src/components/inline-entry/description-autocomplete.tsx
+++ b/app/src/components/inline-entry/description-autocomplete.tsx
@@ -46,7 +46,7 @@ export function DescriptionAutocomplete({
   className,
 }: Props) {
   const [highlightIndex, setHighlightIndex] = useState(-1);
-  const [showDropdown, setShowDropdown] = useState(false);
+  const [dropdownDismissed, setDropdownDismissed] = useState(false);
   const [dropdownPos, setDropdownPos] = useState<{ top: number; left: number; width: number } | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -105,16 +105,11 @@ export function DescriptionAutocomplete({
     return matches.slice(0, 10);
   }, [value, quickFillIndex]);
 
-  // Show/hide dropdown based on suggestions
-  useEffect(() => {
-    if (suggestions.length > 0 && value.trim()) {
-      setShowDropdown(true);
-      setHighlightIndex(0);
-    } else {
-      setShowDropdown(false);
-      setHighlightIndex(-1);
-    }
-  }, [suggestions, value]);
+  const showDropdown = !dropdownDismissed && suggestions.length > 0 && Boolean(value.trim());
+  const activeHighlightIndex =
+    showDropdown && suggestions.length > 0
+      ? Math.min(Math.max(highlightIndex, 0), suggestions.length - 1)
+      : -1;
 
   // Update dropdown position when shown
   useEffect(() => {
@@ -136,7 +131,7 @@ export function DescriptionAutocomplete({
         dropdownRef.current && !dropdownRef.current.contains(e.target as Node) &&
         inputRef.current && !inputRef.current.contains(e.target as Node)
       ) {
-        setShowDropdown(false);
+        setDropdownDismissed(true);
       }
     }
     document.addEventListener("mousedown", handleClick);
@@ -148,7 +143,7 @@ export function DescriptionAutocomplete({
       const match = suggestions[index];
       onChange(match.description);
       onConfirm(match);
-      setShowDropdown(false);
+      setDropdownDismissed(true);
     }
   }, [suggestions, onChange, onConfirm]);
 
@@ -166,8 +161,8 @@ export function DescriptionAutocomplete({
       }
       if (e.key === "Tab") {
         // Confirm the highlighted suggestion, then let Tab propagate for field navigation
-        if (highlightIndex >= 0) {
-          confirmSuggestion(highlightIndex);
+        if (activeHighlightIndex >= 0) {
+          confirmSuggestion(activeHighlightIndex);
         }
         // Don't prevent default - let the parent handle Tab navigation
         onKeyDown(e);
@@ -175,14 +170,14 @@ export function DescriptionAutocomplete({
       }
       if (e.key === "Enter") {
         e.preventDefault();
-        if (highlightIndex >= 0) {
-          confirmSuggestion(highlightIndex);
+        if (activeHighlightIndex >= 0) {
+          confirmSuggestion(activeHighlightIndex);
         }
         return;
       }
       if (e.key === "Escape") {
         e.preventDefault();
-        setShowDropdown(false);
+        setDropdownDismissed(true);
         return;
       }
     }
@@ -204,11 +199,15 @@ export function DescriptionAutocomplete({
         ref={inputRef}
         type="text"
         value={value}
-        onChange={(e) => onChange(e.target.value)}
+        onChange={(e) => {
+          setDropdownDismissed(false);
+          setHighlightIndex(0);
+          onChange(e.target.value);
+        }}
         onKeyDown={handleKeyDown}
         onFocus={(e) => {
           e.target.select();
-          if (suggestions.length > 0 && value.trim()) setShowDropdown(true);
+          if (suggestions.length > 0 && value.trim()) setDropdownDismissed(false);
         }}
         placeholder="Description"
         className={className}
@@ -231,7 +230,7 @@ export function DescriptionAutocomplete({
               <button
                 key={match.description}
                 className={`flex w-full items-center justify-between gap-3 px-3 py-1.5 text-left text-xs transition-colors ${
-                  i === highlightIndex ? "bg-[#3B6B8A]/10 text-[#1A1D1F]" : "text-[#6F767E] hover:bg-[#F4F5F7]"
+                  i === activeHighlightIndex ? "bg-[#3B6B8A]/10 text-[#1A1D1F]" : "text-[#6F767E] hover:bg-[#F4F5F7]"
                 }`}
                 onMouseDown={(e) => {
                   e.preventDefault(); // Don't blur the input

--- a/app/src/components/inline-entry/smart-date-input.tsx
+++ b/app/src/components/inline-entry/smart-date-input.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect } from "react";
 
 /**
  * Detects whether the user's locale uses month-first (US) or day-first format.
@@ -145,13 +145,13 @@ export function SmartDateInput({ value, onChange, onKeyDown, inputRef, className
   // The raw text the user is typing (shown while focused)
   const [rawText, setRawText] = useState("");
   const [isFocused, setIsFocused] = useState(false);
-  const localeOrder = useRef(detectLocaleOrder());
-  const separator = useRef(detectLocaleSeparator());
+  const [localeOrder] = useState<"mdy" | "dmy">(() => detectLocaleOrder());
+  const [separator] = useState(() => detectLocaleSeparator());
 
   // Placeholder hint showing the expected format
-  const placeholder = localeOrder.current === "mdy"
-    ? `mm${separator.current}dd${separator.current}yy`
-    : `dd${separator.current}mm${separator.current}yy`;
+  const placeholder = localeOrder === "mdy"
+    ? `mm${separator}dd${separator}yy`
+    : `dd${separator}mm${separator}yy`;
 
   const handleFocus = useCallback((e: React.FocusEvent<HTMLInputElement>) => {
     setIsFocused(true);
@@ -172,14 +172,14 @@ export function SmartDateInput({ value, onChange, onKeyDown, inputRef, className
       setIsFocused(false);
       return;
     }
-    const parsed = parsePartialDate(trimmed, localeOrder.current);
+    const parsed = parsePartialDate(trimmed, localeOrder);
     if (parsed) {
       onChange(parsed);
       lastUsedDate = parsed;
     }
     // If parse failed, revert to previous value
     setIsFocused(false);
-  }, [rawText, onChange]);
+  }, [rawText, onChange, localeOrder]);
 
   const handleBlur = useCallback(() => {
     commitDate();

--- a/app/src/components/spending/expense-table-card.tsx
+++ b/app/src/components/spending/expense-table-card.tsx
@@ -40,7 +40,7 @@ function compareTx(a: ExpenseTransaction, b: ExpenseTransaction, field: SortFiel
 
 export function ExpenseTableCard({ transactions, currency, title = "Expenses" }: ExpenseTableCardProps) {
   const { period, customRange, selectedCategory, selectedMonth, selectedAccount, excluded } = useSpendingFilter();
-  const [page, setPage] = useState(0);
+  const [pageState, setPageState] = useState({ key: "", page: 0 });
   const [sortField, setSortField] = useState<SortField>("date");
   const [sortDir, setSortDir] = useState<SortDir>("desc");
 
@@ -51,11 +51,10 @@ export function ExpenseTableCard({ transactions, currency, title = "Expenses" }:
       setSortField(field);
       setSortDir(field === "amount" ? "desc" : "asc");
     }
-    setPage(0);
   }
 
   // Reset page when filters change
-  const filterKey = `${period}-${customRange?.start}-${customRange?.end}-${selectedCategory}-${selectedMonth}-${selectedAccount}-${[...excluded].join(",")}`;
+  const filterKey = `${period}-${customRange?.start}-${customRange?.end}-${selectedCategory}-${selectedMonth}-${selectedAccount}-${[...excluded].join(",")}-${sortField}-${sortDir}`;
 
   const filtered = useMemo(() => {
     const validMonths = new Set(selectedMonth ? [selectedMonth] : getMonthsForPeriod(period, customRange ?? undefined));
@@ -87,9 +86,7 @@ export function ExpenseTableCard({ transactions, currency, title = "Expenses" }:
     }).sort((a, b) => compareTx(a, b, sortField, sortDir));
   }, [transactions, period, customRange, selectedCategory, selectedMonth, selectedAccount, excluded, sortField, sortDir]);
 
-  // Reset page when filters change
-  useMemo(() => setPage(0), [filterKey]);
-
+  const page = pageState.key === filterKey ? pageState.page : 0;
   const totalPages = Math.ceil(filtered.length / PAGE_SIZE);
   const pageData = filtered.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);
 
@@ -150,14 +147,14 @@ export function ExpenseTableCard({ transactions, currency, title = "Expenses" }:
                 </span>
                 <div className="flex gap-1">
                   <button
-                    onClick={() => setPage((p) => Math.max(0, p - 1))}
+                    onClick={() => setPageState({ key: filterKey, page: Math.max(0, page - 1) })}
                     disabled={page === 0}
                     className="rounded-md border border-[#EFEFEF] px-2.5 py-1 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:hover:bg-transparent"
                   >
                     Prev
                   </button>
                   <button
-                    onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+                    onClick={() => setPageState({ key: filterKey, page: Math.min(totalPages - 1, page + 1) })}
                     disabled={page >= totalPages - 1}
                     className="rounded-md border border-[#EFEFEF] px-2.5 py-1 text-xs text-[#6F767E] transition-colors hover:bg-[#F4F5F7] disabled:opacity-30 disabled:hover:bg-transparent"
                   >


### PR DESCRIPTION
## Summary
- replace render/effect-time page reset state updates with derived page state keyed by filters
- move hooks above conditional returns and hoist render-created components
- remove synchronous autocomplete state sync effects while preserving dropdown behavior

## Verification
- npm run lint passes with 0 errors, 66 warnings remain
- npm test passes: 239 passed, 12 skipped
- npm run build passes